### PR TITLE
Changed schema for the FieldWeightedPartitionValues

### DIFF
--- a/schemas/adaptivity_options.rnc
+++ b/schemas/adaptivity_options.rnc
@@ -977,10 +977,16 @@ hr_adaptivity =
 	        element scalar_field {
                   attribute rank { "0" },
                   attribute name { "FieldWeightedPartitionValues" },
-                  element prescribed {
-                     coordinate_mesh_choice,
-                     prescribed_scalar_field
-                  }
+                  (
+                     element prescribed {
+                        coordinate_mesh_choice,
+                        prescribed_scalar_field
+                     }|
+                     element diagnostic {
+                        coordinate_mesh_choice,
+                        diagnostic_scalar_field
+                     }
+                  )                  
                }
             }?,
             ## Zoltan Debugging

--- a/schemas/adaptivity_options.rng
+++ b/schemas/adaptivity_options.rng
@@ -1150,10 +1150,16 @@ value of 1 (no normalisation is done within the code).</a:documentation>
                 <attribute name="name">
                   <value>FieldWeightedPartitionValues</value>
                 </attribute>
-                <element name="prescribed">
-                  <ref name="coordinate_mesh_choice"/>
-                  <ref name="prescribed_scalar_field"/>
-                </element>
+                <choice>
+                  <element name="prescribed">
+                    <ref name="coordinate_mesh_choice"/>
+                    <ref name="prescribed_scalar_field"/>
+                  </element>
+                  <element name="diagnostic">
+                    <ref name="coordinate_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
+                  </element>
+                </choice>
               </element>
             </element>
           </optional>


### PR DESCRIPTION
This changes the adaptivity options schema to allow the FieldWeightedPartitionValues to be a diagnostic field. This lets you set spatially dependent weights for load balancing that aren't from a file/python function, etc.