### PR TITLE
Include element halos in dg-ify fields process in vtk_write_fields

### DIFF
--- a/femtools/VTK_interfaces.F90
+++ b/femtools/VTK_interfaces.F90
@@ -309,6 +309,13 @@ contains
           allocate(model_mesh%region_ids(ele_count(model_mesh)))
           model_mesh%region_ids = model%region_ids
         end if
+        ! Copy element_halos to ensure vtkGhostLevels are output 
+        if (associated(model%element_halos)) then
+          allocate(model_mesh%element_halos(size(model%element_halos)))
+          do i = 1, size(model_mesh%element_halos)
+            call allocate(model_mesh%element_halos(i), model%element_halos(i))
+          end do
+        end if
       else
         
         NNod=node_count(model)


### PR DESCRIPTION
Currently if you pass discontinuous fields to `vtk_write_fields` with a continuous `model` mesh  then it will convert the continuous mesh into a discontinuous mesh. In doing so it does not currently copy over the `element_halos` which are required to write the vtkGhostLevels to the pvtu file. This commit copies the element halos to the discontinuous mesh, if required.
