### PR TITLE
Allow running project_vtu without donor mesh.

### DIFF
--- a/tests/project_vtu/project_vtu.xml
+++ b/tests/project_vtu/project_vtu.xml
@@ -12,7 +12,7 @@ rm -rf output*;
 for i in A B C D; do
   sed "s/INPUT/MMS_${i}/" prescribe.flml &gt; output.flml;
   fluidity -l output.flml;
-  project_vtu output_CoordinateMesh_1_checkpoint.vtu output_CoordinateMesh_1_checkpoint.msh MMS_E.msh fine.vtu;
+  project_vtu output_CoordinateMesh_1_checkpoint.vtu MMS_E.msh fine.vtu;
   project_vtu output_1.vtu output_CoordinateMesh_1_checkpoint.msh MMS_E.msh fine_dg.vtu;
   vtudiff fine.vtu reference.vtu diff${i}.vtu;
   vtudiff fine_dg.vtu reference_dg.vtu diff${i}_dg.vtu;

--- a/tools/Project_Vtu.F90
+++ b/tools/Project_Vtu.F90
@@ -118,14 +118,23 @@ subroutine project_vtu(input_filename_, input_filename_len, donor_basename_, don
     output_p0mesh = piecewise_constant_mesh(target_positions%mesh, "P0Mesh")
   end if
   
-  ends_with_msh = .false.
   if (donor_basename_len>4) then
     ends_with_msh = donor_basename(donor_basename_len-3:donor_basename_len)=='.msh'
-  end if
-  if (ends_with_msh) then
-    donor_positions = read_gmsh_file(donor_basename(:donor_basename_len-4), quad_degree = quad_degree)
+    if (ends_with_msh) then
+      donor_positions = read_gmsh_file(donor_basename(:donor_basename_len-4), quad_degree = quad_degree)
+    else
+      donor_positions = read_triangle_files(trim(donor_basename), quad_degree = quad_degree)
+    end if
+  else if (donor_basename_len>0) then
+      donor_positions = read_triangle_files(trim(donor_basename), quad_degree = quad_degree)
   else
-    donor_positions = read_triangle_files(trim(donor_basename), quad_degree = quad_degree)
+    ! no donor mesh specified:
+    ! use the one we got from vtk_read_state
+    ! this only works in serial and with a P1CG vtu
+    if (continuity(donor_positions)<0 .or. shape%degree/=1) then
+      FLExit("No donor mesh specified. This only works for a serial, continuous, linear input vtu")
+    end if
+    call incref(donor_positions)
   end if
   
   allocate(map_BA(ele_count(target_positions)))

--- a/tools/Project_Vtu_main.cpp
+++ b/tools/Project_Vtu_main.cpp
@@ -52,11 +52,12 @@ extern "C" {
 using namespace std; 
 
 void project_vtu_usage(char *binary){
-  cerr<<"Usage: "<<binary<<" [OPTIONS] input_filename donor_mesh target_mesh output_filename\n"
+  cerr<<"Usage: "<<binary<<" [OPTIONS] input_filename [donor_mesh] target_mesh output_filename\n"
       <<"Project an input vtu onto a different mesh\n\n"
       <<"input_filename and output_filename are the names of the input and output vtus\n"
       <<"donor_mesh and target_mesh are either the name of gmsh file corresponding to the donor and target mesh (if ending in .msh), "
       <<"or the basename for the triangle files (.node+.ele+.edge/.face) for those meshes\n\n"
+      <<"The donor_mesh argument can be left out for serial, continuous, linear vtus only. In this case the mesh is derived from the vtu.\n\n"
       <<"\t-h\t\tPrints out this message\n"
       <<"\t-v\t\tVerbose mode\n";
 }
@@ -102,8 +103,8 @@ int main(int argc, char **argv){
     exit(-1);
   }
   
-  if (optind != argc - 4){
-    cerr << "Need exactly four non-option arguments" << endl;
+  if (argc-optind<3 || argc-optind>4) {
+    cerr << "Need three or four non-option arguments" << endl;
     project_vtu_usage(argv[0]);
     exit(-1);
   }
@@ -117,13 +118,23 @@ int main(int argc, char **argv){
   string input_filename = argv[optind];
   size_t input_filename_len = input_filename.size();  
   
-  string donor_basename = argv[optind + 1];
-  size_t donor_basename_len = donor_basename.size();
+  string donor_basename;
+  size_t donor_basename_len;
+  int targetind;
+  if (argc-optind==3) {
+    donor_basename = "";
+    donor_basename_len = 0;
+    targetind = optind + 1;
+  } else {
+    donor_basename = argv[optind + 1];
+    donor_basename_len = donor_basename.size();
+    targetind = optind + 2;
+  }
   
-  string target_basename = argv[optind + 2];
+  string target_basename = argv[targetind];
   size_t target_basename_len = target_basename.size();
   
-  string output_filename = argv[optind + 3];
+  string output_filename = argv[targetind + 1];
   size_t output_filename_len = output_filename.size();  
 
   project_vtu(input_filename.c_str(), input_filename_len, donor_basename.c_str(), donor_basename_len, target_basename.c_str(), target_basename_len, output_filename.c_str(), output_filename_len);


### PR DESCRIPTION
Instead it works out the donor mesh from the input vtu. This only works in
serial (does project_vtu actually work in parallel?) and only for continuous
linear vtus.

New functionality switched on in project_vtu test.