### PR TITLE
Tictoc calls for every timestep

### DIFF
--- a/femtools/tictoc.F90
+++ b/femtools/tictoc.F90
@@ -45,7 +45,7 @@ module tictoc
   integer, parameter, public :: TICTOC_ID_SIMULATION = 1, &
     & TICTOC_ID_SERIAL_ADAPT = 2, TICTOC_ID_DATA_MIGRATION = 3, &
     & TICTOC_ID_ADAPT = 4, TICTOC_ID_IO_READ = 5, TICTOC_ID_DATA_REMAP = 6, &
-    & TICTOC_ID_INTERPOLATION = 7, TICTOC_ID_ASSEMBLE_METRIC = 8
+    & TICTOC_ID_INTERPOLATION = 7, TICTOC_ID_ASSEMBLE_METRIC = 8, TICTOC_ID_TIMESTEP = 9
 
   real :: starttime(MAX_TIC_ID) = 0.0, totaltime(MAX_TIC_ID) = 0.0
 #ifdef DDEBUG
@@ -200,6 +200,8 @@ contains
            ewrite(debug_level, *) "For TICTOC_ID_INTERPOLATION"
          case(TICTOC_ID_ASSEMBLE_METRIC)
            ewrite(debug_level, *) "For TICTOC_ID_ASSEMBLE_METRIC"
+         case(TICTOC_ID_TIMESTEP)
+           ewrite(debug_level, *) "For TICTOC_ID_TIMESTEP (excluding time in mesh adaptivity, if applicable)"
          case default
            ewrite(debug_level, "(a,i0)") "For tictoc ID: ", id
        end select

--- a/main/Fluids.F90
+++ b/main/Fluids.F90
@@ -101,6 +101,7 @@ module fluids_module
 #endif
   use multiphase_module
   use detector_parallel, only: sync_detector_coordinates, deallocate_detector_list_array
+  use tictoc
   use momentum_diagnostic_fields, only: calculate_densities
   use sediment_diagnostics, only: calculate_sediment_flux
 
@@ -457,6 +458,8 @@ contains
        end if
 
        if(simulation_completed(current_time, timestep)) exit timestep_loop
+
+       call tic(TICTOC_ID_TIMESTEP)
 
        if( &
                                 ! Do not dump at the start of the simulation (this is handled by write_state call earlier)
@@ -864,6 +867,10 @@ contains
           end if
 
        end if
+
+       call toc(TICTOC_ID_TIMESTEP)
+       call tictoc_report(2, TICTOC_ID_TIMESTEP)
+       call tictoc_clear(TICTOC_ID_TIMESTEP)
 
        if(simulation_completed(current_time)) exit timestep_loop
 

--- a/main/Makefile.dependencies
+++ b/main/Makefile.dependencies
@@ -60,7 +60,8 @@ Fluids.o ../include/fluids_module.mod: Fluids.F90 \
    ../include/spud.mod ../include/synthetic_bc.mod \
    ../include/timeloop_utilities.mod ../include/timers.mod \
    ../include/vertical_extrapolation_module.mod ../include/vtk_interfaces.mod \
-   ../include/write_state_module.mod ../include/write_triangle.mod
+   ../include/write_state_module.mod ../include/write_triangle.mod \
+   ../include/tictoc.mod
 
 Hybridized_Helmholtz_Solver.o : Hybridized_Helmholtz_Solver.F90 \
    ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \


### PR DESCRIPTION
Added tictoc calls to calculate and print out the time spent in each timestep. This excludes the time spent in mesh adapts (if applicable), which is already calculated using separate tictoc calls.