### PR TITLE
Fix pvtu2vtu for DG pvtus.

### DIFF
--- a/python/fluidity/diagnostics/vtutools.py
+++ b/python/fluidity/diagnostics/vtutools.py
@@ -181,8 +181,8 @@ def ModelPvtuToVtu(pvtu):
   ghostLevel = pvtu.ugrid.GetCellData().GetArray("vtkGhostLevels")
   if ghostLevel is None:
     # We have a serial vtu
-    debug.deprint("Warning: VtuFromPvtu passed a serial vtu")
-    ghostLevel = [0 for i in range(vtu.ugrid.GetNumberOfCells())]
+    debug.deprint("Warning: input file contains no vtkGhostLevels")
+    ghostLevel = [0 for i in range(pvtu.ugrid.GetNumberOfCells())]
   else:
     # We have a parallel vtu
     ghostLevel = [ghostLevel.GetValue(i) for i in range(ghostLevel.GetNumberOfComponents() * ghostLevel.GetNumberOfTuples())]

--- a/python/fluidity/diagnostics/vtutools.py
+++ b/python/fluidity/diagnostics/vtutools.py
@@ -210,21 +210,60 @@ def ModelPvtuToVtu(pvtu):
   
   debug.dprint("Input points: " + str(pvtu.ugrid.GetNumberOfPoints()))
  
-  nodeIds = []
   keepNode = [False for i in range(pvtu.ugrid.GetNumberOfPoints())]
-  oldNodeIdToNew = [None for i in range(pvtu.ugrid.GetNumberOfPoints())]
   
   # Find a list of candidate non-ghost node IDs, based on nodes attached to
   # non-ghost cells
+  keepNodeCount = 0
   for cellId in cellIds:
     cellNodeIds = pvtu.ugrid.GetCell(cellId).GetPointIds()
     cellNodeIds = [cellNodeIds.GetId(i) for i in range(cellNodeIds.GetNumberOfIds())]
+    keepNodeCount += len(cellNodeIds)
     for nodeId in cellNodeIds:
       keepNode[nodeId] = True
       
-  debug.dprint("Non-ghost nodes (pass 1): " + str(keepNode.count(True)))
-      
-  # Detect duplicate nodes
+  uniqueKeepNodeCount = keepNode.count(True)
+  debug.dprint("Non-ghost nodes (pass 1): " + str(uniqueKeepNodeCount))
+  if uniqueKeepNodeCount==keepNodeCount:
+    debug.dprint("Assuming pvtu is discontinuous")
+    # we're keeping all non-ghost nodes:
+    nodeIds = [i for i in range(pvtu.ugrid.GetNumberOfPoints()) if keepNode[i]]
+    oldNodeIdToNew = numpy.array([None]*pvtu.ugrid.GetNumberOfPoints())
+    oldNodeIdToNew[nodeIds] = range(keepNodeCount)
+  else:
+    # for the CG case we still have duplicate nodes that need to be removed
+    oldNodeIdToNew, nodeIds = PvtuToVtuRemoveDuplicateNodes(pvtu, keepNode)
+
+  # Step 4: Generate the new locations
+  locations = pvtu.GetLocations()
+  locations = numpy.array([locations[i] for i in nodeIds])
+  points = vtk.vtkPoints()
+  points.SetDataTypeToDouble()
+  for location in locations:
+    points.InsertNextPoint(location)
+  result.ugrid.SetPoints(points)
+
+  # Step 5: Generate the new cells
+  for cellId in cellIds:
+    cell = pvtu.ugrid.GetCell(cellId)
+    cellNodeIds = cell.GetPointIds()
+    cellNodeIds = [cellNodeIds.GetId(i) for i in range(cellNodeIds.GetNumberOfIds())]
+    idList = vtk.vtkIdList()
+    for nodeId in cellNodeIds:
+      oldNodeId = nodeId
+      nodeId = oldNodeIdToNew[nodeId]
+      assert(not nodeId is None)
+      assert(nodeId >= 0)
+      assert(nodeId <= len(nodeIds))
+      idList.InsertNextId(nodeId)
+    result.ugrid.InsertNextCell(cell.GetCellType(), idList)
+
+  return result, oldNodeIdToNew, oldCellIdToNew
+
+ModelVtuFromPvtu = ModelPvtuToVtu
+
+def PvtuToVtuRemoveDuplicateNodes(pvtu,  keepNode):
+  # Detect duplicate nodes and remove them
     
   # Jumping through Python 2.3 hoops for cx1 - in >= 2.4, can just pass a cmp
   # argument to list.sort
