### PR TITLE
Remove get_active_nparts().

### DIFF
--- a/femtools/Halos_Registration.F90
+++ b/femtools/Halos_Registration.F90
@@ -299,9 +299,11 @@ contains
 
   end subroutine generate_substate_halos
 
-  subroutine write_halos(filename, mesh)
+  subroutine write_halos(filename, mesh, number_of_partitions)
     character(len = *), intent(in) :: filename
     type(mesh_type), intent(in) :: mesh
+    !!< If present, only write for processes 1:number_of_partitions (assumes the other partitions are empty)
+    integer, optional, intent(in):: number_of_partitions
     
     integer :: communicator, error_count, i, nhalos, procno, nparts, nprocs
     integer, dimension(:), allocatable :: nreceives, nsends, receives, sends
@@ -313,7 +315,12 @@ contains
     
     communicator = halo_communicator(mesh%halos(nhalos))
     procno = getprocno(communicator = communicator)
-    nparts = get_active_nparts(ele_count(mesh), communicator = communicator)
+
+    if (present(number_of_partitions)) then
+      nparts = number_of_partitions
+    else
+      nparts = getnprocs()
+    end if
     
     if(procno <= nparts) then
       nprocs = getnprocs(communicator = communicator)

--- a/femtools/Mesh_Files.F90
+++ b/femtools/Mesh_Files.F90
@@ -137,20 +137,22 @@ contains
   ! --------------------------------------------------------------------------
 
 
-  subroutine write_mesh_to_file(filename, format, state, mesh)
+  subroutine write_mesh_to_file(filename, format, state, mesh, number_of_partitions)
     ! Write out the supplied mesh to the specified filename as mesh files.
 
     character(len = *), intent(in) :: filename
     character(len = *), intent(in) :: format
     type(state_type), intent(in) :: state
     type(mesh_type), intent(in) :: mesh
+    !!< If present, only write for processes 1:number_of_partitions (assumes the other partitions are empty)
+    integer, optional, intent(in):: number_of_partitions
 
     select case(format)
     case("triangle")
-       call write_triangle_files(filename, state, mesh)
+       call write_triangle_files(filename, state, mesh, number_of_partitions=number_of_partitions)
 
     case("gmsh")
-       call write_gmsh_file(filename, state, mesh )
+       call write_gmsh_file(filename, state, mesh, number_of_partitions=number_of_partitions)
 
     ! ExodusII write routines are not implemented at this point. 
     ! Mesh is dumped as gmsh format for now.
@@ -168,18 +170,20 @@ contains
 
   ! --------------------------------------------------------------------------
 
-  subroutine write_positions_to_file(filename, format, positions)
+  subroutine write_positions_to_file(filename, format, positions, number_of_partitions)
     !!< Write out the mesh given by the position field in mesh files
     !!< In parallel, empty trailing processes are not written.
     character(len=*), intent(in):: filename, format
     type(vector_field), intent(in):: positions
+    !!< If present, only write for processes 1:number_of_partitions (assumes the other partitions are empty)
+    integer, optional, intent(in):: number_of_partitions
 
     select case( trim(format) )
     case("triangle")
-       call write_triangle_files( trim(filename), positions)
+       call write_triangle_files( trim(filename), positions, number_of_partitions=number_of_partitions)
 
     case("gmsh")
-       call write_gmsh_file( trim(filename), positions)
+       call write_gmsh_file( trim(filename), positions, number_of_partitions=number_of_partitions)
 
     ! ExodusII write routines are not implemented at this point. 
     ! Mesh is dumped as gmsh format for now.

--- a/femtools/VTK_interfaces.F90
+++ b/femtools/VTK_interfaces.F90
@@ -216,7 +216,7 @@ contains
   end subroutine vtk_write_state
 
   subroutine vtk_write_fields(filename, index, position, model, sfields,&
-       & vfields, tfields, write_region_ids, write_columns, write_inactive_parts, stat)
+       & vfields, tfields, write_region_ids, write_columns, number_of_partitions, stat)
     !!< Write the state variables out to a vtu file. Two different elements
     !!< are supported along with fields corresponding to each of them.
     !!<
@@ -235,10 +235,8 @@ contains
     type(tensor_field), dimension(:), intent(in), optional :: tfields
     logical, intent(in), optional :: write_region_ids
     logical, intent(in), optional :: write_columns
-    !! If not provided and true, only the local vtu for processes with at least one element are written
-    !! The zero element processes are supposed to be trailing in rank. If provided and true all
-    !! vtus are written:
-    logical, intent(in), optional :: write_inactive_parts
+    !!< If present, only write for processes 1:number_of_partitions (assumes the other partitions are empty)
+    integer, optional, intent(in):: number_of_partitions
     integer, intent(out), optional :: stat
     
     integer :: NNod, sz_enlist, i, dim, j, k, nparts
@@ -275,10 +273,10 @@ contains
       end do
     end if
     
-    if (present_and_true(write_inactive_parts)) then
-      nparts = getnprocs()
+    if (present(number_of_partitions)) then
+      nparts = number_of_partitions
     else
-      nparts = get_active_nparts(ele_count(model))
+      nparts = getnprocs()
     end if
 
     if(model%shape%degree /= 0) then
@@ -1232,9 +1230,8 @@ contains
     end do
     call remap_field_to_surface(position, surface_position, surface_element_list)
         
-    ! some domains may have no surface elements, so we need write_inactive_parts=.true.
     call vtk_write_fields(filename, index=index, position=surface_position, &
-      model=mesh%faces%surface_mesh, sfields=sfields, write_inactive_parts=.true.)
+      model=mesh%faces%surface_mesh, sfields=sfields)
       
     call deallocate(sfields(1))
     if (associated(mesh%faces%coplanar_ids)) then

--- a/tools/Flredecomp.F90
+++ b/tools/Flredecomp.F90
@@ -183,7 +183,7 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   ! Output
   assert(associated(state))
   call checkpoint_simulation(state, prefix = output_base, postfix = "", protect_simulation_name = .false., &
-    keep_initial_data=.true., ignore_detectors=.true.)
+    keep_initial_data=.true., ignore_detectors=.true., number_of_partitions=target_nprocs)
 
   do i = 1, size(state)
     call deallocate(state(i))


### PR DESCRIPTION
This routine worked out how many of the parallel partitions where active by
checking which ones are empty. This number was then used to decide how for
how many processes to write output (in vtus and meshes). This however puts a strict
requirement for meshes to only have empty partitions in trailing process numbers
which breaks in the case where some of the meshes only cover part of the domain. This
currently breaks the viscous free surface (f.s. + no_normal_stress) and checkpointing.

The functionality of get_active_nparts() was only really useful for flredecomp
when redecomposing to a smaller number of processes.  In that case however,
we know exactly how many partitions we want so instead of automagically working this
number, it's much more robust to pass this information on as an optional argument.
Thus in this commit, vtk_write_fields(), write_mesh_files(), write_gmsh_file() and
write_triangle_files() and also checkpoint_simulation(), checkpoint_meshes() and
checkpoint_fields() all get an extra optional argument number_of_partitions, that
when provided only write out to the specified number of processes. The default is now
to always write all processes (including the empty ones).

This fixes a bug reported by Rhodri Davies.