@@ -254,6 +293,9 @@ def ModelPvtuToVtu(pvtu):
         
     return True
       
+  nodeIds = []
+  oldNodeIdToNew = [None] * pvtu.ugrid.GetNumberOfPoints()
+
   locations = pvtu.GetLocations()
   lbound, ubound = VtuBoundingBox(pvtu).GetBounds()
   tol = calc.L2Norm([ubound[i] - lbound[i] for i in range(len(lbound))]) / 1.0e12
@@ -335,34 +377,8 @@ def ModelPvtuToVtu(pvtu):
       oldNodeIdToNew[i] = oldNodeIdToNew[nodeId]
   
   debug.dprint("Non-ghost nodes (pass 2): " + str(len(nodeIds)))
-    
-  # Step 4: Generate the new locations
-  locations = pvtu.GetLocations()
-  locations = numpy.array([locations[i] for i in nodeIds])
-  points = vtk.vtkPoints()
-  points.SetDataTypeToDouble()
-  for location in locations:
-    points.InsertNextPoint(location)
-  result.ugrid.SetPoints(points)
-  
-  # Step 5: Generate the new cells
-  for cellId in cellIds:
-    cell = pvtu.ugrid.GetCell(cellId)
-    cellNodeIds = cell.GetPointIds()
-    cellNodeIds = [cellNodeIds.GetId(i) for i in range(cellNodeIds.GetNumberOfIds())]
-    idList = vtk.vtkIdList()
-    for nodeId in cellNodeIds:
-      oldNodeId = nodeId
-      nodeId = oldNodeIdToNew[nodeId]
-      assert(not nodeId is None)
-      assert(nodeId >= 0)
-      assert(nodeId <= len(nodeIds))
-      idList.InsertNextId(nodeId)
-    result.ugrid.InsertNextCell(cell.GetCellType(), idList)
-  
-  return result, oldNodeIdToNew, oldCellIdToNew
 
-ModelVtuFromPvtu = ModelPvtuToVtu
+  return oldNodeIdToNew, nodeIds
 
 def PvtuToVtu(pvtu, model = None, oldNodeIdToNew = [], oldCellIdToNew = [],
                     fieldlist = []):

--- a/tests/pvtu2vtu_dg/Makefile
+++ b/tests/pvtu2vtu_dg/Makefile
@@ -1,0 +1,6 @@
+input: clean
+	gmsh -2 -bin src/square.geo -o square.msh
+
+clean:
+	rm -rf output* square.msh pvtu2vtu_flredecomp*
+	rm -rf flredecomp.* fluidity.*

--- a/tests/pvtu2vtu_dg/pvtu2vtu.flml
+++ b/tests/pvtu2vtu_dg/pvtu2vtu.flml
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">output</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="square">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">3</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period_in_timesteps>
+      <constant>
+        <integer_value rank="0">1</integer_value>
+      </constant>
+    </dump_period_in_timesteps>
+    <output_mesh name="VelocityMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.</real_value>
+    </finish_time>
+  </timestepping>
+  <material_phase name="Phase">
+    <vector_field name="Velocity" rank="1">
+      <prescribed>
+        <mesh name="VelocityMesh"/>
+        <value name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0. 0.</real_value>
+          </constant>
+        </value>
+        <output>
+          <exclude_from_vtu/>
+        </output>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </vector_field>
+    <scalar_field name="Field" rank="0">
+      <diagnostic>
+        <algorithm name="universal_numbering" material_phase_support="single"/>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/pvtu2vtu_dg/pvtu2vtu_dg.xml
+++ b/tests/pvtu2vtu_dg/pvtu2vtu_dg.xml
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testproblem>
+  <name>pvtu2vtu_dg</name>
+  <owner userid="skramer"/>
+  <tags>flml parallel</tags>
+  <problem_definition length="short" nprocs="3">
+    <command_line>mpiexec ../../bin/flredecomp -i 1 -o 3 -v -l pvtu2vtu pvtu2vtu_flredecomp &amp;&amp;
+mpiexec ../../bin/fluidity -v2 -l pvtu2vtu_flredecomp.flml &amp;&amp;
+../../bin/pvtu2vtu output 0 0</command_line>
+  </problem_definition>
+  <variables>
+    <variable name="SameNodes" language="python">import vtktools
+import numpy
+
+pvtu = vtktools.vtu('output_0.pvtu')
+vtu = vtktools.vtu('output_0.vtu')
+pfield = pvtu.GetField('Field')
+pxyz = pvtu.GetLocations()
+xyz = vtu.GetLocations()
+field = vtu.GetField('Field')
+
+# build map from uid -&gt; xy locations
+uid2xy = numpy.zeros((int(pfield.max()), 2))
+for uid, loc in zip(pfield, pxyz):
+  uid2xy[uid[0]-1] = loc[0:2]
+
+# check that each node in vtu is still present and at the same location
+same = True
+for uid, loc in zip(field, xyz):
+  same = same and abs(uid2xy[uid[0]-1]-loc[0:2]).max()&lt;1e-7
+
+# also check that there are no duplicate nodes left:
+same = same and len(field)==len(uid2xy)
+
+SameNodes = same</variable>
+    <variable name="SameElements" language="python">import vtktools
+import numpy
+
+pvtu = vtktools.vtu('output_0.pvtu')
+vtu = vtktools.vtu('output_0.vtu')
+pfield = pvtu.GetField('Field')
+pxyz = pvtu.GetLocations()
+xyz = vtu.GetLocations()
+field = pvtu.GetField('Field')
+
+# first build parallel cells
+pcells = set()
+for i in range(pvtu.ugrid.GetNumberOfCells()):
+  cell = pfield[pvtu.GetCellPoints(i),0]
+  # fix orientation by starting at lowest uid
+  j = cell.argmin()
+  cell = numpy.hstack((cell[j:],cell[:j]))
+  pcells.add(tuple(cell))
+
+# check that each cell in vtu exists in the pvtu
+same = True
+for i in range(vtu.ugrid.GetNumberOfCells()):
+  cell = field[vtu.GetCellPoints(i), 0]
+  # fix orientation by starting at lowest uid
+  j = cell.argmin()
+  cell = numpy.hstack((cell[j:],cell[:j]))
+  same = same and tuple(cell) in pcells
+
+# check that we haven't left any cells out:
+same = same and len(pcells)==vtu.ugrid.GetNumberOfCells()
+
+SameElements = same</variable>
+  </variables>
+  <pass_tests>
+    <test name="NodesAreTheSame" language="python">assert SameNodes</test>
+    <test name="ElementsAreTheSame" language="python">assert SameElements</test>
+  </pass_tests>
+</testproblem>

--- a/tests/pvtu2vtu_dg/src/square.geo
+++ b/tests/pvtu2vtu_dg/src/square.geo
@@ -1,0 +1,12 @@
+Point(1) = {0, 0, 0, 0.1};
+Extrude {1, 0, 0} {
+  Point{1};
+}
+Extrude {0, 1, 0} {
+  Line{1};
+}
+Physical Line(6) = {1};
+Physical Line(7) = {4};
+Physical Line(8) = {2};
+Physical Line(9) = {3};
+Physical Surface(10) = {5};


### PR DESCRIPTION
Previously when passing a discontinuous pvtu to pvtu2vtu, it would create a continuous vtu choosing a value at the vertex from one of the surrounding dg nodes at random. Now, it creates a discontinuous vtu without loosing any information or accuracy. Added test for new functionality.
