### PR TITLE
Make radial gravity at gauss points an option rather than automagic 

### DIFF
--- a/assemble/Advection_Diffusion_DG.F90
+++ b/assemble/Advection_Diffusion_DG.F90
@@ -1418,7 +1418,7 @@ contains
        ! Calculate the gradient in the direction of gravity
        ! TODO: Build on_sphere into ele_val_at_quad?
        if (on_sphere) then
-          grav_at_quads = sphere_inward_normal_at_quad_ele(X, ele)
+          grav_at_quads = radial_inward_normal_at_quad_ele(X, ele)
        else
           grav_at_quads = ele_val_at_quad(gravity, ele)
        end if

--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -118,7 +118,7 @@
     logical :: have_les
     logical :: have_surface_fs_stabilisation
     logical :: les_second_order, les_fourth_order, wale, dynamic_les
-    logical :: on_sphere
+    logical :: on_sphere, radial_gravity
     
     logical :: move_mesh
     
@@ -392,6 +392,9 @@
         gravity_magnitude = 0.0
       end if
       ewrite_minmax(buoyancy)
+
+      radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation"//&
+         &"/buoyancy/radial_gravity_direction_at_gauss_points")
 
       ! Splits up the Density and Pressure fields into a hydrostatic component (') and a perturbed component (''). 
       ! The hydrostatic components, denoted p' and rho', should satisfy the balance: grad(p') = rho'*g
@@ -1107,7 +1110,7 @@
 
       if (velocity_bc_type(1,sele)==BC_TYPE_FREE_SURFACE .and. have_surface_fs_stabilisation) then
         if (on_sphere) then
-          upwards_gi=-sphere_inward_normal_at_quad_face(x, sele)
+          upwards_gi=-radial_inward_normal_at_quad_face(x, sele)
         else
           upwards_gi=-face_val_at_quad(gravity, sele)
         end if
@@ -1773,12 +1776,12 @@
          coefficient_detwei = coefficient_detwei*nvfrac_gi
       end if
 
-      if (on_sphere) then
-      ! If we're on a spherical Earth evaluate the direction of the gravity vector
+      if (radial_gravity) then
+      ! If we're using radial gravity evaluate the direction of the gravity vector
       ! exactly at quadrature points.
         rhs_addto = rhs_addto + &
                     shape_vector_rhs(test_function, &
-                                     sphere_inward_normal_at_quad_ele(positions, ele), &
+                                     radial_inward_normal_at_quad_ele(positions, ele), &
                                      coefficient_detwei)
       else
         rhs_addto = rhs_addto + &
@@ -1922,7 +1925,7 @@
 
           ! Calculate the gradient in the direction of gravity
           if (on_sphere) then
-            grav_at_quads=sphere_inward_normal_at_quad_ele(positions, ele)
+            grav_at_quads=radial_inward_normal_at_quad_ele(positions, ele)
           else
             grav_at_quads=ele_val_at_quad(gravity, ele)
           end if

--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -393,7 +393,7 @@
       end if
       ewrite_minmax(buoyancy)
 
-      radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation"//&
+      radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation/continuous_galerkin"//&
          &"/buoyancy/radial_gravity_direction_at_gauss_points")
 
       ! Splits up the Density and Pressure fields into a hydrostatic component (') and a perturbed component (''). 

--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -430,7 +430,7 @@ contains
     end if
     ewrite_minmax(buoyancy)
 
-    radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation"//&
+    radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation/discontinuous_galerkin"//&
        &"/buoyancy/radial_gravity_direction_at_gauss_points")
 
     ! Splits up the Density and Pressure fields into a hydrostatic component (') and a perturbed component (''). 

--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -121,7 +121,7 @@ module momentum_DG
   logical :: have_mass
   logical :: have_source
   logical :: have_gravity
-  logical :: on_sphere
+  logical :: on_sphere, radial_gravity
   logical :: have_absorption
   logical :: have_vertical_stabilization
   logical :: have_implicit_buoyancy
@@ -422,7 +422,6 @@ contains
       call incref(buoyancy)
       gravity=extract_vector_field(state, "GravityDirection", stat)
       call incref(gravity)
-
     else
       call allocate(buoyancy, u%mesh, "VelocityBuoyancyDensity", FIELD_TYPE_CONSTANT)
       call zero(buoyancy)
@@ -430,6 +429,9 @@ contains
       call zero(gravity)
     end if
     ewrite_minmax(buoyancy)
+
+    radial_gravity = have_option(trim(u%option_path)//"/prognostic/spatial_discretisation"//&
+       &"/buoyancy/radial_gravity_direction_at_gauss_points")
 
     ! Splits up the Density and Pressure fields into a hydrostatic component (') and a perturbed component (''). 
     ! The hydrostatic components, denoted p' and rho', should satisfy the balance: grad(p') = rho'*g
@@ -720,7 +722,7 @@ contains
             & P, old_pressure, Rho, surfacetension, q_mesh, &
             & velocity_bc, velocity_bc_type, &
             & pressure_bc, pressure_bc_type, &
-            & turbine_conn_mesh, on_sphere, depth, have_wd_abs, &
+            & turbine_conn_mesh, depth, have_wd_abs, &
             & alpha_u_field, Abs_wd, vvr_sf, ib_min_grad, nvfrac, &
             & inverse_mass=inverse_mass, &
             & inverse_masslump=inverse_masslump, &
@@ -779,7 +781,7 @@ contains
        &Viscosity, swe_bottom_drag, swe_u_nl, P, old_pressure, Rho, surfacetension, q_mesh, &
        &velocity_bc, velocity_bc_type, &
        &pressure_bc, pressure_bc_type, &
-       &turbine_conn_mesh, on_sphere, depth, have_wd_abs, alpha_u_field, Abs_wd, &
+       &turbine_conn_mesh, depth, have_wd_abs, alpha_u_field, Abs_wd, &
        &vvr_sf, ib_min_grad, nvfrac, &
        &inverse_mass, inverse_masslump, mass, subcycle_m, partial_stress)
 
@@ -928,9 +930,6 @@ contains
     ! In parallel, we assemble terms on elements we own, and those in
     ! the L1 element halo
     logical :: assemble_element
-
-    ! If on the sphere evaluate gravity direction at the gauss points
-    logical :: on_sphere
 
     ! Absorption matrices
     real, dimension(u%dim, ele_ngi(u, ele)) :: absorption_gi
@@ -1319,11 +1318,11 @@ contains
          coefficient_detwei = detwei*gravity_magnitude*ele_val_at_quad(buoyancy, ele)
       end if
 
-      if (on_sphere) then
-      ! If were on a spherical Earth evaluate the direction of the gravity vector
+      if (radial_gravity) then
+      ! If we're using a radial gravity, evaluate the direction of the gravity vector
       ! exactly at quadrature points.
         rhs_addto(:, :loc) = rhs_addto(:, :loc) + shape_vector_rhs(u_shape, &
-                                    sphere_inward_normal_at_quad_ele(X, ele), &
+                                    radial_inward_normal_at_quad_ele(X, ele), &
                                     coefficient_detwei)
       else
       
@@ -1383,7 +1382,7 @@ contains
 
         ! Calculate the gradient in the direction of gravity
         if (on_sphere) then
-          grav_at_quads=sphere_inward_normal_at_quad_ele(X, ele)
+          grav_at_quads=radial_inward_normal_at_quad_ele(X, ele)
         else
           grav_at_quads=ele_val_at_quad(gravity, ele)
         end if

--- a/examples/backward_facing_step_2d/backward_facing_step_2d.flml
+++ b/examples/backward_facing_step_2d/backward_facing_step_2d.flml
@@ -509,11 +509,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/backward_facing_step_2d/backward_facing_step_2d.flml
+++ b/examples/backward_facing_step_2d/backward_facing_step_2d.flml
@@ -513,6 +513,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/backward_facing_step_3d/backward_facing_step_3d.flml
+++ b/examples/backward_facing_step_3d/backward_facing_step_3d.flml
@@ -138,6 +138,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/backward_facing_step_3d/backward_facing_step_3d.flml
+++ b/examples/backward_facing_step_3d/backward_facing_step_3d.flml
@@ -134,11 +134,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/driven_cavity/driven_cavity.flml
+++ b/examples/driven_cavity/driven_cavity.flml
@@ -162,11 +162,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/driven_cavity/driven_cavity.flml
+++ b/examples/driven_cavity/driven_cavity.flml
@@ -166,6 +166,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re1/flow_past_sphere_Re1.flml
+++ b/examples/flow_past_sphere_Re1/flow_past_sphere_Re1.flml
@@ -155,11 +155,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re1/flow_past_sphere_Re1.flml
+++ b/examples/flow_past_sphere_Re1/flow_past_sphere_Re1.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re10/flow_past_sphere_Re10.flml
+++ b/examples/flow_past_sphere_Re10/flow_past_sphere_Re10.flml
@@ -155,11 +155,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re10/flow_past_sphere_Re10.flml
+++ b/examples/flow_past_sphere_Re10/flow_past_sphere_Re10.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re100/flow_past_sphere_Re100.flml
+++ b/examples/flow_past_sphere_Re100/flow_past_sphere_Re100.flml
@@ -155,11 +155,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re100/flow_past_sphere_Re100.flml
+++ b/examples/flow_past_sphere_Re100/flow_past_sphere_Re100.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re1000/flow_past_sphere_Re1000.flml
+++ b/examples/flow_past_sphere_Re1000/flow_past_sphere_Re1000.flml
@@ -155,11 +155,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/flow_past_sphere_Re1000/flow_past_sphere_Re1000.flml
+++ b/examples/flow_past_sphere_Re1000/flow_past_sphere_Re1000.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/hokkaido-nansei-oki_tsunami/MonaiValley_C_p1p1_nu0.01_kmkstab_drag0.002_butcircularoundisland0.2.flml
+++ b/examples/hokkaido-nansei-oki_tsunami/MonaiValley_C_p1p1_nu0.01_kmkstab_drag0.002_butcircularoundisland0.2.flml
@@ -340,6 +340,7 @@ def val(X,t):
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/hokkaido-nansei-oki_tsunami/MonaiValley_C_p1p1_nu0.01_kmkstab_drag0.002_butcircularoundisland0.2.flml
+++ b/examples/hokkaido-nansei-oki_tsunami/MonaiValley_C_p1p1_nu0.01_kmkstab_drag0.002_butcircularoundisland0.2.flml
@@ -336,11 +336,11 @@ def val(X,t):
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/lock_exchange/lock_exchange.flml
+++ b/examples/lock_exchange/lock_exchange.flml
@@ -184,11 +184,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/lock_exchange/lock_exchange.flml
+++ b/examples/lock_exchange/lock_exchange.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/restratification_after_oodc/restratification_after_oodc.flml
+++ b/examples/restratification_after_oodc/restratification_after_oodc.flml
@@ -286,11 +286,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/restratification_after_oodc/restratification_after_oodc.flml
+++ b/examples/restratification_after_oodc/restratification_after_oodc.flml
@@ -290,6 +290,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/rotating_channel/channel.flml
+++ b/examples/rotating_channel/channel.flml
@@ -184,11 +184,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/rotating_channel/channel.flml
+++ b/examples/rotating_channel/channel.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/stokes_square_convection/stokes-square-convection-24.flml
+++ b/examples/stokes_square_convection/stokes-square-convection-24.flml
@@ -238,11 +238,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/stokes_square_convection/stokes-square-convection-24.flml
+++ b/examples/stokes_square_convection/stokes-square-convection-24.flml
@@ -242,6 +242,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/stokes_square_convection/stokes-square-convection-48.flml
+++ b/examples/stokes_square_convection/stokes-square-convection-48.flml
@@ -238,11 +238,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/stokes_square_convection/stokes-square-convection-48.flml
+++ b/examples/stokes_square_convection/stokes-square-convection-48.flml
@@ -242,6 +242,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/tephra_settling/tephra_settling.flml
+++ b/examples/tephra_settling/tephra_settling.flml
@@ -158,11 +158,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -374,11 +374,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/tephra_settling/tephra_settling.flml
+++ b/examples/tephra_settling/tephra_settling.flml
@@ -162,6 +162,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -377,6 +378,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/tides_in_the_Mediterranean_Sea/med.flml
+++ b/examples/tides_in_the_Mediterranean_Sea/med.flml
@@ -346,6 +346,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/tides_in_the_Mediterranean_Sea/med.flml
+++ b/examples/tides_in_the_Mediterranean_Sea/med.flml
@@ -342,11 +342,11 @@
                 <length_scale_type>tensor</length_scale_type>
               </second_order>
             </les_model>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/water_collapse/water_collapse.flml
+++ b/examples/water_collapse/water_collapse.flml
@@ -259,11 +259,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/examples/water_collapse/water_collapse.flml
+++ b/examples/water_collapse/water_collapse.flml
@@ -263,6 +263,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/femtools/Coordinates.F90
+++ b/femtools/Coordinates.F90
@@ -61,7 +61,7 @@ module Coordinates
        vector_lon_lat_height_2_cartesian_c, vector_cartesian_2_lon_lat_height_c, &
        tensor_spherical_polar_2_cartesian, &
        higher_order_sphere_projection, &
-       sphere_inward_normal_at_quad_ele, sphere_inward_normal_at_quad_face, &
+       radial_inward_normal_at_quad_ele, radial_inward_normal_at_quad_face, &
        rotate_diagonal_to_sphere_gi, rotate_diagonal_to_sphere_face, &
        rotate_ct_m_sphere, rotate_momentum_to_sphere, &
        rotate_velocity_sphere, rotate_velocity_back_sphere, &
@@ -1020,7 +1020,7 @@ contains
   
   end subroutine higher_order_sphere_projection
 
-  function sphere_inward_normal_at_quad_ele(positions, ele_number) result(quad_val)
+  function radial_inward_normal_at_quad_ele(positions, ele_number) result(quad_val)
     ! Return the direction of gravity at the quadrature points of and element.
     type(vector_field), intent(in) :: positions
     integer, intent(in) :: ele_number
@@ -1035,9 +1035,9 @@ contains
       end do
     end do
 
-  end function sphere_inward_normal_at_quad_ele
+  end function radial_inward_normal_at_quad_ele
 
-  function sphere_inward_normal_at_quad_face(positions, face_number) result(quad_val)
+  function radial_inward_normal_at_quad_face(positions, face_number) result(quad_val)
     ! Return the direction of gravity at the quadrature points of and element.
     type(vector_field), intent(in) :: positions
     integer, intent(in) :: face_number
@@ -1052,7 +1052,7 @@ contains
       end do
     end do
 
-  end function sphere_inward_normal_at_quad_face
+  end function radial_inward_normal_at_quad_face
 
   function rotate_diagonal_to_sphere_gi(positions, ele_number, diagonal) result(quad_val)
     ! Given the diagonal of a tensor in cartesian coordinates, this function

--- a/libspud/python/test.flml
+++ b/libspud/python/test.flml
@@ -147,7 +147,7 @@
         <mesh name="VelocityMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
    # Do not remove this comment
    u =  0.25 * ((4*X[0] - 2) + (4*X[1] - 2)**3)
    v = -0.25 * ((4*X[1] - 2) + (4*X[0] - 2)**3)
@@ -241,7 +241,7 @@
         <explicit/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
 	from math import sqrt, pi
 	dx1 = X[0]-0.5
 	dx2 = X[1]-0.5
@@ -277,7 +277,7 @@
         <mesh name="PressureMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
 	from math import sqrt, pi
 	dx1 = X[0]-0.5
 	dx2 = X[1]-0.5

--- a/manual/configuring_fluidity.tex
+++ b/manual/configuring_fluidity.tex
@@ -133,32 +133,25 @@ The quadrature degree is specified by setting \option{/geometry/quadrature/degre
 \index{mesh!superparametric}
 
 Enabling \option{/geometry/spherical\_earth} informs \fluidity that your
-simulation is being carried out in an Earth like geometry. In three dimensions
-this means that the mesh domain is assumed to approximate (a part of) a sphere, but this option can
-also be used in two dimensions where the domain is assumed to be (a part of) a
-circle (cylindrical domain). The domain is still described in
-general $x,y,z$ coordinates (no spherical coordinates)
-and the centre of the N-sphere must coincide with the origin. Gravity is assumed
-to point to the centre. Generally, the sphere is only extruded to a certain
+simulation is being carried out in an Earth like geometry. This means that the mesh domain is assumed to approximate (a part of) an
+N-sphere (sphere in three dimensions, circle in two dimensions). The domain is still described in
+general $x,y,z$ coordinates (no spherical/cylindrical coordinates)
+and the centre of the N-sphere must coincide with the origin.  Turning on this option has a number of effects.
+
+In combination with extrusion options (see section \ref{sec:extruded_meshes}), 
+specifying a \option{spherical\_earth} will extrude radially from the top surface of the
+domain towards the origin.  Generally, the sphere is only extruded to a certain
 depth, leaving a void around the origin. The two main applications of this
 option are large-scale ocean simulations on the sphere, and geodynamic simulations of the
 Earth's mantle.
 
-One consequence of this option is that an input mesh can be set up that
-approximates the top surface of the spherical domain. This will be
-a $N$-dimensional mesh embedded in $N+1$ dimensions, and its vertex locations
-therefore need to be $N+1$-dimensional. If this option is combined with
-extrusion (see section \ref{sec:extruded_meshes}), the extrusion will
-happen downwards in the radial direction.
-
-Another consequence of this option is that the direction of gravity is no longer
-read from the \option{GravityDirection} field (under
-\option{/physical\_parameters/gravity}), but is always assumed to be the
-negative radial direction and is directly calculated at the gauss points
-(instead of being interpolated from the mesh nodes). It is however still advised
-to setup the \option{GravityDirection} from a python function that returns
-the same negative radial unit vector, as some places in the code still expect
-it.
+In general, when using this option you will want to specify the gravity direction to be opposed to the radial
+direction (i.e. pointing to the origin) however it can also be used in conjunction with the
+\option{buoyancy/radial\_gravity\_direction\_at\_gauss\_points} option underneath the \option{spatial\_discretisation} option for
+Velocity to both specify that it should be radial and defined at the gauss points (rather than the nodes) in the buoyancy term
+(ignoring whatever gravity direction you have specified manually but only in the buoyancy term).  Specifying the gravity direction at the
+gauss points helps eliminate spurious interpolation errors and non-physical imbalance in spherical simulations (see
+\ref{sec:configuring_fluidity!spatial_discretisation!buoyancy}).
 
 For ocean simulations, the option has implications for various options and terms such as wind forcing (see section \ref{sec:wind_forcing}), the calculation of buoyancy and the `direction' of absorptions (see \ref{sec:Source}).
 If this option is checked, wind forcing and \eg momentum forcing from bulk formulae (see \ref{sec:bulk_formulae}) will automatically be rotated and applied in the direction tangential to the Earth's surface. It will also result in absorption terms set through the options tree being rotated and applied in the longitudinal, latitudinal and radial directions respectively. Note however that the viscosity and diffusion operators are currently not rotated automatically and thus the user must carry such rotations out themselves. An example in which the viscosity is rotated is giving in section \ref{sec:tides_in_the_med}.
@@ -175,16 +168,19 @@ an element are moved a little in the radial direction,
 such that the radial coordinate varies linearly
 between the vertices. For example, in the case of a triangle with all three
 points on a perfect sphere, this means the entire triangle is now curved
-to be exactly on that sphere. Using the \option{superparametric\_mapping} option
+to be exactly on that sphere. 
+
+Using the \option{superparametric\_mapping} option
 the curved elements are approximated by a higher order polynomial by using a
 higher order \option{CoordinateMesh}. To use this option, you therefore need a
 seperate \option{CoordinateMesh} that is derived from the usual continuous P1
-mesh (typicall called \option{BaseMesh}). For example, when combining this with
+mesh (typically called \option{BaseMesh}). For example, when combining this with
 extrusion in 3D, one needs a 2D input mesh \option{InputMesh}, an extruded
 \option{BaseMesh} with extrusion options, and a \option{CoordinateMesh} derived
 from this that has set a higher order \option{mesh\_shape/polynomial\_degree}.
 Other meshes (function spaces) used in the discretisation, e.g. a \PoDG or a $P2$ mesh, are
 also derived from the \option{BaseMesh}.
+
 For the \option{analytical\_mapping} option a higher order
 \option{CoordinateMesh} is not necessary; the bending of the element is done
 directly at the gauss points using an analytical expression. Thus the
@@ -1132,6 +1128,21 @@ equation). If BETA is set to zero, the discretisation is left
 non-conservative. An intermediate value can alternatively be
 selected. Please refer to section \ref{sec:ND_momentum_equation} for a comprehensive discussion on the influence of this parameter.
 
+\subsubsection{Buoyancy}
+\label{sec:configuring_fluidity!spatial_discretisation!buoyancy}
+\index{spherical earth}
+
+When solving for momentum on a spherical or cylindrical domain it is possible to specify that the gravity direction should be automatically
+calculated to be radial (towards the origin) and evaluated directly at the gauss points using the
+\option{buoyancy/radial\_gravity\_direction\_at\_gauss\_points} option (underneath Velocity \option{spatial\_discretisation}).  This
+ignores the direction specified in \option{/physical\_parameters/gravity} but still uses the magnitude specified there.  Note
+that the direction is only ignored in the buoyancy term of the momentum equation and the version specified under
+\option{/physical\_parameters/gravity} may be used elsewhere in the model.
+
+Evaluating the gravity direction directly at gauss points, rather than interpolating it from the values specified at the nodes,
+avoids interpolation errors that introduce non-physical imbalances between buoyancy and pressure in spherical simulations.  As this
+is mostly used for simulations on N-spheres it is generally combined with the \option{/geometry/spherical\_earth} option (see
+\ref{sec:spherical_earth}).
 
 \subsection{Temporal discretisations}
 \label{sec:configuring_fluidity_temporal_discretisation}

--- a/manual/configuring_fluidity.tex
+++ b/manual/configuring_fluidity.tex
@@ -145,12 +145,13 @@ depth, leaving a void around the origin. The two main applications of this
 option are large-scale ocean simulations on the sphere, and geodynamic simulations of the
 Earth's mantle.
 
-In general, when using this option you will want to specify the gravity direction to be opposed to the radial
-direction (i.e. pointing to the origin) however it can also be used in conjunction with the
+When using this option the gravity direction should be defined manually in the radial
+direction (pointing to the origin) using python
+(\option{/physical\_parameters/gravity/vector\_field::GravityDirection/prescribed/value::WholeMesh/python}).  If used in conjunction with the
 \option{buoyancy/radial\_gravity\_direction\_at\_gauss\_points} option underneath the \option{spatial\_discretisation} option for
-Velocity to both specify that it should be radial and defined at the gauss points (rather than the nodes) in the buoyancy term
-(ignoring whatever gravity direction you have specified manually but only in the buoyancy term).  Specifying the gravity direction at the
-gauss points helps eliminate spurious interpolation errors and non-physical imbalance in spherical simulations (see
+Velocity then gravity will be automatically defined to be radial at the gauss points (rather than the nodes) in the buoyancy term
+(ignoring whatever gravity direction you have specified manually in the buoyancy term only).  Specifying the gravity direction at the
+gauss points in the buoyancy term helps eliminate spurious interpolation errors and non-physical imbalance in spherical simulations (see
 \ref{sec:configuring_fluidity!spatial_discretisation!buoyancy}).
 
 For ocean simulations, the option has implications for various options and terms such as wind forcing (see section \ref{sec:wind_forcing}), the calculation of buoyancy and the `direction' of absorptions (see \ref{sec:Source}).

--- a/parameterisation/Gls_vertical_turbulence_model.F90
+++ b/parameterisation/Gls_vertical_turbulence_model.F90
@@ -1463,7 +1463,7 @@ subroutine gls_buoyancy(state)
             end if
           
             if (on_sphere) then
-                grav_at_quads=sphere_inward_normal_at_quad_ele(positions, ele)
+                grav_at_quads=radial_inward_normal_at_quad_ele(positions, ele)
             else
                 grav_at_quads=ele_val_at_quad(gravity, ele)
             end if

--- a/schemas/prognostic_field_options.rnc
+++ b/schemas/prognostic_field_options.rnc
@@ -921,6 +921,17 @@ prognostic_velocity_field =
          ##  0. < BETA < 1.
          element conservative_advection {
             real
+         },
+         ## Options dealing with buoyancy
+         element buoyancy {
+           ## Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+           ## and evaluate it at the gauss points.
+           ##
+           ## NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+           ## for the buoyancy terms.
+           element radial_gravity_direction_at_gauss_points {
+             comment
+           }?
          }
       },
       ## Temporal discretisation options

--- a/schemas/prognostic_field_options.rnc
+++ b/schemas/prognostic_field_options.rnc
@@ -713,7 +713,18 @@ prognostic_velocity_field =
                    element activation_energy {
                     real
                    }
-               }?
+               }?,
+               ## Options dealing with buoyancy
+               element buoyancy {
+                 ## Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+                 ## and evaluate it at the gauss points.
+                 ##
+                 ## NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+                 ## for the buoyancy terms.
+                 element radial_gravity_direction_at_gauss_points {
+                   comment
+                 }?
+               }
             }|
             ## Discontinuous galerkin formulation. Confusingly it is not necessary to provide
             ## a discontinuous velocity field for this to work!
@@ -912,6 +923,17 @@ prognostic_velocity_field =
                   element integrate_conservation_term_by_parts {
                     empty
                   }?
+               },
+               ## Options dealing with buoyancy
+               element buoyancy {
+                 ## Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+                 ## and evaluate it at the gauss points.
+                 ##
+                 ## NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+                 ## for the buoyancy terms.
+                 element radial_gravity_direction_at_gauss_points {
+                   comment
+                 }?
                }
             }
          ),
@@ -921,17 +943,6 @@ prognostic_velocity_field =
          ##  0. < BETA < 1.
          element conservative_advection {
             real
-         },
-         ## Options dealing with buoyancy
-         element buoyancy {
-           ## Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
-           ## and evaluate it at the gauss points.
-           ##
-           ## NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
-           ## for the buoyancy terms.
-           element radial_gravity_direction_at_gauss_points {
-             comment
-           }?
          }
       },
       ## Temporal discretisation options

--- a/schemas/prognostic_field_options.rng
+++ b/schemas/prognostic_field_options.rng
@@ -1120,6 +1120,19 @@ twice.</a:documentation>
  0. &lt; BETA &lt; 1.</a:documentation>
         <ref name="real"/>
       </element>
+      <element name="buoyancy">
+        <a:documentation>Options dealing with buoyancy</a:documentation>
+        <optional>
+          <element name="radial_gravity_direction_at_gauss_points">
+            <a:documentation>Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+and evaluate it at the gauss points.
+
+NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+for the buoyancy terms.</a:documentation>
+            <ref name="comment"/>
+          </element>
+        </optional>
+      </element>
     </element>
     <element name="temporal_discretisation">
       <a:documentation>Temporal discretisation options</a:documentation>

--- a/schemas/prognostic_field_options.rng
+++ b/schemas/prognostic_field_options.rng
@@ -880,6 +880,19 @@ upon temperature. This is only valid when you have a temperature field.</a:docum
               </element>
             </element>
           </optional>
+          <element name="buoyancy">
+            <a:documentation>Options dealing with buoyancy</a:documentation>
+            <optional>
+              <element name="radial_gravity_direction_at_gauss_points">
+                <a:documentation>Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+and evaluate it at the gauss points.
+
+NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+for the buoyancy terms.</a:documentation>
+                <ref name="comment"/>
+              </element>
+            </optional>
+          </element>
         </element>
         <element name="discontinuous_galerkin">
           <a:documentation>Discontinuous galerkin formulation. Confusingly it is not necessary to provide
@@ -1111,6 +1124,19 @@ twice.</a:documentation>
               </element>
             </optional>
           </element>
+          <element name="buoyancy">
+            <a:documentation>Options dealing with buoyancy</a:documentation>
+            <optional>
+              <element name="radial_gravity_direction_at_gauss_points">
+                <a:documentation>Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
+and evaluate it at the gauss points.
+
+NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
+for the buoyancy terms.</a:documentation>
+                <ref name="comment"/>
+              </element>
+            </optional>
+          </element>
         </element>
       </choice>
       <element name="conservative_advection">
@@ -1119,19 +1145,6 @@ twice.</a:documentation>
  BETA=0. -- non-conservative
  0. &lt; BETA &lt; 1.</a:documentation>
         <ref name="real"/>
-      </element>
-      <element name="buoyancy">
-        <a:documentation>Options dealing with buoyancy</a:documentation>
-        <optional>
-          <element name="radial_gravity_direction_at_gauss_points">
-            <a:documentation>Align the gravity opposite to the radial direction (-(x,y) in 2d, -(x,y,z) in 3d)
-and evaluate it at the gauss points.
-
-NOTE: this ignores whatever values are set under /physical_parameters/gravity/vector_field::GravityDirection 
-for the buoyancy terms.</a:documentation>
-            <ref name="comment"/>
-          </element>
-        </optional>
       </element>
     </element>
     <element name="temporal_discretisation">

--- a/tests/1mat-shocktube-gmsh/1material_shocktube.flml
+++ b/tests/1mat-shocktube-gmsh/1material_shocktube.flml
@@ -199,11 +199,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/1mat-shocktube-gmsh/1material_shocktube.flml
+++ b/tests/1mat-shocktube-gmsh/1material_shocktube.flml
@@ -203,6 +203,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/1mat-shocktube/1material_shocktube.flml
+++ b/tests/1mat-shocktube/1material_shocktube.flml
@@ -199,11 +199,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/1mat-shocktube/1material_shocktube.flml
+++ b/tests/1mat-shocktube/1material_shocktube.flml
@@ -203,6 +203,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-adapt/3material-droplet.flml
+++ b/tests/3material-droplet-adapt/3material-droplet.flml
@@ -209,11 +209,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-adapt/3material-droplet.flml
+++ b/tests/3material-droplet-adapt/3material-droplet.flml
@@ -213,6 +213,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d.flml
+++ b/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d.flml
@@ -248,11 +248,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d.flml
+++ b/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d/3material-droplet-p1dgp2-test-cty-cv-rhop1dg-3d.flml
@@ -252,6 +252,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg/3material-droplet-p1dgp2-test-cty-cv-rhop1dg.flml
+++ b/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg/3material-droplet-p1dgp2-test-cty-cv-rhop1dg.flml
@@ -248,11 +248,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg/3material-droplet-p1dgp2-test-cty-cv-rhop1dg.flml
+++ b/tests/3material-droplet-p1dgp2-test-cty-cv-rhop1dg/3material-droplet-p1dgp2-test-cty-cv-rhop1dg.flml
@@ -252,6 +252,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet/3material-droplet.flml
+++ b/tests/3material-droplet/3material-droplet.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/3material-droplet/3material-droplet.flml
+++ b/tests/3material-droplet/3material-droplet.flml
@@ -206,11 +206,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-adapt-lumped/5material-droplet.flml
+++ b/tests/5material-droplet-adapt-lumped/5material-droplet.flml
@@ -211,11 +211,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-adapt-lumped/5material-droplet.flml
+++ b/tests/5material-droplet-adapt-lumped/5material-droplet.flml
@@ -215,6 +215,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-adapt/5material-droplet.flml
+++ b/tests/5material-droplet-adapt/5material-droplet.flml
@@ -224,6 +224,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-adapt/5material-droplet.flml
+++ b/tests/5material-droplet-adapt/5material-droplet.flml
@@ -220,11 +220,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-parallel/5material-droplet.flml
+++ b/tests/5material-droplet-parallel/5material-droplet.flml
@@ -200,6 +200,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-parallel/5material-droplet.flml
+++ b/tests/5material-droplet-parallel/5material-droplet.flml
@@ -196,11 +196,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-serial/5material-droplet.flml
+++ b/tests/5material-droplet-serial/5material-droplet.flml
@@ -200,6 +200,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/5material-droplet-serial/5material-droplet.flml
+++ b/tests/5material-droplet-serial/5material-droplet.flml
@@ -196,11 +196,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_A_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_A_structured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_A_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_A_structured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_B_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_B_structured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_B_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_B_structured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_C_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_C_structured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_C_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_C_structured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_D_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_D_structured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_D_structured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-structured/MMS_D_structured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_A_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_A_unstructured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_A_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_A_unstructured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_B_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_B_unstructured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_B_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_B_unstructured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_C_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_C_unstructured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_C_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_C_unstructured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_D_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_D_unstructured.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_D_unstructured.flml
+++ b/tests/Helmholtz-anisotropic-vector-mms-p1p1cg-unstructured/MMS_D_unstructured.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Instability/Thin_No_Forcing_Adapt_25_checkpoint.flml
+++ b/tests/Instability/Thin_No_Forcing_Adapt_25_checkpoint.flml
@@ -205,11 +205,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Instability/Thin_No_Forcing_Adapt_25_checkpoint.flml
+++ b/tests/Instability/Thin_No_Forcing_Adapt_25_checkpoint.flml
@@ -209,6 +209,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_3d_busse_1a_p2p1/Stokes-3d-busse-1a-p2p1.flml
+++ b/tests/Stokes_3d_busse_1a_p2p1/Stokes-3d-busse-1a-p2p1.flml
@@ -240,11 +240,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_3d_busse_1a_p2p1/Stokes-3d-busse-1a-p2p1.flml
+++ b/tests/Stokes_3d_busse_1a_p2p1/Stokes-3d-busse-1a-p2p1.flml
@@ -244,6 +244,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_Subduction_VK_Case_1b/Stokes-Subduction-VK-Case-1b.flml
+++ b/tests/Stokes_Subduction_VK_Case_1b/Stokes-Subduction-VK-Case-1b.flml
@@ -249,11 +249,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_Subduction_VK_Case_1b/Stokes-Subduction-VK-Case-1b.flml
+++ b/tests/Stokes_Subduction_VK_Case_1b/Stokes-Subduction-VK-Case-1b.flml
@@ -253,6 +253,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-fs.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-fs.flml
@@ -238,11 +238,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-fs.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-fs.flml
@@ -242,6 +242,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
@@ -226,11 +226,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
@@ -230,6 +230,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-mg.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-mg.flml
@@ -226,6 +226,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-mg.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-mg.flml
@@ -222,11 +222,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-sor.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-sor.flml
@@ -226,6 +226,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-sor.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-sor.flml
@@ -222,11 +222,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-fs.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-fs.flml
@@ -241,6 +241,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-fs.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-fs.flml
@@ -237,11 +237,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-gamg.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-gamg.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-gamg.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-gamg.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-mg.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-mg.flml
@@ -221,11 +221,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-mg.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-mg.flml
@@ -225,6 +225,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-sor.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-sor.flml
@@ -221,11 +221,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-sor.flml
+++ b/tests/Stokes_may_solcx_stepx/Stokes-may-solcx-stepx-sor.flml
@@ -225,6 +225,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-fs.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-fs.flml
@@ -241,6 +241,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-fs.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-fs.flml
@@ -237,11 +237,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-gamg.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-gamg.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-gamg.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-gamg.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-mg.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-mg.flml
@@ -221,11 +221,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-mg.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-mg.flml
@@ -225,6 +225,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-sor.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-sor.flml
@@ -221,11 +221,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-sor.flml
+++ b/tests/Stokes_may_solky_exponential/Stokes-may-solky-exponential-sor.flml
@@ -225,6 +225,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_A.flml
@@ -161,6 +161,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_A.flml
@@ -157,11 +157,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_B.flml
@@ -161,6 +161,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_B.flml
@@ -157,11 +157,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_C.flml
@@ -161,6 +161,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_C.flml
@@ -157,11 +157,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_D.flml
@@ -161,6 +161,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1bp1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p1bp1/MMS_D.flml
@@ -157,11 +157,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_A.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_A.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_B.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_B.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_C.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_C.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_D.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p1p1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p1p1/MMS_D.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_A.flml
@@ -214,6 +214,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_A.flml
@@ -210,11 +210,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_B.flml
@@ -214,6 +214,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_B.flml
@@ -210,11 +210,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_C.flml
@@ -214,6 +214,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_C.flml
@@ -210,11 +210,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_D.flml
@@ -214,6 +214,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1/MMS_D.flml
@@ -210,11 +210,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_A.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_A.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_B.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_B.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_C.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_C.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_D.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_periodic/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_periodic/MMS_D.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_A.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_A.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_B.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_B.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_C.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_C.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_D.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_tdepvisc/MMS_D.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_A.flml
@@ -213,11 +213,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_A.flml
@@ -217,6 +217,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_B.flml
@@ -213,11 +213,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_B.flml
@@ -217,6 +217,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_C.flml
@@ -213,11 +213,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_C.flml
@@ -217,6 +217,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_D.flml
@@ -213,11 +213,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_test_cty_cv/MMS_D.flml
@@ -217,6 +217,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_A.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_A.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_A.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_B.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_B.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_B.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_C.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_C.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_C.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_D.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_cg_p2p1_varvisc/MMS_D.flml
+++ b/tests/Stokes_mms_cg_p2p1_varvisc/MMS_D.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_A.flml
+++ b/tests/Stokes_mms_q1p0/MMS_A.flml
@@ -208,11 +208,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_A.flml
+++ b/tests/Stokes_mms_q1p0/MMS_A.flml
@@ -212,6 +212,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_B.flml
+++ b/tests/Stokes_mms_q1p0/MMS_B.flml
@@ -208,11 +208,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_B.flml
+++ b/tests/Stokes_mms_q1p0/MMS_B.flml
@@ -212,6 +212,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_C.flml
+++ b/tests/Stokes_mms_q1p0/MMS_C.flml
@@ -208,11 +208,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_C.flml
+++ b/tests/Stokes_mms_q1p0/MMS_C.flml
@@ -212,6 +212,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_D.flml
+++ b/tests/Stokes_mms_q1p0/MMS_D.flml
@@ -208,11 +208,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_mms_q1p0/MMS_D.flml
+++ b/tests/Stokes_mms_q1p0/MMS_D.flml
@@ -212,6 +212,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_slab_detachment/Slab-detachment.flml
+++ b/tests/Stokes_slab_detachment/Slab-detachment.flml
@@ -262,6 +262,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_slab_detachment/Slab-detachment.flml
+++ b/tests/Stokes_slab_detachment/Slab-detachment.flml
@@ -258,11 +258,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1dgp2/Stokes-square-convection-1e4-p1dgp2.flml
+++ b/tests/Stokes_square_convection_1e4_p1dgp2/Stokes-square-convection-1e4-p1dgp2.flml
@@ -253,6 +253,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1dgp2/Stokes-square-convection-1e4-p1dgp2.flml
+++ b/tests/Stokes_square_convection_1e4_p1dgp2/Stokes-square-convection-1e4-p1dgp2.flml
@@ -249,11 +249,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1/Stokes-square-convection-1e4-p1p1.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1/Stokes-square-convection-1e4-p1p1.flml
@@ -228,6 +228,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1/Stokes-square-convection-1e4-p1p1.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1/Stokes-square-convection-1e4-p1p1.flml
@@ -224,11 +224,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1_parallel/Stokes-square-convection-1e4-p1p1-parallel.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1_parallel/Stokes-square-convection-1e4-p1p1-parallel.flml
@@ -208,6 +208,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1_parallel/Stokes-square-convection-1e4-p1p1-parallel.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1_parallel/Stokes-square-convection-1e4-p1p1-parallel.flml
@@ -204,11 +204,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1cv/Stokes-square-convection-1e4-p1p1cv.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1cv/Stokes-square-convection-1e4-p1p1cv.flml
@@ -208,6 +208,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p1p1cv/Stokes-square-convection-1e4-p1p1cv.flml
+++ b/tests/Stokes_square_convection_1e4_p1p1cv/Stokes-square-convection-1e4-p1p1cv.flml
@@ -204,11 +204,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p2p1/Stokes-square-convection-1e4-p2p1.flml
+++ b/tests/Stokes_square_convection_1e4_p2p1/Stokes-square-convection-1e4-p2p1.flml
@@ -272,6 +272,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p2p1/Stokes-square-convection-1e4-p2p1.flml
+++ b/tests/Stokes_square_convection_1e4_p2p1/Stokes-square-convection-1e4-p2p1.flml
@@ -268,11 +268,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p2p1_parallel/Stokes-square-convection-1e4-p2p1-parallel.flml
+++ b/tests/Stokes_square_convection_1e4_p2p1_parallel/Stokes-square-convection-1e4-p2p1-parallel.flml
@@ -206,11 +206,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/Stokes_square_convection_1e4_p2p1_parallel/Stokes-square-convection-1e4-p2p1-parallel.flml
+++ b/tests/Stokes_square_convection_1e4_p2p1_parallel/Stokes-square-convection-1e4-p2p1-parallel.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/adapt_extrude_bathymetry_1p1d/adapt_extrude_bathymetry_1p1d.flml
+++ b/tests/adapt_extrude_bathymetry_1p1d/adapt_extrude_bathymetry_1p1d.flml
@@ -330,11 +330,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/adapt_extrude_bathymetry_1p1d/adapt_extrude_bathymetry_1p1d.flml
+++ b/tests/adapt_extrude_bathymetry_1p1d/adapt_extrude_bathymetry_1p1d.flml
@@ -334,6 +334,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/analytical-sphere-cg-tracer/sphericalSegment.flml
+++ b/tests/analytical-sphere-cg-tracer/sphericalSegment.flml
@@ -319,6 +319,9 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>

--- a/tests/backward_facing_step_2d_test/backward_facing_step_2d.flml
+++ b/tests/backward_facing_step_2d_test/backward_facing_step_2d.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/backward_facing_step_2d_test/backward_facing_step_2d.flml
+++ b/tests/backward_facing_step_2d_test/backward_facing_step_2d.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/backward_facing_step_2d_zoltan_sam/backward_facing_step_2d.flml
+++ b/tests/backward_facing_step_2d_zoltan_sam/backward_facing_step_2d.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/backward_facing_step_2d_zoltan_sam/backward_facing_step_2d.flml
+++ b/tests/backward_facing_step_2d_zoltan_sam/backward_facing_step_2d.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/balance-pressure/balance-pressure.flml
+++ b/tests/balance-pressure/balance-pressure.flml
@@ -185,6 +185,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/balance-pressure/balance-pressure.flml
+++ b/tests/balance-pressure/balance-pressure.flml
@@ -181,11 +181,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bc_from_field/vector_field_bc_from_field.flml
+++ b/tests/bc_from_field/vector_field_bc_from_field.flml
@@ -160,6 +160,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bc_from_field/vector_field_bc_from_field.flml
+++ b/tests/bc_from_field/vector_field_bc_from_field.flml
@@ -156,11 +156,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bed_shear_from_grad_u_CG/bed_shear_from_grad_u_CG.flml
+++ b/tests/bed_shear_from_grad_u_CG/bed_shear_from_grad_u_CG.flml
@@ -70,11 +70,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bed_shear_from_grad_u_CG/bed_shear_from_grad_u_CG.flml
+++ b/tests/bed_shear_from_grad_u_CG/bed_shear_from_grad_u_CG.flml
@@ -74,6 +74,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bed_shear_from_grad_u_DG/bed_shear_from_grad_u_DG.flml
+++ b/tests/bed_shear_from_grad_u_DG/bed_shear_from_grad_u_DG.flml
@@ -79,6 +79,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/bed_shear_from_grad_u_DG/bed_shear_from_grad_u_DG.flml
+++ b/tests/bed_shear_from_grad_u_DG/bed_shear_from_grad_u_DG.flml
@@ -75,11 +75,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_two_element/mix.flml
+++ b/tests/buoyancy_adjustment_dg_two_element/mix.flml
@@ -258,6 +258,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_two_element/mix.flml
+++ b/tests/buoyancy_adjustment_dg_two_element/mix.flml
@@ -254,11 +254,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_two_element_generic_linear_eos/mix.flml
+++ b/tests/buoyancy_adjustment_dg_two_element_generic_linear_eos/mix.flml
@@ -252,11 +252,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_two_element_generic_linear_eos/mix.flml
+++ b/tests/buoyancy_adjustment_dg_two_element_generic_linear_eos/mix.flml
@@ -256,6 +256,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_with_projection_two_element/mix.flml
+++ b/tests/buoyancy_adjustment_dg_with_projection_two_element/mix.flml
@@ -258,6 +258,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/buoyancy_adjustment_dg_with_projection_two_element/mix.flml
+++ b/tests/buoyancy_adjustment_dg_with_projection_two_element/mix.flml
@@ -254,11 +254,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel-flow-dg/channel_viscous.flml
+++ b/tests/channel-flow-dg/channel_viscous.flml
@@ -184,11 +184,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel-flow-dg/channel_viscous.flml
+++ b/tests/channel-flow-dg/channel_viscous.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel_wind_drag_parallel/channel_parallel.flml
+++ b/tests/channel_wind_drag_parallel/channel_parallel.flml
@@ -175,11 +175,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel_wind_drag_parallel/channel_parallel.flml
+++ b/tests/channel_wind_drag_parallel/channel_parallel.flml
@@ -179,6 +179,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel_wind_drag_rotated/channel.flml
+++ b/tests/channel_wind_drag_rotated/channel.flml
@@ -221,6 +221,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/channel_wind_drag_rotated/channel.flml
+++ b/tests/channel_wind_drag_rotated/channel.flml
@@ -217,11 +217,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel-adaptive.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel-adaptive.flml
@@ -158,11 +158,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel-adaptive.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel-adaptive.flml
@@ -162,6 +162,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel.flml
@@ -158,11 +158,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-parallel.flml
@@ -162,6 +162,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-serial.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-serial.flml
@@ -146,6 +146,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circle-2d-drag-zoltan/circle-2d-drag-serial.flml
+++ b/tests/circle-2d-drag-zoltan/circle-2d-drag-serial.flml
@@ -142,11 +142,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circular_duct/circular_duct.flml
+++ b/tests/circular_duct/circular_duct.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/circular_duct/circular_duct.flml
+++ b/tests/circular_duct/circular_duct.flml
@@ -171,11 +171,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/column-parallel/column-parallel.flml
+++ b/tests/column-parallel/column-parallel.flml
@@ -694,6 +694,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/column-parallel/column-parallel.flml
+++ b/tests/column-parallel/column-parallel.flml
@@ -690,11 +690,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/cube-1/cube-1.flml
+++ b/tests/cube-1/cube-1.flml
@@ -136,6 +136,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/cube-1/cube-1.flml
+++ b/tests/cube-1/cube-1.flml
@@ -132,11 +132,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/cube-dg/cube.flml
+++ b/tests/cube-dg/cube.flml
@@ -130,11 +130,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/cube-dg/cube.flml
+++ b/tests/cube-dg/cube.flml
@@ -134,6 +134,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_1d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_1d.flml
@@ -214,11 +214,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_1d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_1d.flml
@@ -218,6 +218,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -215,11 +215,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -219,6 +219,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -215,11 +215,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -219,6 +219,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_2d.flml
@@ -207,6 +207,7 @@ the absorption term is included in the pressure correction (being a necessity as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -527,6 +528,7 @@ for n in range(field.node_count):
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_2d.flml
@@ -203,11 +203,11 @@ the absorption term is included in the pressure correction (being a necessity as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -524,11 +524,11 @@ for n in range(field.node_count):
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_3d.flml
@@ -203,11 +203,11 @@ the absorption term is included in the pressure correction (being a necessity as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -538,11 +538,11 @@ for n in range(field.node_count):
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs/darcy_p0p1_test_cty_cv_pressBCinlet_2phase_constant_volf_and_abs_3d.flml
@@ -207,6 +207,7 @@ the absorption term is included in the pressure correction (being a necessity as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -541,6 +542,7 @@ for n in range(field.node_count):
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p0_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p0_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -208,11 +208,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p0_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p0_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -212,6 +212,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -208,11 +208,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -212,6 +212,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel_adaptive/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel_adaptive/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -208,11 +208,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel_adaptive/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1cv_steptwochannel_adaptive/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -212,6 +212,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_2d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -210,11 +210,11 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_advect_tracer_p1dg/darcy_p0p1_test_cty_cv_pressBCinlet_3d.flml
@@ -214,6 +214,7 @@ NOTE: Because the velocity and pressure are time independent the simulation is b
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain_2d.flml
@@ -186,11 +186,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain/darcy_p0p1_test_cty_cv_pressBCinlet_rotated_domain_2d.flml
@@ -190,6 +190,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_1d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_1d.flml
@@ -200,6 +200,7 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_1d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_1d.flml
@@ -196,11 +196,11 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_2d.flml
@@ -197,11 +197,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_2d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_2d.flml
@@ -201,6 +201,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_3d.flml
@@ -197,11 +197,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_3d.flml
+++ b/tests/darcy_p0p1_test_cty_cv_velBCinlet/darcy_p0p1_test_cty_cv_velBCinlet_3d.flml
@@ -201,6 +201,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_1d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_1d.flml
@@ -208,6 +208,7 @@ the geometry is 1d and one time step is done (as nothing depends on time).</comm
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_1d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_1d.flml
@@ -204,11 +204,11 @@ the geometry is 1d and one time step is done (as nothing depends on time).</comm
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_2d.flml
@@ -210,6 +210,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_2d.flml
@@ -206,11 +206,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_3d.flml
@@ -206,11 +206,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet/darcy_p0p1cv_pressBCinlet_3d.flml
@@ -210,6 +210,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_1d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_1d.flml
@@ -188,11 +188,11 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_1d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_1d.flml
@@ -192,6 +192,7 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_2d.flml
@@ -193,6 +193,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_2d.flml
@@ -189,11 +189,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_3d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_3d.flml
@@ -189,11 +189,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_3d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_1solidphase/darcy_p0p1cv_pressBCinlet_1solidphase_3d.flml
@@ -193,6 +193,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_rotated_domain/darcy_p0p1cv_pressBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_rotated_domain/darcy_p0p1cv_pressBCinlet_rotated_domain_2d.flml
@@ -184,11 +184,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_pressBCinlet_rotated_domain/darcy_p0p1cv_pressBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1cv_pressBCinlet_rotated_domain/darcy_p0p1cv_pressBCinlet_rotated_domain_2d.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_1d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_1d.flml
@@ -194,11 +194,11 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_1d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_1d.flml
@@ -198,6 +198,7 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_2d.flml
@@ -177,6 +177,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_2d.flml
@@ -173,11 +173,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_3d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_3d.flml
@@ -198,6 +198,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_3d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet/darcy_p0p1cv_velBCinlet_3d.flml
@@ -194,11 +194,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_1d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_1d.flml
@@ -178,11 +178,11 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_1d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_1d.flml
@@ -182,6 +182,7 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_2d.flml
@@ -178,11 +178,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_2d.flml
@@ -182,6 +182,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_3d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_3d.flml
@@ -182,6 +182,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_3d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_1solidphase/darcy_p0p1cv_velBCinlet_1solidphase_3d.flml
@@ -178,11 +178,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_rotated_domain/darcy_p0p1cv_velBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_rotated_domain/darcy_p0p1cv_velBCinlet_rotated_domain_2d.flml
@@ -177,6 +177,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p0p1cv_velBCinlet_rotated_domain/darcy_p0p1cv_velBCinlet_rotated_domain_2d.flml
+++ b/tests/darcy_p0p1cv_velBCinlet_rotated_domain/darcy_p0p1cv_velBCinlet_rotated_domain_2d.flml
@@ -173,11 +173,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_1d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_1d.flml
@@ -194,11 +194,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_1d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_1d.flml
@@ -198,6 +198,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_2d.flml
@@ -194,11 +194,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_2d.flml
@@ -198,6 +198,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_3d.flml
@@ -194,11 +194,11 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_pressBCinlet/darcy_p1dgp2_pressBCinlet_3d.flml
@@ -198,6 +198,7 @@ The latter didnt work in 1d. The same vel-press element pair is used as the mixe
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_2d.flml
@@ -211,11 +211,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_2d.flml
@@ -215,6 +215,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_3d.flml
@@ -211,11 +211,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_test_cty_cv_pressBCinlet/darcy_p1dgp2_test_cty_cv_pressBCinlet_3d.flml
@@ -215,6 +215,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_1d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_1d.flml
@@ -178,11 +178,11 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_1d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_1d.flml
@@ -182,6 +182,7 @@ the geometry is 1d and one time step is done (as nothing depends on time)</comme
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_2d.flml
@@ -178,11 +178,11 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_2d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_2d.flml
@@ -182,6 +182,7 @@ the geometry is 2d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_3d.flml
@@ -182,6 +182,7 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_3d.flml
+++ b/tests/darcy_p1dgp2_velBCinlet/darcy_p1dgp2_velBCinlet_3d.flml
@@ -178,11 +178,11 @@ the geometry is 3d (although this is a 1d problem) and one time step is done (as
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/empty-mesh.flml
+++ b/tests/data/empty-mesh.flml
@@ -146,11 +146,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/empty-mesh.flml
+++ b/tests/data/empty-mesh.flml
@@ -150,6 +150,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_A.flml
+++ b/tests/data/solenoidal_interpolation_A.flml
@@ -130,11 +130,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_A.flml
+++ b/tests/data/solenoidal_interpolation_A.flml
@@ -134,6 +134,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_B.flml
+++ b/tests/data/solenoidal_interpolation_B.flml
@@ -133,11 +133,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_B.flml
+++ b/tests/data/solenoidal_interpolation_B.flml
@@ -137,6 +137,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_press_cg_test_div_cv_A.flml
+++ b/tests/data/solenoidal_interpolation_press_cg_test_div_cv_A.flml
@@ -135,6 +135,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_press_cg_test_div_cv_A.flml
+++ b/tests/data/solenoidal_interpolation_press_cg_test_div_cv_A.flml
@@ -131,11 +131,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_press_cg_test_div_cv_B.flml
+++ b/tests/data/solenoidal_interpolation_press_cg_test_div_cv_B.flml
@@ -138,6 +138,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/data/solenoidal_interpolation_press_cg_test_div_cv_B.flml
+++ b/tests/data/solenoidal_interpolation_press_cg_test_div_cv_B.flml
@@ -134,11 +134,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity/divergence_free_velocity.flml
+++ b/tests/divergence_free_velocity/divergence_free_velocity.flml
@@ -208,11 +208,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity/divergence_free_velocity.flml
+++ b/tests/divergence_free_velocity/divergence_free_velocity.flml
@@ -212,6 +212,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p0p1_3d.flml
+++ b/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p0p1_3d.flml
@@ -195,11 +195,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p0p1_3d.flml
+++ b/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p0p1_3d.flml
@@ -199,6 +199,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p1dgp2_3d.flml
+++ b/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p1dgp2_3d.flml
@@ -219,11 +219,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p1dgp2_3d.flml
+++ b/tests/divergence_free_velocity_press_cg_test_cty_cv/divergence_free_velocity_press_cg_test_cty_cv_p1dgp2_3d.flml
@@ -223,6 +223,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/driven_cavity_2d/driven_cavity_2d.flml
+++ b/tests/driven_cavity_2d/driven_cavity_2d.flml
@@ -157,6 +157,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/driven_cavity_2d/driven_cavity_2d.flml
+++ b/tests/driven_cavity_2d/driven_cavity_2d.flml
@@ -153,11 +153,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/ekman/ekman.flml
+++ b/tests/ekman/ekman.flml
@@ -207,11 +207,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.5</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/ekman/ekman.flml
+++ b/tests/ekman/ekman.flml
@@ -211,6 +211,7 @@
           <conservative_advection>
             <real_value rank="0">0.5</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrochemical_p1p1_2d/electrochemical.flml
+++ b/tests/electrochemical_p1p1_2d/electrochemical.flml
@@ -177,6 +177,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrochemical_p1p1_2d/electrochemical.flml
+++ b/tests/electrochemical_p1p1_2d/electrochemical.flml
@@ -173,11 +173,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrokinetic_p1p1_2d/electrokinetic.flml
+++ b/tests/electrokinetic_p1p1_2d/electrokinetic.flml
@@ -176,6 +176,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrokinetic_p1p1_2d/electrokinetic.flml
+++ b/tests/electrokinetic_p1p1_2d/electrokinetic.flml
@@ -172,11 +172,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrothermal_p1p1_2d/electrothermal.flml
+++ b/tests/electrothermal_p1p1_2d/electrothermal.flml
@@ -177,6 +177,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/electrothermal_p1p1_2d/electrothermal.flml
+++ b/tests/electrothermal_p1p1_2d/electrothermal.flml
@@ -173,11 +173,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_2d_with_sideset.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_2d_with_sideset.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_2d_with_sideset.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_2d_with_sideset.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_2d_without_sideset.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_2d_without_sideset.flml
@@ -132,11 +132,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_2d_without_sideset.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_2d_without_sideset.flml
@@ -136,6 +136,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_3d.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_3d.flml
@@ -132,11 +132,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/exodusii_read_support/exodusii_read_support_3d.flml
+++ b/tests/exodusii_read_support/exodusii_read_support_3d.flml
@@ -136,6 +136,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flredecomp_2d_fieldweighted/flredecomp-2d-fieldweighted.flml
+++ b/tests/flredecomp_2d_fieldweighted/flredecomp-2d-fieldweighted.flml
@@ -207,6 +207,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flredecomp_2d_fieldweighted/flredecomp-2d-fieldweighted.flml
+++ b/tests/flredecomp_2d_fieldweighted/flredecomp-2d-fieldweighted.flml
@@ -203,11 +203,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flux_bc/flux_bc_2d.flml
+++ b/tests/flux_bc/flux_bc_2d.flml
@@ -201,6 +201,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flux_bc/flux_bc_2d.flml
+++ b/tests/flux_bc/flux_bc_2d.flml
@@ -197,11 +197,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flux_bc/flux_bc_3d.flml
+++ b/tests/flux_bc/flux_bc_3d.flml
@@ -201,6 +201,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/flux_bc/flux_bc_3d.flml
+++ b/tests/flux_bc/flux_bc_3d.flml
@@ -197,11 +197,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/foam_2d_p1dgp2_weak_strong/drainage_a.flml
+++ b/tests/foam_2d_p1dgp2_weak_strong/drainage_a.flml
@@ -261,11 +261,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/foam_2d_p1dgp2_weak_strong/drainage_a.flml
+++ b/tests/foam_2d_p1dgp2_weak_strong/drainage_a.flml
@@ -265,6 +265,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-coare.flml
+++ b/tests/forcing/forcing-coare.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-coare.flml
+++ b/tests/forcing/forcing-coare.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-kara.flml
+++ b/tests/forcing/forcing-kara.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-kara.flml
+++ b/tests/forcing/forcing-kara.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-ncar.flml
+++ b/tests/forcing/forcing-ncar.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing/forcing-ncar.flml
+++ b/tests/forcing/forcing-ncar.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_inst_vals/forcing-ncar.flml
+++ b/tests/forcing_inst_vals/forcing-ncar.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_inst_vals/forcing-ncar.flml
+++ b/tests/forcing_inst_vals/forcing-ncar.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_inst_vals/forcing-ncar_inst.flml
+++ b/tests/forcing_inst_vals/forcing-ncar_inst.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_inst_vals/forcing-ncar_inst.flml
+++ b/tests/forcing_inst_vals/forcing-ncar_inst.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_single_position/forcing_single_position.flml
+++ b/tests/forcing_single_position/forcing_single_position.flml
@@ -163,6 +163,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/forcing_single_position/forcing_single_position.flml
+++ b/tests/forcing_single_position/forcing_single_position.flml
@@ -159,11 +159,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/friction-slope-swe/friction.flml
+++ b/tests/friction-slope-swe/friction.flml
@@ -223,6 +223,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/friction-slope-swe/friction.flml
+++ b/tests/friction-slope-swe/friction.flml
@@ -219,11 +219,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gauss_point_buoyancy/Makefile
+++ b/tests/gauss_point_buoyancy/Makefile
@@ -1,0 +1,6 @@
+input: clean
+	gmsh -2 src/circle.geo
+
+clean:
+	rm -rf *.d.* *.stat *.vtu *.convergence *checkpoint* src/circle.msh fluidity.[le]* \
+	matrixdump matrixdump.info

--- a/tests/gauss_point_buoyancy/Makefile
+++ b/tests/gauss_point_buoyancy/Makefile
@@ -1,6 +1,7 @@
 input: clean
 	gmsh -2 src/circle.geo
+	gmsh -2 src/hemisphere_shell.geo
 
 clean:
-	rm -rf *.d.* *.stat *.vtu *.convergence *checkpoint* src/circle.msh fluidity.[le]* \
+	rm -rf *.d.* *.stat *.vtu *.convergence *checkpoint* src/circle.msh src/hemisphere_shell.msh fluidity.[le]* \
 	matrixdump matrixdump.info

--- a/tests/gauss_point_buoyancy/gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/gauss_2d.flml
@@ -1,0 +1,307 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">gauss_2d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method/>
+        </scheme>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <viscosity_scheme>
+              <compact_discontinuous_galerkin/>
+              <tensor_form/>
+            </viscosity_scheme>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_surface>
+              <normal_component>
+                <constant>
+                  <real_value rank="0">0.0</real_value>
+                </constant>
+              </normal_component>
+              <normal_direction>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+                </python>
+              </normal_direction>
+            </align_bc_with_surface>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -2,8 +2,8 @@
 <testproblem>
   <name>Test of buoyancy at gauss points.</name>
   <owner userid="cwilson"/>
-  <problem_definition length="special" nprocs="1">
-    <command_line>fluidity -v3 -l p1dgp2_nodal_2d.flml; fluidity -v3 -l p1dgp2_gauss_2d.flml; fluidity -v3 -l p2p1_nodal_2d.flml; fluidity -v3 -l p2p1_gauss_2d.flml</command_line>
+  <problem_definition length="short" nprocs="1">
+    <command_line>fluidity -v3 -l p1dgp2_nodal_2d.flml; fluidity -v3 -l p1dgp2_gauss_2d.flml; fluidity -v3 -l p2p1_nodal_2d.flml; fluidity -v3 -l p2p1_gauss_2d.flml; fluidity -v3 -l p1dgp2_nodal_3d.flml; fluidity -v3 -l p1dgp2_gauss_3d.flml; fluidity -v3 -l p2p1_nodal_3d.flml; fluidity -v3 -l p2p1_gauss_3d.flml</command_line>
   </problem_definition>
   <variables>
     <variable name="p1dgp2_nodal_2d_pressure_error" language="python">from fluidity_tools import stat_parser
@@ -30,7 +30,48 @@ p2p1_nodal_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]
     <variable name="p2p1_gauss_2d_velocity_error" language="python">from fluidity_tools import stat_parser
 stat = stat_parser("p2p1_gauss_2d.stat")
 p2p1_gauss_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_nodal_3d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_nodal_3d.stat")
+p1dgp2_nodal_3d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_gauss_3d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_gauss_3d.stat")
+p1dgp2_gauss_3d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_nodal_3d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_nodal_3d.stat")
+p1dgp2_nodal_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_gauss_3d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_gauss_3d.stat")
+p1dgp2_gauss_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p2p1_nodal_3d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_nodal_3d.stat")
+p2p1_nodal_3d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p2p1_gauss_3d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_gauss_3d.stat")
+p2p1_gauss_3d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p2p1_nodal_3d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_nodal_3d.stat")
+p2p1_nodal_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p2p1_gauss_3d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_gauss_3d.stat")
+p2p1_gauss_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
   </variables>
-  <pass_tests/>
+  <pass_tests>
+    <test name="p1dgp2_nodal_2d_pressure" language="python">assert abs(p1dgp2_nodal_2d_pressure_error - 1.5e-5) &lt; 1.e-6</test>
+    <test name="p1dgp2_gauss_2d_pressure" language="python">assert p1dgp2_gauss_2d_pressure_error/p1dgp2_nodal_2d_pressure_error &lt; 1.e-6</test>
+    <test name="p1dgp2_nodal_2d_velocity" language="python">assert abs(p1dgp2_nodal_2d_velocity_error - 1.5e-5) &lt; 9.9e-5</test>
+    <test name="p1dgp2_gauss_2d_velocity" language="python">assert p1dgp2_gauss_2d_velocity_error/p1dgp2_nodal_2d_velocity_error &lt; 1.e-6</test>
+    <test name="p2p1_nodal_2d_pressure" language="python">assert abs(p2p1_nodal_2d_pressure_error - 0.017) &lt; 1.e-3</test>
+    <test name="p2p1_gauss_2d_pressure" language="python">assert p2p1_gauss_2d_pressure_error/p2p1_nodal_2d_pressure_error &lt; 1.e-3</test>
+    <test name="p2p1_nodal_2d_velocity" language="python">assert abs(p2p1_nodal_2d_velocity_error - 0.035) &lt; 1.e-3</test>
+    <test name="p2p1_gauss_2d_velocity" language="python">assert p2p1_gauss_2d_velocity_error/p2p1_nodal_2d_velocity_error &lt; 1.e-3</test>
+    <test name="p1dgp2_nodal_3d_pressure" language="python">assert abs(p1dgp2_nodal_3d_pressure_error - 0.018) &lt; 1.e-3</test>
+    <test name="p1dgp2_gauss_3d_pressure" language="python">assert p1dgp2_gauss_3d_pressure_error/p1dgp2_nodal_3d_pressure_error &lt; 1.e-6</test>
+    <test name="p1dgp2_nodal_3d_velocity" language="python">assert abs(p1dgp2_nodal_3d_velocity_error - 0.15) &lt; 1.e-2</test>
+    <test name="p1dgp2_gauss_3d_velocity" language="python">assert p1dgp2_gauss_3d_velocity_error/p1dgp2_nodal_3d_velocity_error &lt; 1.e-6</test>
+    <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.e-2</test>
+    <test name="p2p1_gauss_3d_pressure" language="python">assert p2p1_gauss_3d_pressure_error/p2p1_nodal_3d_pressure_error &lt; 1.e-4</test>
+    <test name="p2p1_nodal_3d_velocity" language="python">assert abs(p2p1_nodal_3d_velocity_error - 1.31) &lt; 1.e-2</test>
+    <test name="p2p1_gauss_3d_velocity" language="python">assert p2p1_gauss_3d_velocity_error/p2p1_nodal_3d_velocity_error &lt; 1.e-4</test>
+  </pass_tests>
   <warn_tests/>
 </testproblem>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -3,21 +3,33 @@
   <name>Test of buoyancy at gauss points.</name>
   <owner userid="cwilson"/>
   <problem_definition length="special" nprocs="1">
-    <command_line>fluidity -v3 -l nodal_2d.flml; fluidity -v3 -l gauss_2d.flml</command_line>
+    <command_line>fluidity -v3 -l p1dgp2_nodal_2d.flml; fluidity -v3 -l p1dgp2_gauss_2d.flml; fluidity -v3 -l p2p1_nodal_2d.flml; fluidity -v3 -l p2p1_gauss_2d.flml</command_line>
   </problem_definition>
   <variables>
-    <variable name="nodal_2d_pressure_error" language="python">from fluidity_tools import stat_parser
-stat = stat_parser("nodal_2d.stat")
-nodal_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
-    <variable name="gauss_2d_pressure_error" language="python">from fluidity_tools import stat_parser
-stat = stat_parser("gauss_2d.stat")
-gauss_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
-    <variable name="nodal_2d_velocity_error" language="python">from fluidity_tools import stat_parser
-stat = stat_parser("nodal_2d.stat")
-nodal_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
-    <variable name="gauss_2d_velocity_error" language="python">from fluidity_tools import stat_parser
-stat = stat_parser("gauss_2d.stat")
-gauss_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_nodal_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_nodal_2d.stat")
+p1dgp2_nodal_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_gauss_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_gauss_2d.stat")
+p1dgp2_gauss_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_nodal_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_nodal_2d.stat")
+p1dgp2_nodal_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p1dgp2_gauss_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p1dgp2_gauss_2d.stat")
+p1dgp2_gauss_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p2p1_nodal_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_nodal_2d.stat")
+p2p1_nodal_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p2p1_gauss_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_gauss_2d.stat")
+p2p1_gauss_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="p2p1_nodal_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_nodal_2d.stat")
+p2p1_nodal_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="p2p1_gauss_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("p2p1_gauss_2d.stat")
+p2p1_gauss_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
   </variables>
   <pass_tests/>
   <warn_tests/>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -61,17 +61,17 @@ p2p1_gauss_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]
     <test name="p1dgp2_nodal_2d_velocity" language="python">assert abs(p1dgp2_nodal_2d_velocity_error - 1.5e-5) &lt; 9.9e-5</test>
     <test name="p1dgp2_gauss_2d_velocity" language="python">assert p1dgp2_gauss_2d_velocity_error/p1dgp2_nodal_2d_velocity_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_2d_pressure" language="python">assert abs(p2p1_nodal_2d_pressure_error - 0.017) &lt; 1.e-3</test>
-    <test name="p2p1_gauss_2d_pressure" language="python">assert p2p1_gauss_2d_pressure_error/p2p1_nodal_2d_pressure_error &lt; 1.e-3</test>
+    <test name="p2p1_gauss_2d_pressure" language="python">assert p2p1_gauss_2d_pressure_error/p2p1_nodal_2d_pressure_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_2d_velocity" language="python">assert abs(p2p1_nodal_2d_velocity_error - 0.035) &lt; 1.e-3</test>
-    <test name="p2p1_gauss_2d_velocity" language="python">assert p2p1_gauss_2d_velocity_error/p2p1_nodal_2d_velocity_error &lt; 1.e-3</test>
+    <test name="p2p1_gauss_2d_velocity" language="python">assert p2p1_gauss_2d_velocity_error/p2p1_nodal_2d_velocity_error &lt; 1.e-6</test>
     <test name="p1dgp2_nodal_3d_pressure" language="python">assert abs(p1dgp2_nodal_3d_pressure_error - 0.018) &lt; 1.e-3</test>
     <test name="p1dgp2_gauss_3d_pressure" language="python">assert p1dgp2_gauss_3d_pressure_error/p1dgp2_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p1dgp2_nodal_3d_velocity" language="python">assert abs(p1dgp2_nodal_3d_velocity_error - 0.15) &lt; 1.e-2</test>
     <test name="p1dgp2_gauss_3d_velocity" language="python">assert p1dgp2_gauss_3d_velocity_error/p1dgp2_nodal_3d_velocity_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.e-2</test>
-    <test name="p2p1_gauss_3d_pressure" language="python">assert p2p1_gauss_3d_pressure_error/p2p1_nodal_3d_pressure_error &lt; 1.e-4</test>
+    <test name="p2p1_gauss_3d_pressure" language="python">assert p2p1_gauss_3d_pressure_error/p2p1_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_3d_velocity" language="python">assert abs(p2p1_nodal_3d_velocity_error - 1.31) &lt; 1.e-2</test>
-    <test name="p2p1_gauss_3d_velocity" language="python">assert p2p1_gauss_3d_velocity_error/p2p1_nodal_3d_velocity_error &lt; 1.e-4</test>
+    <test name="p2p1_gauss_3d_velocity" language="python">assert p2p1_gauss_3d_velocity_error/p2p1_nodal_3d_velocity_error &lt; 1.e-6</test>
   </pass_tests>
   <warn_tests/>
 </testproblem>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testproblem>
+  <name>Test of buoyancy at gauss points.</name>
+  <owner userid="cwilson"/>
+  <problem_definition length="special" nprocs="1">
+    <command_line>fluidity -v3 -l nodal_2d.flml; fluidity -v3 -l gauss_2d.flml</command_line>
+  </problem_definition>
+  <variables>
+    <variable name="nodal_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("nodal_2d.stat")
+nodal_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="gauss_2d_pressure_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("gauss_2d.stat")
+gauss_2d_pressure_error = stat["State"]["AbsoluteDifferencePressure"]["l2norm"][-1]</variable>
+    <variable name="nodal_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("nodal_2d.stat")
+nodal_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+    <variable name="gauss_2d_velocity_error" language="python">from fluidity_tools import stat_parser
+stat = stat_parser("gauss_2d.stat")
+gauss_2d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]</variable>
+  </variables>
+  <pass_tests/>
+  <warn_tests/>
+</testproblem>

--- a/tests/gauss_point_buoyancy/nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/nodal_2d.flml
@@ -1,0 +1,305 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">nodal_2d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value type="code" lines="20" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method/>
+        </scheme>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <viscosity_scheme>
+              <compact_discontinuous_galerkin/>
+              <tensor_form/>
+            </viscosity_scheme>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <buoyancy/>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_surface>
+              <normal_component>
+                <constant>
+                  <real_value rank="0">0.0</real_value>
+                </constant>
+              </normal_component>
+              <normal_direction>
+                <python>
+                  <string_value type="code" lines="20" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+                </python>
+              </normal_direction>
+            </align_bc_with_surface>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value type="code" lines="20" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" source_field_2_type="scalar" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p1dgp2_gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_gauss_2d.flml
@@ -13,6 +13,11 @@
     <mesh name="CoordinateMesh">
       <from_mesh>
         <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -71,6 +76,10 @@
         <integer_value rank="0">5</integer_value>
       </degree>
     </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
   </geometry>
   <io>
     <dump_format>
@@ -236,22 +245,7 @@
           <surface_ids>
             <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
           </surface_ids>
-          <type name="dirichlet">
-            <align_bc_with_surface>
-              <normal_component>
-                <constant>
-                  <real_value rank="0">0.0</real_value>
-                </constant>
-              </normal_component>
-              <normal_direction>
-                <python>
-                  <string_value lines="20" type="code" language="python">def val(X, t):
-  r = (X[0]**2 + X[1]**2)**0.5
-  return [-X[0]/r, -X[1]/r]</string_value>
-                </python>
-              </normal_direction>
-            </align_bc_with_surface>
-          </type>
+          <type name="no_normal_flow"/>
         </boundary_conditions>
         <output/>
         <stat>

--- a/tests/gauss_point_buoyancy/p1dgp2_gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_gauss_2d.flml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fluidity_options>
   <simulation_name>
-    <string_value lines="1">nodal_2d</string_value>
+    <string_value lines="1">p1dgp2_gauss_2d</string_value>
   </simulation_name>
   <problem_type>
     <string_value lines="1">fluids</string_value>
@@ -11,16 +11,16 @@
       <integer_value rank="0">2</integer_value>
     </dimension>
     <mesh name="CoordinateMesh">
-      <from_file file_name="src/circle">
-        <format name="gmsh"/>
+      <from_mesh>
+        <mesh name="InputMesh"/>
         <stat>
-          <include_in_stat/>
+          <exclude_from_stat/>
         </stat>
-      </from_file>
+      </from_mesh>
     </mesh>
     <mesh name="VelocityMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_continuity>
           <string_value>discontinuous</string_value>
         </mesh_continuity>
@@ -31,7 +31,7 @@
     </mesh>
     <mesh name="PressureMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -44,7 +44,7 @@
     </mesh>
     <mesh name="OutputMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -57,6 +57,14 @@
           <exclude_from_stat/>
         </stat>
       </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
     </mesh>
     <quadrature>
       <degree>
@@ -100,7 +108,7 @@
           <mesh name="PressureMesh"/>
           <value name="WholeMesh">
             <python>
-              <string_value type="code" lines="20" language="python">def val(X, t):
+              <string_value lines="20" type="code" language="python">def val(X, t):
   r = (X[0]**2 + X[1]**2)**0.5
   return [-X[0]/r, -X[1]/r]</string_value>
             </python>
@@ -187,7 +195,9 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
-            <buoyancy/>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
@@ -235,7 +245,7 @@
               </normal_component>
               <normal_direction>
                 <python>
-                  <string_value type="code" lines="20" language="python">def val(X, t):
+                  <string_value lines="20" type="code" language="python">def val(X, t):
   r = (X[0]**2 + X[1]**2)**0.5
   return [-X[0]/r, -X[1]/r]</string_value>
                 </python>
@@ -270,7 +280,7 @@
         <mesh name="PressureMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value type="code" lines="20" language="python">def val(X, t):
+            <string_value lines="20" type="code" language="python">def val(X, t):
   r = (X[0]**2 + X[1]**2)**0.5
   return 10.*(2.7 - r)</string_value>
           </python>
@@ -284,7 +294,7 @@
     </scalar_field>
     <scalar_field name="AbsoluteDifferencePressure" rank="0">
       <diagnostic>
-        <algorithm name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" source_field_2_type="scalar" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="PressureMesh"/>

--- a/tests/gauss_point_buoyancy/p1dgp2_gauss_3d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_gauss_3d.flml
@@ -1,0 +1,661 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p1dgp2_gauss_3d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/hemisphere_shell">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="ExtrudedMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <extrude>
+          <regions name="25">
+            <region_ids>
+              <integer_value shape="1" rank="1">25</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">25</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">1</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="26">
+            <region_ids>
+              <integer_value shape="1" rank="1">26</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">26</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">2</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="27">
+            <region_ids>
+              <integer_value shape="1" rank="1">27</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">27</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">3</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="28">
+            <region_ids>
+              <integer_value shape="1" rank="1">28</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">28</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">4</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="29">
+            <region_ids>
+              <integer_value shape="1" rank="1">29</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">29</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">5</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="30">
+            <region_ids>
+              <integer_value shape="1" rank="1">30</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">30</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">6</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="31">
+            <region_ids>
+              <integer_value shape="1" rank="1">31</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">31</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">7</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="32">
+            <region_ids>
+              <integer_value shape="1" rank="1">32</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">32</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">8</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="33">
+            <region_ids>
+              <integer_value shape="1" rank="1">33</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">33</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">9</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="34">
+            <region_ids>
+              <integer_value shape="1" rank="1">34</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">34</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">10</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="35">
+            <region_ids>
+              <integer_value shape="1" rank="1">35</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">35</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">11</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="36">
+            <region_ids>
+              <integer_value shape="1" rank="1">36</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">36</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">12</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="37">
+            <region_ids>
+              <integer_value shape="1" rank="1">37</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">37</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">13</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="38">
+            <region_ids>
+              <integer_value shape="1" rank="1">38</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">38</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">14</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="39">
+            <region_ids>
+              <integer_value shape="1" rank="1">39</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">39</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">15</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="40">
+            <region_ids>
+              <integer_value shape="1" rank="1">40</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">40</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">16</integer_value>
+            </bottom_surface_id>
+          </regions>
+        </extrude>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return [-X[0]/r, -X[1]/r, -X[2]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method/>
+        </scheme>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <viscosity_scheme>
+              <compact_discontinuous_galerkin/>
+              <tensor_form/>
+            </viscosity_scheme>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="3" dim1="dim" rank="1">0.0 0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="16" rank="1">1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <boundary_conditions name="Sides">
+          <surface_ids>
+            <integer_value shape="8" rank="1">17 18 19 20 21 22 23 24</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p1dgp2_nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_nodal_2d.flml
@@ -13,6 +13,11 @@
     <mesh name="CoordinateMesh">
       <from_mesh>
         <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -71,6 +76,10 @@
         <integer_value rank="0">5</integer_value>
       </degree>
     </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
   </geometry>
   <io>
     <dump_format>
@@ -234,22 +243,7 @@
           <surface_ids>
             <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
           </surface_ids>
-          <type name="dirichlet">
-            <align_bc_with_surface>
-              <normal_component>
-                <constant>
-                  <real_value rank="0">0.0</real_value>
-                </constant>
-              </normal_component>
-              <normal_direction>
-                <python>
-                  <string_value lines="20" type="code" language="python">def val(X, t):
-  r = (X[0]**2 + X[1]**2)**0.5
-  return [-X[0]/r, -X[1]/r]</string_value>
-                </python>
-              </normal_direction>
-            </align_bc_with_surface>
-          </type>
+          <type name="no_normal_flow"/>
         </boundary_conditions>
         <output/>
         <stat>

--- a/tests/gauss_point_buoyancy/p1dgp2_nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_nodal_2d.flml
@@ -1,0 +1,313 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p1dgp2_nodal_2d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method/>
+        </scheme>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <viscosity_scheme>
+              <compact_discontinuous_galerkin/>
+              <tensor_form/>
+            </viscosity_scheme>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <buoyancy/>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_surface>
+              <normal_component>
+                <constant>
+                  <real_value rank="0">0.0</real_value>
+                </constant>
+              </normal_component>
+              <normal_direction>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+                </python>
+              </normal_direction>
+            </align_bc_with_surface>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p1dgp2_nodal_3d.flml
+++ b/tests/gauss_point_buoyancy/p1dgp2_nodal_3d.flml
@@ -1,0 +1,659 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p1dgp2_nodal_3d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/hemisphere_shell">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="ExtrudedMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <extrude>
+          <regions name="25">
+            <region_ids>
+              <integer_value shape="1" rank="1">25</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">25</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">1</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="26">
+            <region_ids>
+              <integer_value shape="1" rank="1">26</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">26</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">2</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="27">
+            <region_ids>
+              <integer_value shape="1" rank="1">27</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">27</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">3</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="28">
+            <region_ids>
+              <integer_value shape="1" rank="1">28</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">28</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">4</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="29">
+            <region_ids>
+              <integer_value shape="1" rank="1">29</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">29</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">5</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="30">
+            <region_ids>
+              <integer_value shape="1" rank="1">30</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">30</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">6</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="31">
+            <region_ids>
+              <integer_value shape="1" rank="1">31</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">31</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">7</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="32">
+            <region_ids>
+              <integer_value shape="1" rank="1">32</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">32</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">8</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="33">
+            <region_ids>
+              <integer_value shape="1" rank="1">33</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">33</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">9</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="34">
+            <region_ids>
+              <integer_value shape="1" rank="1">34</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">34</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">10</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="35">
+            <region_ids>
+              <integer_value shape="1" rank="1">35</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">35</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">11</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="36">
+            <region_ids>
+              <integer_value shape="1" rank="1">36</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">36</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">12</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="37">
+            <region_ids>
+              <integer_value shape="1" rank="1">37</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">37</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">13</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="38">
+            <region_ids>
+              <integer_value shape="1" rank="1">38</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">38</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">14</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="39">
+            <region_ids>
+              <integer_value shape="1" rank="1">39</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">39</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">15</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="40">
+            <region_ids>
+              <integer_value shape="1" rank="1">40</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">40</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">16</integer_value>
+            </bottom_surface_id>
+          </regions>
+        </extrude>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return [-X[0]/r, -X[1]/r, -X[2]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method/>
+        </scheme>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <viscosity_scheme>
+              <compact_discontinuous_galerkin/>
+              <tensor_form/>
+            </viscosity_scheme>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <buoyancy/>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="3" dim1="dim" rank="1">0.0 0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="16" rank="1">1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <boundary_conditions name="Sides">
+          <surface_ids>
+            <integer_value shape="8" rank="1">17 18 19 20 21 22 23 24</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <fluidity_options>
   <simulation_name>
-    <string_value lines="1">gauss_2d</string_value>
+    <string_value lines="1">p2p1_gauss_2d</string_value>
   </simulation_name>
   <problem_type>
     <string_value lines="1">fluids</string_value>
@@ -21,9 +21,11 @@
     <mesh name="VelocityMesh">
       <from_mesh>
         <mesh name="CoordinateMesh"/>
-        <mesh_continuity>
-          <string_value>discontinuous</string_value>
-        </mesh_continuity>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -32,11 +34,6 @@
     <mesh name="PressureMesh">
       <from_mesh>
         <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -132,19 +129,55 @@
         <spatial_discretisation>
           <continuous_galerkin>
             <remove_stabilisation_term/>
-            <integrate_continuity_by_parts/>
           </continuous_galerkin>
         </spatial_discretisation>
         <scheme>
           <poisson_pressure_solution>
             <string_value lines="1">never</string_value>
           </poisson_pressure_solution>
-          <use_projection_method/>
+          <use_projection_method>
+            <full_schur_complement>
+              <inner_matrix name="FullMassMatrix">
+                <solver>
+                  <iterative_method name="preonly"/>
+                  <preconditioner name="lu">
+                    <factorization_package name="mumps"/>
+                  </preconditioner>
+                  <relative_error>
+                    <real_value rank="0">1.e-6</real_value>
+                  </relative_error>
+                  <max_iterations>
+                    <integer_value rank="0">100</integer_value>
+                  </max_iterations>
+                  <never_ignore_solver_failures/>
+                  <diagnostics>
+                    <monitors/>
+                  </diagnostics>
+                </solver>
+              </inner_matrix>
+              <preconditioner_matrix name="DiagonalSchurComplement"/>
+            </full_schur_complement>
+          </use_projection_method>
         </scheme>
         <solver>
-          <iterative_method name="preonly"/>
-          <preconditioner name="lu">
-            <factorization_package name="mumps"/>
+          <iterative_method name="fgmres"/>
+          <preconditioner name="ksp">
+            <solver>
+              <iterative_method name="preonly"/>
+              <preconditioner name="lu">
+                <factorization_package name="mumps"/>
+              </preconditioner>
+              <relative_error>
+                <real_value rank="0">1.e-10</real_value>
+              </relative_error>
+              <max_iterations>
+                <integer_value rank="0">100</integer_value>
+              </max_iterations>
+              <never_ignore_solver_failures/>
+              <diagnostics>
+                <monitors/>
+              </diagnostics>
+            </solver>
           </preconditioner>
           <relative_error>
             <real_value rank="0">1.e-6</real_value>
@@ -176,21 +209,21 @@
         <mesh name="VelocityMesh"/>
         <equation name="Boussinesq"/>
         <spatial_discretisation>
-          <discontinuous_galerkin>
-            <viscosity_scheme>
-              <compact_discontinuous_galerkin/>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms/>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
               <tensor_form/>
-            </viscosity_scheme>
-            <advection_scheme>
-              <none/>
-              <integrate_advection_by_parts>
-                <twice/>
-              </integrate_advection_by_parts>
-            </advection_scheme>
+            </stress_terms>
             <buoyancy>
               <radial_gravity_direction_at_gauss_points/>
             </buoyancy>
-          </discontinuous_galerkin>
+          </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>

--- a/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
@@ -11,16 +11,21 @@
       <integer_value rank="0">2</integer_value>
     </dimension>
     <mesh name="CoordinateMesh">
-      <from_file file_name="src/circle">
-        <format name="gmsh"/>
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
         <stat>
-          <include_in_stat/>
+          <exclude_from_stat/>
         </stat>
-      </from_file>
+      </from_mesh>
     </mesh>
     <mesh name="VelocityMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -33,7 +38,7 @@
     </mesh>
     <mesh name="PressureMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -41,7 +46,7 @@
     </mesh>
     <mesh name="OutputMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -55,11 +60,23 @@
         </stat>
       </from_mesh>
     </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
       </degree>
     </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
   </geometry>
   <io>
     <dump_format>
@@ -129,6 +146,7 @@
         <spatial_discretisation>
           <continuous_galerkin>
             <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
           </continuous_galerkin>
         </spatial_discretisation>
         <scheme>
@@ -261,22 +279,7 @@
           <surface_ids>
             <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
           </surface_ids>
-          <type name="dirichlet">
-            <align_bc_with_surface>
-              <normal_component>
-                <constant>
-                  <real_value rank="0">0.0</real_value>
-                </constant>
-              </normal_component>
-              <normal_direction>
-                <python>
-                  <string_value lines="20" type="code" language="python">def val(X, t):
-  r = (X[0]**2 + X[1]**2)**0.5
-  return [-X[0]/r, -X[1]/r]</string_value>
-                </python>
-              </normal_direction>
-            </align_bc_with_surface>
-          </type>
+          <type name="no_normal_flow"/>
         </boundary_conditions>
         <output/>
         <stat>

--- a/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_gauss_2d.flml
@@ -198,7 +198,7 @@
             </solver>
           </preconditioner>
           <relative_error>
-            <real_value rank="0">1.e-6</real_value>
+            <real_value rank="0">1.e-12</real_value>
           </relative_error>
           <max_iterations>
             <integer_value rank="0">100</integer_value>

--- a/tests/gauss_point_buoyancy/p2p1_gauss_3d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_gauss_3d.flml
@@ -1,0 +1,695 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p2p1_gauss_3d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/hemisphere_shell">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="ExtrudedMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <extrude>
+          <regions name="25">
+            <region_ids>
+              <integer_value shape="1" rank="1">25</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">25</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">1</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="26">
+            <region_ids>
+              <integer_value shape="1" rank="1">26</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">26</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">2</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="27">
+            <region_ids>
+              <integer_value shape="1" rank="1">27</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">27</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">3</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="28">
+            <region_ids>
+              <integer_value shape="1" rank="1">28</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">28</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">4</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="29">
+            <region_ids>
+              <integer_value shape="1" rank="1">29</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">29</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">5</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="30">
+            <region_ids>
+              <integer_value shape="1" rank="1">30</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">30</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">6</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="31">
+            <region_ids>
+              <integer_value shape="1" rank="1">31</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">31</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">7</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="32">
+            <region_ids>
+              <integer_value shape="1" rank="1">32</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">32</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">8</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="33">
+            <region_ids>
+              <integer_value shape="1" rank="1">33</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">33</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">9</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="34">
+            <region_ids>
+              <integer_value shape="1" rank="1">34</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">34</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">10</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="35">
+            <region_ids>
+              <integer_value shape="1" rank="1">35</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">35</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">11</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="36">
+            <region_ids>
+              <integer_value shape="1" rank="1">36</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">36</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">12</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="37">
+            <region_ids>
+              <integer_value shape="1" rank="1">37</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">37</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">13</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="38">
+            <region_ids>
+              <integer_value shape="1" rank="1">38</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">38</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">14</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="39">
+            <region_ids>
+              <integer_value shape="1" rank="1">39</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">39</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">15</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="40">
+            <region_ids>
+              <integer_value shape="1" rank="1">40</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">40</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">16</integer_value>
+            </bottom_surface_id>
+          </regions>
+        </extrude>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return [-X[0]/r, -X[1]/r, -X[2]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method>
+            <full_schur_complement>
+              <inner_matrix name="FullMassMatrix">
+                <solver>
+                  <iterative_method name="preonly"/>
+                  <preconditioner name="lu">
+                    <factorization_package name="mumps"/>
+                  </preconditioner>
+                  <relative_error>
+                    <real_value rank="0">1.e-6</real_value>
+                  </relative_error>
+                  <max_iterations>
+                    <integer_value rank="0">100</integer_value>
+                  </max_iterations>
+                  <never_ignore_solver_failures/>
+                  <diagnostics>
+                    <monitors/>
+                  </diagnostics>
+                </solver>
+              </inner_matrix>
+              <preconditioner_matrix name="DiagonalSchurComplement"/>
+            </full_schur_complement>
+          </use_projection_method>
+        </scheme>
+        <solver>
+          <iterative_method name="fgmres"/>
+          <preconditioner name="ksp">
+            <solver>
+              <iterative_method name="preonly"/>
+              <preconditioner name="lu">
+                <factorization_package name="mumps"/>
+              </preconditioner>
+              <relative_error>
+                <real_value rank="0">1.e-10</real_value>
+              </relative_error>
+              <max_iterations>
+                <integer_value rank="0">100</integer_value>
+              </max_iterations>
+              <never_ignore_solver_failures/>
+              <diagnostics>
+                <monitors/>
+              </diagnostics>
+            </solver>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms/>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
+              <tensor_form/>
+            </stress_terms>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
+          </continuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="3" dim1="dim" rank="1">0.0 0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="16" rank="1">1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <boundary_conditions name="Sides">
+          <surface_ids>
+            <integer_value shape="8" rank="1">17 18 19 20 21 22 23 24</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p2p1_gauss_3d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_gauss_3d.flml
@@ -544,7 +544,7 @@
             </solver>
           </preconditioner>
           <relative_error>
-            <real_value rank="0">1.e-6</real_value>
+            <real_value rank="0">1.e-12</real_value>
           </relative_error>
           <max_iterations>
             <integer_value rank="0">100</integer_value>

--- a/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
@@ -11,16 +11,21 @@
       <integer_value rank="0">2</integer_value>
     </dimension>
     <mesh name="CoordinateMesh">
-      <from_file file_name="src/circle">
-        <format name="gmsh"/>
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
         <stat>
-          <include_in_stat/>
+          <exclude_from_stat/>
         </stat>
-      </from_file>
+      </from_mesh>
     </mesh>
     <mesh name="VelocityMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -33,7 +38,7 @@
     </mesh>
     <mesh name="PressureMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <stat>
           <exclude_from_stat/>
         </stat>
@@ -41,7 +46,7 @@
     </mesh>
     <mesh name="OutputMesh">
       <from_mesh>
-        <mesh name="CoordinateMesh"/>
+        <mesh name="InputMesh"/>
         <mesh_shape>
           <polynomial_degree>
             <integer_value rank="0">2</integer_value>
@@ -55,11 +60,23 @@
         </stat>
       </from_mesh>
     </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
       </degree>
     </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
   </geometry>
   <io>
     <dump_format>
@@ -129,6 +146,7 @@
         <spatial_discretisation>
           <continuous_galerkin>
             <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
           </continuous_galerkin>
         </spatial_discretisation>
         <scheme>
@@ -259,22 +277,7 @@
           <surface_ids>
             <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
           </surface_ids>
-          <type name="dirichlet">
-            <align_bc_with_surface>
-              <normal_component>
-                <constant>
-                  <real_value rank="0">0.0</real_value>
-                </constant>
-              </normal_component>
-              <normal_direction>
-                <python>
-                  <string_value lines="20" type="code" language="python">def val(X, t):
-  r = (X[0]**2 + X[1]**2)**0.5
-  return [-X[0]/r, -X[1]/r]</string_value>
-                </python>
-              </normal_direction>
-            </align_bc_with_surface>
-          </type>
+          <type name="no_normal_flow"/>
         </boundary_conditions>
         <output/>
         <stat>

--- a/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
@@ -1,0 +1,338 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p2p1_nodal_2d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="src/circle">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method>
+            <full_schur_complement>
+              <inner_matrix name="FullMassMatrix">
+                <solver>
+                  <iterative_method name="preonly"/>
+                  <preconditioner name="lu">
+                    <factorization_package name="mumps"/>
+                  </preconditioner>
+                  <relative_error>
+                    <real_value rank="0">1.e-6</real_value>
+                  </relative_error>
+                  <max_iterations>
+                    <integer_value rank="0">100</integer_value>
+                  </max_iterations>
+                  <never_ignore_solver_failures/>
+                  <diagnostics>
+                    <monitors/>
+                  </diagnostics>
+                </solver>
+              </inner_matrix>
+              <preconditioner_matrix name="DiagonalSchurComplement"/>
+            </full_schur_complement>
+          </use_projection_method>
+        </scheme>
+        <solver>
+          <iterative_method name="fgmres"/>
+          <preconditioner name="ksp">
+            <solver>
+              <iterative_method name="preonly"/>
+              <preconditioner name="lu">
+                <factorization_package name="mumps"/>
+              </preconditioner>
+              <relative_error>
+                <real_value rank="0">1.e-10</real_value>
+              </relative_error>
+              <max_iterations>
+                <integer_value rank="0">100</integer_value>
+              </max_iterations>
+              <never_ignore_solver_failures/>
+              <diagnostics>
+                <monitors/>
+              </diagnostics>
+            </solver>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms/>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
+              <tensor_form/>
+            </stress_terms>
+            <buoyancy/>
+          </continuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="8" rank="1">1 2 3 4 5 6 7 8</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_surface>
+              <normal_component>
+                <constant>
+                  <real_value rank="0">0.0</real_value>
+                </constant>
+              </normal_component>
+              <normal_direction>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return [-X[0]/r, -X[1]/r]</string_value>
+                </python>
+              </normal_direction>
+            </align_bc_with_surface>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_nodal_2d.flml
@@ -198,7 +198,7 @@
             </solver>
           </preconditioner>
           <relative_error>
-            <real_value rank="0">1.e-6</real_value>
+            <real_value rank="0">1.e-12</real_value>
           </relative_error>
           <max_iterations>
             <integer_value rank="0">100</integer_value>

--- a/tests/gauss_point_buoyancy/p2p1_nodal_3d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_nodal_3d.flml
@@ -1,0 +1,693 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">p2p1_nodal_3d</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="PressureMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="OutputMesh">
+      <from_mesh>
+        <mesh name="ExtrudedMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="InputMesh">
+      <from_file file_name="src/hemisphere_shell">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="ExtrudedMesh">
+      <from_mesh>
+        <mesh name="InputMesh"/>
+        <extrude>
+          <regions name="25">
+            <region_ids>
+              <integer_value shape="1" rank="1">25</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">25</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">1</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="26">
+            <region_ids>
+              <integer_value shape="1" rank="1">26</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">26</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">2</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="27">
+            <region_ids>
+              <integer_value shape="1" rank="1">27</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">27</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">3</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="28">
+            <region_ids>
+              <integer_value shape="1" rank="1">28</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">28</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">4</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="29">
+            <region_ids>
+              <integer_value shape="1" rank="1">29</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">29</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">5</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="30">
+            <region_ids>
+              <integer_value shape="1" rank="1">30</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">30</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">6</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="31">
+            <region_ids>
+              <integer_value shape="1" rank="1">31</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">31</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">7</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="32">
+            <region_ids>
+              <integer_value shape="1" rank="1">32</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">32</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">8</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="33">
+            <region_ids>
+              <integer_value shape="1" rank="1">33</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">33</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">9</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="34">
+            <region_ids>
+              <integer_value shape="1" rank="1">34</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">34</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">10</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="35">
+            <region_ids>
+              <integer_value shape="1" rank="1">35</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">35</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">11</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="36">
+            <region_ids>
+              <integer_value shape="1" rank="1">36</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">36</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">12</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="37">
+            <region_ids>
+              <integer_value shape="1" rank="1">37</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">37</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">13</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="38">
+            <region_ids>
+              <integer_value shape="1" rank="1">38</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">38</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">14</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="39">
+            <region_ids>
+              <integer_value shape="1" rank="1">39</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">39</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">15</integer_value>
+            </bottom_surface_id>
+          </regions>
+          <regions name="40">
+            <region_ids>
+              <integer_value shape="1" rank="1">40</integer_value>
+            </region_ids>
+            <bottom_depth>
+              <constant>
+                <real_value rank="0">1.5</real_value>
+              </constant>
+            </bottom_depth>
+            <sizing_function>
+              <constant>
+                <real_value rank="0">10</real_value>
+              </constant>
+            </sizing_function>
+            <top_surface_id>
+              <integer_value rank="0">40</integer_value>
+            </top_surface_id>
+            <bottom_surface_id>
+              <integer_value rank="0">16</integer_value>
+            </bottom_surface_id>
+          </regions>
+        </extrude>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+    <spherical_earth>
+      <superparametric_mapping/>
+      <analytical_mapping/>
+    </spherical_earth>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="OutputMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <physical_parameters>
+    <gravity>
+      <magnitude>
+        <real_value rank="0">10.0</real_value>
+      </magnitude>
+      <vector_field name="GravityDirection" rank="1">
+        <prescribed>
+          <mesh name="PressureMesh"/>
+          <value name="WholeMesh">
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return [-X[0]/r, -X[1]/r, -X[2]/r]</string_value>
+            </python>
+          </value>
+          <output/>
+          <stat>
+            <include_in_stat/>
+          </stat>
+          <detectors>
+            <exclude_from_detectors/>
+          </detectors>
+        </prescribed>
+      </vector_field>
+    </gravity>
+  </physical_parameters>
+  <material_phase name="State">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1.0</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="PressureMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method>
+            <full_schur_complement>
+              <inner_matrix name="FullMassMatrix">
+                <solver>
+                  <iterative_method name="preonly"/>
+                  <preconditioner name="lu">
+                    <factorization_package name="mumps"/>
+                  </preconditioner>
+                  <relative_error>
+                    <real_value rank="0">1.e-6</real_value>
+                  </relative_error>
+                  <max_iterations>
+                    <integer_value rank="0">100</integer_value>
+                  </max_iterations>
+                  <never_ignore_solver_failures/>
+                  <diagnostics>
+                    <monitors/>
+                  </diagnostics>
+                </solver>
+              </inner_matrix>
+              <preconditioner_matrix name="DiagonalSchurComplement"/>
+            </full_schur_complement>
+          </use_projection_method>
+        </scheme>
+        <solver>
+          <iterative_method name="fgmres"/>
+          <preconditioner name="ksp">
+            <solver>
+              <iterative_method name="preonly"/>
+              <preconditioner name="lu">
+                <factorization_package name="mumps"/>
+              </preconditioner>
+              <relative_error>
+                <real_value rank="0">1.e-10</real_value>
+              </relative_error>
+              <max_iterations>
+                <integer_value rank="0">100</integer_value>
+              </max_iterations>
+              <never_ignore_solver_failures/>
+              <diagnostics>
+                <monitors/>
+              </diagnostics>
+            </solver>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms/>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
+              <tensor_form/>
+            </stress_terms>
+            <buoyancy/>
+          </continuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1.e-6</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">100</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="3" dim1="dim" rank="1">0.0 0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Bottom">
+          <surface_ids>
+            <integer_value shape="16" rank="1">1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <boundary_conditions name="Sides">
+          <surface_ids>
+            <integer_value shape="8" rank="1">17 18 19 20 21 22 23 24</integer_value>
+          </surface_ids>
+          <type name="no_normal_flow"/>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="AnalyticalPressure" rank="0">
+      <prescribed>
+        <mesh name="PressureMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X, t):
+  r = (X[0]**2 + X[1]**2 + X[2]**2)**0.5
+  return 10.*(2.7 - r)</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat/>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </scalar_field>
+    <scalar_field name="AbsoluteDifferencePressure" rank="0">
+      <diagnostic>
+        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="Pressure" source_field_2_name="AnalyticalPressure" material_phase_support="single" source_field_1_type="scalar">
+          <absolute_difference/>
+        </algorithm>
+        <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/gauss_point_buoyancy/p2p1_nodal_3d.flml
+++ b/tests/gauss_point_buoyancy/p2p1_nodal_3d.flml
@@ -544,7 +544,7 @@
             </solver>
           </preconditioner>
           <relative_error>
-            <real_value rank="0">1.e-6</real_value>
+            <real_value rank="0">1.e-12</real_value>
           </relative_error>
           <max_iterations>
             <integer_value rank="0">100</integer_value>

--- a/tests/gauss_point_buoyancy/src/circle.geo
+++ b/tests/gauss_point_buoyancy/src/circle.geo
@@ -1,0 +1,86 @@
+lr=10; // number of cells in the radial direction
+lti=lr; // number of cells in a pi/4 segment in the tangential direction of the inner radius
+lto=lti; // has to be for a transfinite surface
+p=1;
+Point(1) = {1.2, 0, 0, 1.0};
+Extrude {1.5, 0, 0} {
+  Point{1};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{1};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{2};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{6};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{10};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{14};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{18};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{22};
+}
+Extrude {{0, 0, 1}, {0, 0, 0}, Pi/4} {
+  Line{26};
+}
+Transfinite Line{1} = lr+1 Using Bump p;
+Transfinite Line{2} = lr+1 Using Bump p;
+Transfinite Line{6} = lr+1 Using Bump p;
+Transfinite Line{10} = lr+1 Using Bump p;
+Transfinite Line{14} = lr+1 Using Bump p;
+Transfinite Line{18} = lr+1 Using Bump p;
+Transfinite Line{22} = lr+1 Using Bump p;
+Transfinite Line{26} = lr+1 Using Bump p;
+Transfinite Line{3} = lti+1;
+Transfinite Line{7} = lti+1;
+Transfinite Line{11} = lti+1;
+Transfinite Line{15} = lti+1;
+Transfinite Line{19} = lti+1;
+Transfinite Line{23} = lti+1;
+Transfinite Line{27} = lti+1;
+Transfinite Line{31} = lti+1;
+Transfinite Line{4} = lto+1;
+Transfinite Line{8} = lto+1;
+Transfinite Line{12} = lto+1;
+Transfinite Line{16} = lto+1;
+Transfinite Line{20} = lto+1;
+Transfinite Line{24} = lto+1;
+Transfinite Line{28} = lto+1;
+Transfinite Line{32} = lto+1;
+Transfinite Surface{5} = {1,2,3,4} Alternate;
+Transfinite Surface{9} = {3,4,9,10} Alternate;
+Transfinite Surface{13} = {9,10,11,12} Alternate;
+Transfinite Surface{17} = {11,12,13,14} Alternate;
+Transfinite Surface{21} = {13,14,15,16} Alternate;
+Transfinite Surface{25} = {15,16,17,18} Alternate;
+Transfinite Surface{29} = {17,18,19,20} Alternate;
+Transfinite Surface{33} = {19,20,1,2} Alternate;
+
+// inner tangential arc segments
+Physical Line(1) = {3};
+Physical Line(2) = {7};
+Physical Line(3) = {11};
+Physical Line(4) = {15};
+Physical Line(5) = {19};
+Physical Line(6) = {23};
+Physical Line(7) = {27};
+Physical Line(8) = {31};
+
+// outer tangential arc segments
+Physical Line(9) = {4};
+Physical Line(10) = {8};
+Physical Line(11) = {12};
+Physical Line(12) = {16};
+Physical Line(13) = {20};
+Physical Line(14) = {24};
+Physical Line(15) = {28};
+Physical Line(16) = {32};
+
+Physical Surface(1) = {13, 17, 21, 25, 29, 33, 5, 9};

--- a/tests/gauss_point_buoyancy/src/hemisphere_shell.geo
+++ b/tests/gauss_point_buoyancy/src/hemisphere_shell.geo
@@ -1,0 +1,107 @@
+lr=5; // number of cells in the radial direction
+Point(1) = {0, 0, 2.7, 1.0};
+Extrude {{1, 0, 0}, {0, 0, 0}, Pi/4} {
+  Point{1};
+}
+Extrude {{1, 0, 0}, {0, 0, 0}, Pi/4} {
+  Point{2};
+}
+Extrude {{-1, 0, 0}, {0, 0, 0}, Pi/4} {
+  Point{1};
+}
+Extrude {{-1, 0, 0}, {0, 0, 0}, Pi/4} {
+  Point{5};
+}
+Extrude {{0, 1, 0}, {0, 0, 0}, Pi/4} {
+  Line{4, 3, 1, 2};
+}
+Extrude {{0, 1, 0}, {0, 0, 0}, Pi/4} {
+  Line{8, 5, 12, 16};
+}
+Extrude {{0, -1, 0}, {0, 0, 0}, Pi/4} {
+  Line{4, 3, 1, 2};
+}
+Extrude {{0, -1, 0}, {0, 0, 0}, Pi/4} {
+  Line{33, 36, 40, 44};
+}
+Transfinite Line {47} = lr Using Progression 1;
+Transfinite Line {33} = lr Using Progression 1;
+Transfinite Line {4}  = lr Using Progression 1;
+Transfinite Line {5}  = lr Using Progression 1;
+Transfinite Line {23} = lr Using Progression 1;
+Transfinite Line {50} = lr Using Progression 1;
+Transfinite Line {36} = lr Using Progression 1;
+Transfinite Line {3}  = lr Using Progression 1;
+Transfinite Line {8}  = lr Using Progression 1;
+Transfinite Line {19} = lr Using Progression 1;
+Transfinite Line {54} = lr Using Progression 1;
+Transfinite Line {40} = lr Using Progression 1;
+Transfinite Line {1}  = lr Using Progression 1;
+Transfinite Line {12} = lr Using Progression 1;
+Transfinite Line {26} = lr Using Progression 1;
+Transfinite Line {58} = lr Using Progression 1;
+Transfinite Line {44} = lr Using Progression 1;
+Transfinite Line {2}  = lr Using Progression 1;
+Transfinite Line {16} = lr Using Progression 1;
+Transfinite Line {30} = lr Using Progression 1;
+Transfinite Line {48} = lr Using Progression 1;
+Transfinite Line {34} = lr Using Progression 1;
+Transfinite Line {6}  = lr Using Progression 1;
+Transfinite Line {21} = lr Using Progression 1;
+Transfinite Line {51} = lr Using Progression 1;
+Transfinite Line {37} = lr Using Progression 1;
+Transfinite Line {9}  = lr Using Progression 1;
+Transfinite Line {20} = lr Using Progression 1;
+Transfinite Line {56} = lr Using Progression 1;
+Transfinite Line {42} = lr Using Progression 1;
+Transfinite Line {14} = lr Using Progression 1;
+Transfinite Line {28} = lr Using Progression 1;
+// top
+Transfinite Surface {49} Alternated;
+Transfinite Surface {35} Alternated;
+Transfinite Surface {7} Alternated;
+Transfinite Surface {25} Alternated;
+// upper middle
+Transfinite Surface {53} Alternated;
+Transfinite Surface {39} Alternated;
+Transfinite Surface {11} Alternated;
+Transfinite Surface {22} Alternated;
+// lower middle
+Transfinite Surface {57} Alternated;
+Transfinite Surface {43} Alternated;
+Transfinite Surface {15} Alternated;
+Transfinite Surface {29} Alternated;
+// bottom
+Transfinite Surface {60} Alternated;
+Transfinite Surface {46} Alternated;
+Transfinite Surface {18} Alternated;
+Transfinite Surface {32} Alternated;
+// flat edges
+Physical Line(17) = {47};
+Physical Line(18) = {23};
+Physical Line(19) = {50};
+Physical Line(20) = {19};
+Physical Line(21) = {54};
+Physical Line(22) = {26};
+Physical Line(23) = {58};
+Physical Line(24) = {30};
+// top
+Physical Surface(33) = {49};
+Physical Surface(34) = {35};
+Physical Surface(35) = {7};
+Physical Surface(36) = {25};
+// upper middle
+Physical Surface(25) = {53};
+Physical Surface(26) = {39};
+Physical Surface(27) = {11};
+Physical Surface(28) = {22};
+// lower middle
+Physical Surface(29) = {57};
+Physical Surface(30) = {43};
+Physical Surface(31) = {15};
+Physical Surface(32) = {29};
+// bottom
+Physical Surface(37) = {60};
+Physical Surface(38) = {46};
+Physical Surface(39) = {18};
+Physical Surface(40) = {32};

--- a/tests/genpvd_test/genpvd_test.flml
+++ b/tests/genpvd_test/genpvd_test.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/genpvd_test/genpvd_test.flml
+++ b/tests/genpvd_test/genpvd_test.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence/geopressure_8.flml
+++ b/tests/geopressure_convergence/geopressure_8.flml
@@ -116,6 +116,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence/geopressure_8.flml
+++ b/tests/geopressure_convergence/geopressure_8.flml
@@ -112,11 +112,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence_p1/geopressure_8.flml
+++ b/tests/geopressure_convergence_p1/geopressure_8.flml
@@ -111,6 +111,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence_p1/geopressure_8.flml
+++ b/tests/geopressure_convergence_p1/geopressure_8.flml
@@ -107,11 +107,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence_p3/geopressure_8.flml
+++ b/tests/geopressure_convergence_p3/geopressure_8.flml
@@ -116,6 +116,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geopressure_convergence_p3/geopressure_8.flml
+++ b/tests/geopressure_convergence_p3/geopressure_8.flml
@@ -112,11 +112,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geostrophic_interpolation_gp/balanced.flml
+++ b/tests/geostrophic_interpolation_gp/balanced.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/geostrophic_interpolation_gp/balanced.flml
+++ b/tests/geostrophic_interpolation_gp/balanced.flml
@@ -171,11 +171,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CA.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CA.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CB.flml
@@ -763,11 +763,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-CB.flml
@@ -767,6 +767,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-GL.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-GL.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-KC94.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-gen-KC94.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CA.flml
@@ -765,6 +765,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CA.flml
@@ -761,11 +761,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CB.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-CB.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-GL.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-GL.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-KC94.flml
@@ -763,11 +763,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_e-KC94.flml
@@ -767,6 +767,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-CA.flml
@@ -769,6 +769,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-CA.flml
@@ -765,11 +765,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-KC94.flml
@@ -769,6 +769,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_kl-KC94.flml
@@ -765,11 +765,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CA.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CA.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CA.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CB.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CB.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-CB.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-GL.flml
@@ -763,11 +763,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-GL.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-GL.flml
@@ -767,6 +767,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-KC94.flml
@@ -762,11 +762,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-KC94.flml
+++ b/tests/gls-Kato_Phillips-mixed_layer_depth/gls-Kato_Phillips-mixed_layer_depth-k_w-KC94.flml
@@ -766,6 +766,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-orig.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-orig.flml
@@ -715,6 +715,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-orig.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-orig.flml
@@ -711,11 +711,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-param.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-param.flml
@@ -719,11 +719,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-param.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-param.flml
@@ -723,6 +723,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-setup.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-setup.flml
@@ -719,11 +719,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-ocean-param/gls-StationPapa-setup.flml
+++ b/tests/gls-ocean-param/gls-StationPapa-setup.flml
@@ -723,6 +723,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-relax/gls-orig.flml
+++ b/tests/gls-relax/gls-orig.flml
@@ -743,6 +743,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-relax/gls-orig.flml
+++ b/tests/gls-relax/gls-orig.flml
@@ -739,11 +739,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-relax/gls-relax.flml
+++ b/tests/gls-relax/gls-relax.flml
@@ -742,11 +742,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gls-relax/gls-relax.flml
+++ b/tests/gls-relax/gls-relax.flml
@@ -746,6 +746,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
@@ -171,11 +171,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
@@ -184,6 +184,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
@@ -180,11 +180,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
@@ -174,11 +174,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
@@ -178,6 +178,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
@@ -199,6 +199,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
+++ b/tests/gravity-col-press_cg_test_cty_cv/gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
@@ -195,11 +195,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gyre_2d/gyre.flml
+++ b/tests/gyre_2d/gyre.flml
@@ -138,11 +138,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gyre_2d/gyre.flml
+++ b/tests/gyre_2d/gyre.flml
@@ -142,6 +142,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gyre_2d_p1dgp2/gyre.flml
+++ b/tests/gyre_2d_p1dgp2/gyre.flml
@@ -150,6 +150,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/gyre_2d_p1dgp2/gyre.flml
+++ b/tests/gyre_2d_p1dgp2/gyre.flml
@@ -146,11 +146,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/harmonic_analysis_small/harmonic_analysis_simple.flml
+++ b/tests/harmonic_analysis_small/harmonic_analysis_simple.flml
@@ -223,6 +223,7 @@ Shows how numerical scheme predicts frequencey and damping rate</comment>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/harmonic_analysis_small/harmonic_analysis_simple.flml
+++ b/tests/harmonic_analysis_small/harmonic_analysis_simple.flml
@@ -219,11 +219,11 @@ Shows how numerical scheme predicts frequencey and damping rate</comment>
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible/inlet_velocity_bc_compressible_1d.flml
+++ b/tests/inlet_velocity_bc_compressible/inlet_velocity_bc_compressible_1d.flml
@@ -314,11 +314,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible/inlet_velocity_bc_compressible_1d.flml
+++ b/tests/inlet_velocity_bc_compressible/inlet_velocity_bc_compressible_1d.flml
@@ -318,6 +318,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_1d.flml
+++ b/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_1d.flml
@@ -268,6 +268,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_1d.flml
+++ b/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_1d.flml
@@ -264,11 +264,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_pseudo1d.flml
+++ b/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_pseudo1d.flml
@@ -242,11 +242,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_pseudo1d.flml
+++ b/tests/inlet_velocity_bc_compressible_without_gravity/inlet_velocity_bc_compressible_without_gravity_pseudo1d.flml
@@ -246,6 +246,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_incompressible/inlet_velocity_bc_incompressible.flml
+++ b/tests/inlet_velocity_bc_incompressible/inlet_velocity_bc_incompressible.flml
@@ -276,11 +276,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/inlet_velocity_bc_incompressible/inlet_velocity_bc_incompressible.flml
+++ b/tests/inlet_velocity_bc_incompressible/inlet_velocity_bc_incompressible.flml
@@ -280,6 +280,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/internal_boundary_adaptivity/internal_boundary.flml
+++ b/tests/internal_boundary_adaptivity/internal_boundary.flml
@@ -81,11 +81,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/internal_boundary_adaptivity/internal_boundary.flml
+++ b/tests/internal_boundary_adaptivity/internal_boundary.flml
@@ -85,6 +85,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -276,7 +277,7 @@
         <mesh name="DGMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value type="code" lines="20" language="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
   return X[1]*2.0</string_value>
           </python>
         </value>
@@ -316,7 +317,7 @@
     <scalar_field name="Error" rank="0">
       <diagnostic>
         <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value type="code" lines="20" language="python">asb = state.scalar_fields['AnalyticalSolutionBottom']
+          <string_value lines="20" type="code" language="python">asb = state.scalar_fields['AnalyticalSolutionBottom']
 bo = state.scalar_fields['BottomOnly']
 s = state.scalar_fields['Scalar']
 field.val[:] = bo.val[:]*(asb.val[:]-s.val[:])</string_value>

--- a/tests/internal_wave/internal_wave.flml
+++ b/tests/internal_wave/internal_wave.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/internal_wave/internal_wave.flml
+++ b/tests/internal_wave/internal_wave.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/kovasznay/kovasznay.flml
+++ b/tests/kovasznay/kovasznay.flml
@@ -153,11 +153,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/kovasznay/kovasznay.flml
+++ b/tests/kovasznay/kovasznay.flml
@@ -157,6 +157,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/lock_exchange_2d_cg/lock_exchange_2d_cg.flml
+++ b/tests/lock_exchange_2d_cg/lock_exchange_2d_cg.flml
@@ -174,11 +174,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/lock_exchange_2d_cg/lock_exchange_2d_cg.flml
+++ b/tests/lock_exchange_2d_cg/lock_exchange_2d_cg.flml
@@ -178,6 +178,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_exo2gmsh.flml
+++ b/tests/meshconv_test/meshconv_exo2gmsh.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_exo2gmsh.flml
+++ b/tests/meshconv_test/meshconv_exo2gmsh.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_gmsh2triangle.flml
+++ b/tests/meshconv_test/meshconv_gmsh2triangle.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_gmsh2triangle.flml
+++ b/tests/meshconv_test/meshconv_gmsh2triangle.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_parallel_gmsh2triangle.flml
+++ b/tests/meshconv_test/meshconv_parallel_gmsh2triangle.flml
@@ -140,6 +140,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/meshconv_test/meshconv_parallel_gmsh2triangle.flml
+++ b/tests/meshconv_test/meshconv_parallel_gmsh2triangle.flml
@@ -136,11 +136,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -228,6 +228,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -224,11 +224,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -234,11 +234,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -238,6 +238,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -283,6 +283,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -279,11 +279,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -257,6 +257,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure-extrude-parallel/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -253,11 +253,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -228,6 +228,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -224,11 +224,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -234,11 +234,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -238,6 +238,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -283,6 +283,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -279,11 +279,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -257,6 +257,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-extrude/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure-extrude/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -253,11 +253,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d.flml
+++ b/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d.flml
@@ -246,6 +246,7 @@ This is however the same as when using the geostrophic or hydrostatic pressure s
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d.flml
+++ b/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg-3d.flml
@@ -242,11 +242,11 @@ This is however the same as when using the geostrophic or hydrostatic pressure s
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg.flml
+++ b/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg.flml
@@ -246,6 +246,7 @@ This is however the same as when using the geostrophic or hydrostatic pressure s
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg.flml
+++ b/tests/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg/mmat-balancepressure-p1dgp2-test-cty-cv-rhop1dg.flml
@@ -242,11 +242,11 @@ This is however the same as when using the geostrophic or hydrostatic pressure s
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -200,6 +200,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0-vfracp0.flml
@@ -196,11 +196,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0.flml
@@ -200,6 +200,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1-rhop0.flml
@@ -196,11 +196,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2-bc.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2-bc.flml
@@ -252,6 +252,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2-bc.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2-bc.flml
@@ -248,11 +248,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-gpp2.flml
@@ -206,11 +206,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2.flml
@@ -255,6 +255,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2.flml
@@ -251,11 +251,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -255,6 +255,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2dg.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-hpp2dg.flml
@@ -251,11 +251,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp1.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp1.flml
@@ -197,6 +197,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp1.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp1.flml
@@ -193,11 +193,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp2.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-gpp2.flml
@@ -206,11 +206,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-vfracp0.flml
@@ -197,6 +197,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-vfracp0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0-vfracp0.flml
@@ -193,11 +193,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0.flml
@@ -197,6 +197,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-rhop0.flml
@@ -193,11 +193,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-vbpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-vbpp2.flml
@@ -213,6 +213,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-vbpp2.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv-vbpp2.flml
@@ -209,11 +209,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv.flml
@@ -197,6 +197,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p0p1cv.flml
@@ -193,11 +193,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -213,6 +213,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2-rhop1dg-vfracp1cv.flml
@@ -209,11 +209,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2cv-rhop1dg.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2cv-rhop1dg.flml
@@ -202,6 +202,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2cv-rhop1dg.flml
+++ b/tests/mmat-balancepressure/mmat-balancepressure-p1dgp2cv-rhop1dg.flml
@@ -198,11 +198,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p0p1-weak/column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p0p1-weak/column_under_gravity.flml
@@ -194,11 +194,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p0p1-weak/column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p0p1-weak/column_under_gravity.flml
@@ -198,6 +198,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p0p1cv-weak/column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p0p1cv-weak/column_under_gravity.flml
@@ -182,11 +182,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p0p1cv-weak/column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p0p1cv-weak/column_under_gravity.flml
@@ -186,6 +186,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p1bp1-2d/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p1bp1-2d/2material_column_under_gravity.flml
@@ -176,6 +176,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p1bp1-2d/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p1bp1-2d/2material_column_under_gravity.flml
@@ -172,11 +172,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p1bp1-3d/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p1bp1-3d/2material_column_under_gravity.flml
@@ -180,6 +180,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p1bp1-3d/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p1bp1-3d/2material_column_under_gravity.flml
@@ -176,11 +176,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p2lumpedp1/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p2lumpedp1/2material_column_under_gravity.flml
@@ -198,11 +198,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p2lumpedp1/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p2lumpedp1/2material_column_under_gravity.flml
@@ -202,6 +202,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p2p1/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p2p1/2material_column_under_gravity.flml
@@ -221,6 +221,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-p2p1/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col-p2p1/2material_column_under_gravity.flml
@@ -217,11 +217,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
@@ -175,6 +175,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p0p1_2d.flml
@@ -171,11 +171,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
@@ -183,11 +183,11 @@ crashes.</comment>
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p1dgp2_2d.flml
@@ -187,6 +187,7 @@ crashes.</comment>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
@@ -174,11 +174,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2lumpedp1_2d.flml
@@ -178,6 +178,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
@@ -199,6 +199,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
+++ b/tests/mmat-gravity-col-press_cg_test_cty_cv/mmat-gravity-col-press_cg_test_cty_cv_p2p1_2d.flml
@@ -195,11 +195,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col/2material_column_under_gravity.flml
@@ -186,11 +186,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-gravity-col/2material_column_under_gravity.flml
+++ b/tests/mmat-gravity-col/2material_column_under_gravity.flml
@@ -190,6 +190,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-impact/2material_impact.flml
+++ b/tests/mmat-impact/2material_impact.flml
@@ -191,11 +191,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-impact/2material_impact.flml
+++ b/tests/mmat-impact/2material_impact.flml
@@ -195,6 +195,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-shocktube/1material_shocktube.flml
+++ b/tests/mmat-shocktube/1material_shocktube.flml
@@ -177,11 +177,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat-shocktube/1material_shocktube.flml
+++ b/tests/mmat-shocktube/1material_shocktube.flml
@@ -181,6 +181,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_arithmetic.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_arithmetic.flml
@@ -104,6 +104,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_arithmetic.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_arithmetic.flml
@@ -100,11 +100,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_geometric.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_geometric.flml
@@ -104,6 +104,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_geometric.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_geometric.flml
@@ -100,11 +100,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_harmonic.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_harmonic.flml
@@ -104,6 +104,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_harmonic.flml
+++ b/tests/mmat_bulk_viscosity/mmat_bulk_viscosity_harmonic.flml
@@ -100,11 +100,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_les_second_order_p2p1/MMS_X.flml
+++ b/tests/mms_les_second_order_p2p1/MMS_X.flml
@@ -225,11 +225,11 @@
                 </tensor_field>
               </second_order>
             </les_model>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_les_second_order_p2p1/MMS_X.flml
+++ b/tests/mms_les_second_order_p2p1/MMS_X.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_A.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_A.flml
@@ -172,11 +172,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_A.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_A.flml
@@ -176,6 +176,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_B.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_B.flml
@@ -172,11 +172,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_B.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_B.flml
@@ -176,6 +176,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_C.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_C.flml
@@ -172,11 +172,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_C.flml
+++ b/tests/mms_ns_p0p1cv_weak_velBC_steady/MMS_C.flml
@@ -176,6 +176,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_A.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_A.flml
@@ -167,11 +167,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_A.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_A.flml
@@ -171,6 +171,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_B.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_B.flml
@@ -167,11 +167,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_B.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_B.flml
@@ -171,6 +171,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_C.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_C.flml
@@ -167,11 +167,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_C.flml
+++ b/tests/mms_ns_p1dgp1cv_weak_velBC_steady/MMS_C.flml
@@ -171,6 +171,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_A.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_A.flml
@@ -200,11 +200,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_A.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_A.flml
@@ -204,6 +204,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_B.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_B.flml
@@ -200,11 +200,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_B.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_B.flml
@@ -204,6 +204,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_C.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_C.flml
@@ -200,11 +200,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_C.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_C.flml
@@ -204,6 +204,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_D.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_D.flml
@@ -200,11 +200,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p0_steady/MMS_D.flml
+++ b/tests/mms_ns_p2p0_steady/MMS_D.flml
@@ -204,6 +204,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_A.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_A.flml
@@ -212,11 +212,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_A.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_A.flml
@@ -216,6 +216,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_B.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_B.flml
@@ -212,11 +212,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_B.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_B.flml
@@ -216,6 +216,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_C.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_C.flml
@@ -212,11 +212,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_C.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_C.flml
@@ -216,6 +216,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_D.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_D.flml
@@ -212,11 +212,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_D.flml
+++ b/tests/mms_ns_p2p1_test_cty_cv_steady/MMS_D.flml
@@ -216,6 +216,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_p1dgp2_stressform_br_sp/MMS_X.flml
+++ b/tests/mms_p1dgp2_stressform_br_sp/MMS_X.flml
@@ -155,6 +155,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_p1dgp2_stressform_br_sp/MMS_X.flml
+++ b/tests/mms_p1dgp2_stressform_br_sp/MMS_X.flml
@@ -151,11 +151,11 @@
                 <once/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_rans_p2p1_keps/MMS_X.flml
+++ b/tests/mms_rans_p2p1_keps/MMS_X.flml
@@ -785,11 +785,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_rans_p2p1_keps/MMS_X.flml
+++ b/tests/mms_rans_p2p1_keps/MMS_X.flml
@@ -789,6 +789,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_sediment/MMS_X.flml
+++ b/tests/mms_sediment/MMS_X.flml
@@ -225,6 +225,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mms_sediment/MMS_X.flml
+++ b/tests/mms_sediment/MMS_X.flml
@@ -221,11 +221,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/moving_seiche/Seiche_coarse.flml
+++ b/tests/moving_seiche/Seiche_coarse.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/moving_seiche/Seiche_coarse.flml
+++ b/tests/moving_seiche/Seiche_coarse.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_divergence_free_velocity/mphase_divergence_free_velocity.flml
+++ b/tests/mphase_divergence_free_velocity/mphase_divergence_free_velocity.flml
@@ -123,11 +123,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -320,11 +320,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_divergence_free_velocity/mphase_divergence_free_velocity.flml
+++ b/tests/mphase_divergence_free_velocity/mphase_divergence_free_velocity.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -323,6 +324,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_dusty_gas_shock_tube/mphase_dusty_gas_shock_tube.flml
+++ b/tests/mphase_dusty_gas_shock_tube/mphase_dusty_gas_shock_tube.flml
@@ -221,6 +221,7 @@ u_ref = sqrt(p/rho_g)</comment>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -480,6 +481,7 @@ InternalEnergy needed for a Pressure of 1.013e5 = 205894.308943</comment>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_dusty_gas_shock_tube/mphase_dusty_gas_shock_tube.flml
+++ b/tests/mphase_dusty_gas_shock_tube/mphase_dusty_gas_shock_tube.flml
@@ -217,11 +217,11 @@ u_ref = sqrt(p/rho_g)</comment>
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -477,11 +477,11 @@ InternalEnergy needed for a Pressure of 1.013e5 = 205894.308943</comment>
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_dusty_gas_shock_tube/single_phase_frozen_flow_test.flml
+++ b/tests/mphase_dusty_gas_shock_tube/single_phase_frozen_flow_test.flml
@@ -221,6 +221,7 @@ u_ref = sqrt(p/rho_g)</comment>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_dusty_gas_shock_tube/single_phase_frozen_flow_test.flml
+++ b/tests/mphase_dusty_gas_shock_tube/single_phase_frozen_flow_test.flml
@@ -217,11 +217,11 @@ u_ref = sqrt(p/rho_g)</comment>
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_identical_velocities/mphase_identical_velocities.flml
+++ b/tests/mphase_identical_velocities/mphase_identical_velocities.flml
@@ -126,6 +126,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -342,6 +343,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_identical_velocities/mphase_identical_velocities.flml
+++ b/tests/mphase_identical_velocities/mphase_identical_velocities.flml
@@ -122,11 +122,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -339,11 +339,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_identical_velocities_dg/mphase_identical_velocities_dg.flml
+++ b/tests/mphase_identical_velocities_dg/mphase_identical_velocities_dg.flml
@@ -122,6 +122,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -345,6 +346,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_identical_velocities_dg/mphase_identical_velocities_dg.flml
+++ b/tests/mphase_identical_velocities_dg/mphase_identical_velocities_dg.flml
@@ -118,11 +118,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -342,11 +342,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_inlet_velocity_bc_compressible/mphase_inlet_velocity_bc_compressible.flml
+++ b/tests/mphase_inlet_velocity_bc_compressible/mphase_inlet_velocity_bc_compressible.flml
@@ -297,11 +297,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -597,11 +597,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_inlet_velocity_bc_compressible/mphase_inlet_velocity_bc_compressible.flml
+++ b/tests/mphase_inlet_velocity_bc_compressible/mphase_inlet_velocity_bc_compressible.flml
@@ -301,6 +301,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -600,6 +601,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_inlet_velocity_bc_incompressible/mphase_inlet_velocity_bc_incompressible.flml
+++ b/tests/mphase_inlet_velocity_bc_incompressible/mphase_inlet_velocity_bc_incompressible.flml
@@ -176,11 +176,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -401,11 +401,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_inlet_velocity_bc_incompressible/mphase_inlet_velocity_bc_incompressible.flml
+++ b/tests/mphase_inlet_velocity_bc_incompressible/mphase_inlet_velocity_bc_incompressible.flml
@@ -180,6 +180,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -404,6 +405,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_A.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_A.flml
@@ -155,11 +155,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -483,11 +483,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_A.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_A.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -486,6 +487,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_B.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_B.flml
@@ -155,11 +155,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -483,11 +483,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_B.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_B.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -486,6 +487,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_C.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_C.flml
@@ -155,11 +155,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -483,11 +483,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_C.flml
+++ b/tests/mphase_mms_p1dgp2_test_cty_cv_no_interactions/MMS_C.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -486,6 +487,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_A.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_A.flml
@@ -123,11 +123,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -448,11 +448,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_A.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_A.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -451,6 +452,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_B.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_B.flml
@@ -123,11 +123,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -448,11 +448,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_B.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_B.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -451,6 +452,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_C.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_C.flml
@@ -123,11 +123,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -448,11 +448,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_C.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_C.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -451,6 +452,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_D.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_D.flml
@@ -123,11 +123,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -448,11 +448,11 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_D.flml
+++ b/tests/mphase_mms_p1p1stabilised_no_interactions/MMS_D.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -451,6 +452,7 @@ mass*rho*v_t + adv*rho*(u*v_x+v*v_y + beta*(v*u_x + v*v_y)) + p_y - nu*v_xx - nu
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p2p1_stress_form/MMS_X.flml
+++ b/tests/mphase_mms_p2p1_stress_form/MMS_X.flml
@@ -149,11 +149,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -446,11 +446,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_mms_p2p1_stress_form/MMS_X.flml
+++ b/tests/mphase_mms_p2p1_stress_form/MMS_X.flml
@@ -153,6 +153,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -449,6 +450,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rising_body/mphase_rising_body.flml
+++ b/tests/mphase_rising_body/mphase_rising_body.flml
@@ -155,11 +155,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -391,11 +391,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rising_body/mphase_rising_body.flml
+++ b/tests/mphase_rising_body/mphase_rising_body.flml
@@ -159,6 +159,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -394,6 +395,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rogue_shock_tube_dense_bed_glass/mphase_rogue_shock_tube_dense_bed_glass.flml
+++ b/tests/mphase_rogue_shock_tube_dense_bed_glass/mphase_rogue_shock_tube_dense_bed_glass.flml
@@ -222,11 +222,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -520,11 +520,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rogue_shock_tube_dense_bed_glass/mphase_rogue_shock_tube_dense_bed_glass.flml
+++ b/tests/mphase_rogue_shock_tube_dense_bed_glass/mphase_rogue_shock_tube_dense_bed_glass.flml
@@ -226,6 +226,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -523,6 +524,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rogue_shock_tube_dense_bed_nylon/mphase_rogue_shock_tube_dense_bed_nylon.flml
+++ b/tests/mphase_rogue_shock_tube_dense_bed_nylon/mphase_rogue_shock_tube_dense_bed_nylon.flml
@@ -222,11 +222,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -520,11 +520,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_rogue_shock_tube_dense_bed_nylon/mphase_rogue_shock_tube_dense_bed_nylon.flml
+++ b/tests/mphase_rogue_shock_tube_dense_bed_nylon/mphase_rogue_shock_tube_dense_bed_nylon.flml
@@ -226,6 +226,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -523,6 +524,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_sedimentation_1d/mphase_sedimentation_1d.flml
+++ b/tests/mphase_sedimentation_1d/mphase_sedimentation_1d.flml
@@ -163,6 +163,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -374,6 +375,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_sedimentation_1d/mphase_sedimentation_1d.flml
+++ b/tests/mphase_sedimentation_1d/mphase_sedimentation_1d.flml
@@ -159,11 +159,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -371,11 +371,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_sedimentation_2d/mphase_sedimentation_2d.flml
+++ b/tests/mphase_sedimentation_2d/mphase_sedimentation_2d.flml
@@ -154,6 +154,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -389,6 +390,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_sedimentation_2d/mphase_sedimentation_2d.flml
+++ b/tests/mphase_sedimentation_2d/mphase_sedimentation_2d.flml
@@ -150,11 +150,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -386,11 +386,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_stokes_law/mphase_stokes_law.flml
+++ b/tests/mphase_stokes_law/mphase_stokes_law.flml
@@ -150,11 +150,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -353,11 +353,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_stokes_law/mphase_stokes_law.flml
+++ b/tests/mphase_stokes_law/mphase_stokes_law.flml
@@ -154,6 +154,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -356,6 +357,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p0p1.flml
+++ b/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p0p1.flml
@@ -258,11 +258,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -497,11 +497,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p0p1.flml
+++ b/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p0p1.flml
@@ -262,6 +262,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -500,6 +501,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p2p1.flml
+++ b/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p2p1.flml
@@ -264,6 +264,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -507,6 +508,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p2p1.flml
+++ b/tests/mphase_strong_pressure_bc_compressible/mphase_strong_pressure_bc_compressible_p2p1.flml
@@ -260,11 +260,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -504,11 +504,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_subtract_out_reference_profile/mphase_subtract_out_reference_profile_1d.flml
+++ b/tests/mphase_subtract_out_reference_profile/mphase_subtract_out_reference_profile_1d.flml
@@ -300,6 +300,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -586,6 +587,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_subtract_out_reference_profile/mphase_subtract_out_reference_profile_1d.flml
+++ b/tests/mphase_subtract_out_reference_profile/mphase_subtract_out_reference_profile_1d.flml
@@ -296,11 +296,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -583,11 +583,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_tephra_settling/mphase_tephra_settling.flml
+++ b/tests/mphase_tephra_settling/mphase_tephra_settling.flml
@@ -181,6 +181,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -396,6 +397,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_tephra_settling/mphase_tephra_settling.flml
+++ b/tests/mphase_tephra_settling/mphase_tephra_settling.flml
@@ -177,11 +177,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -393,11 +393,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_three_layers/mphase_three_layers.flml
+++ b/tests/mphase_three_layers/mphase_three_layers.flml
@@ -158,6 +158,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -351,6 +352,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -622,6 +624,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_three_layers/mphase_three_layers.flml
+++ b/tests/mphase_three_layers/mphase_three_layers.flml
@@ -154,11 +154,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -348,11 +348,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -620,11 +620,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_wen_yu_drag_correlation/mphase_wen_yu_drag_correlation.flml
+++ b/tests/mphase_wen_yu_drag_correlation/mphase_wen_yu_drag_correlation.flml
@@ -147,11 +147,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -350,11 +350,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/mphase_wen_yu_drag_correlation/mphase_wen_yu_drag_correlation.flml
+++ b/tests/mphase_wen_yu_drag_correlation/mphase_wen_yu_drag_correlation.flml
@@ -151,6 +151,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -353,6 +354,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/netcdf_read_errors/valid.flml
+++ b/tests/netcdf_read_errors/valid.flml
@@ -211,6 +211,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/netcdf_read_errors/valid.flml
+++ b/tests/netcdf_read_errors/valid.flml
@@ -207,11 +207,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/netcdf_read_free_surface/netcdf_read_free_surface.flml
+++ b/tests/netcdf_read_free_surface/netcdf_read_free_surface.flml
@@ -211,6 +211,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/netcdf_read_free_surface/netcdf_read_free_surface.flml
+++ b/tests/netcdf_read_free_surface/netcdf_read_free_surface.flml
@@ -207,11 +207,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/no_normal_flow_dg/no_normal_flow.flml
+++ b/tests/no_normal_flow_dg/no_normal_flow.flml
@@ -179,11 +179,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/no_normal_flow_dg/no_normal_flow.flml
+++ b/tests/no_normal_flow_dg/no_normal_flow.flml
@@ -183,6 +183,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/parallel_dg/cube.flml
+++ b/tests/parallel_dg/cube.flml
@@ -159,11 +159,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/parallel_dg/cube.flml
+++ b/tests/parallel_dg/cube.flml
@@ -163,6 +163,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave.flml
+++ b/tests/petsc_readnsolve/standing_wave.flml
@@ -223,11 +223,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave.flml
+++ b/tests/petsc_readnsolve/standing_wave.flml
@@ -227,6 +227,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave_failing_pressure.flml
+++ b/tests/petsc_readnsolve/standing_wave_failing_pressure.flml
@@ -223,11 +223,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave_failing_pressure.flml
+++ b/tests/petsc_readnsolve/standing_wave_failing_pressure.flml
@@ -227,6 +227,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave_failing_velocity.flml
+++ b/tests/petsc_readnsolve/standing_wave_failing_velocity.flml
@@ -223,11 +223,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/petsc_readnsolve/standing_wave_failing_velocity.flml
+++ b/tests/petsc_readnsolve/standing_wave_failing_velocity.flml
@@ -227,6 +227,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
+++ b/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
@@ -144,11 +144,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
+++ b/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
@@ -148,6 +148,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_landslide/Storegga_2d.flml
+++ b/tests/prescribed_normal_flow_landslide/Storegga_2d.flml
@@ -273,6 +273,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_landslide/Storegga_2d.flml
+++ b/tests/prescribed_normal_flow_landslide/Storegga_2d.flml
@@ -269,11 +269,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_landslide/Storegga_2d_presc.flml
+++ b/tests/prescribed_normal_flow_landslide/Storegga_2d_presc.flml
@@ -273,6 +273,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/prescribed_normal_flow_landslide/Storegga_2d_presc.flml
+++ b/tests/prescribed_normal_flow_landslide/Storegga_2d_presc.flml
@@ -269,11 +269,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/project_vtu/prescribe.flml
+++ b/tests/project_vtu/prescribe.flml
@@ -89,7 +89,7 @@
         <mesh name="VelocityMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value type="code" lines="20" language="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
   from math import cos, sin
   return cos(X[0])*sin(X[1]), cos(X[1])*sin(X[0])</string_value>
           </python>
@@ -108,7 +108,7 @@
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value type="code" lines="20" language="python">def val(X,t):
+            <string_value lines="20" type="code" language="python">def val(X,t):
   from math import sin,cos
   return sin(X[0])*cos(X[1])</string_value>
           </python>
@@ -127,7 +127,7 @@
         <value name="WholeMesh">
           <anisotropic_asymmetric>
             <python>
-              <string_value type="code" lines="20" language="python">def val(X,t):
+              <string_value lines="20" type="code" language="python">def val(X,t):
   from math import sin,cos
   return [[cos(X[0]),sin(X[1])],[sin(X[0]),cos(X[1])]]</string_value>
             </python>

--- a/tests/pydiag_material_phase_support_multiple_velocity_children/pydiag_material_phase_support_multiple_velocity_children.flml
+++ b/tests/pydiag_material_phase_support_multiple_velocity_children/pydiag_material_phase_support_multiple_velocity_children.flml
@@ -192,11 +192,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -491,11 +491,11 @@ for ele in range(field.element_count):
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/pydiag_material_phase_support_multiple_velocity_children/pydiag_material_phase_support_multiple_velocity_children.flml
+++ b/tests/pydiag_material_phase_support_multiple_velocity_children/pydiag_material_phase_support_multiple_velocity_children.flml
@@ -196,6 +196,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>
@@ -494,6 +495,7 @@ for ele in range(field.element_count):
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/saltfinger2d_tri/saltfinger2d_tri.flml
+++ b/tests/saltfinger2d_tri/saltfinger2d_tri.flml
@@ -201,6 +201,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/saltfinger2d_tri/saltfinger2d_tri.flml
+++ b/tests/saltfinger2d_tri/saltfinger2d_tri.flml
@@ -197,11 +197,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/saltfinger_adapt_periodic/saltfinger_adapt_periodic.flml
+++ b/tests/saltfinger_adapt_periodic/saltfinger_adapt_periodic.flml
@@ -213,11 +213,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/saltfinger_adapt_periodic/saltfinger_adapt_periodic.flml
+++ b/tests/saltfinger_adapt_periodic/saltfinger_adapt_periodic.flml
@@ -217,6 +217,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_0.flml
+++ b/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_0.flml
@@ -146,11 +146,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_0.flml
+++ b/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_0.flml
@@ -150,6 +150,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_1.flml
@@ -158,6 +158,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1dgp2/sc_barotropic_fplane_balance_p1dgp2_1.flml
@@ -154,11 +154,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_0.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_0.flml
@@ -144,6 +144,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_0.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_0.flml
@@ -140,11 +140,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_1.flml
@@ -148,11 +148,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1_1.flml
@@ -152,6 +152,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1gp2_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1gp2_1.flml
@@ -161,11 +161,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1gp2_1.flml
+++ b/tests/sc_barotropic_fplane_balance_p1p1/sc_barotropic_fplane_balance_p1p1gp2_1.flml
@@ -165,6 +165,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sem/sem.flml
+++ b/tests/sem/sem.flml
@@ -179,6 +179,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sem/sem.flml
+++ b/tests/sem/sem.flml
@@ -175,11 +175,11 @@
                 <length_scale_type>tensor</length_scale_type>
               </second_order>
             </les_model>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shelf_meshtransform_freesurfaceinitialcondition/shelf.flml
+++ b/tests/shelf_meshtransform_freesurfaceinitialcondition/shelf.flml
@@ -253,6 +253,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shelf_meshtransform_freesurfaceinitialcondition/shelf.flml
+++ b/tests/shelf_meshtransform_freesurfaceinitialcondition/shelf.flml
@@ -249,11 +249,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shocktube_1d/shocktube.flml
+++ b/tests/shocktube_1d/shocktube.flml
@@ -174,11 +174,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shocktube_1d/shocktube.flml
+++ b/tests/shocktube_1d/shocktube.flml
@@ -178,6 +178,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shocktube_1d_explicit/shocktube.flml
+++ b/tests/shocktube_1d_explicit/shocktube.flml
@@ -186,11 +186,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/shocktube_1d_explicit/shocktube.flml
+++ b/tests/shocktube_1d_explicit/shocktube.flml
@@ -190,6 +190,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank/sloshing_tank_p1dgp2.flml
+++ b/tests/sloshing_tank/sloshing_tank_p1dgp2.flml
@@ -290,11 +290,11 @@ def val(X, t):
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank/sloshing_tank_p1dgp2.flml
+++ b/tests/sloshing_tank/sloshing_tank_p1dgp2.flml
@@ -294,6 +294,7 @@ def val(X, t):
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank/sloshing_tank_p1p1.flml
+++ b/tests/sloshing_tank/sloshing_tank_p1p1.flml
@@ -266,11 +266,11 @@ def val(X, t):
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank/sloshing_tank_p1p1.flml
+++ b/tests/sloshing_tank/sloshing_tank_p1p1.flml
@@ -270,6 +270,7 @@ def val(X, t):
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank_deep/sloshing_tank_deep.flml
+++ b/tests/sloshing_tank_deep/sloshing_tank_deep.flml
@@ -225,11 +225,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank_deep/sloshing_tank_deep.flml
+++ b/tests/sloshing_tank_deep/sloshing_tank_deep.flml
@@ -229,6 +229,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank_tracer/sloshing_tank_tracer.flml
+++ b/tests/sloshing_tank_tracer/sloshing_tank_tracer.flml
@@ -286,6 +286,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/sloshing_tank_tracer/sloshing_tank_tracer.flml
+++ b/tests/sloshing_tank_tracer/sloshing_tank_tracer.flml
@@ -282,11 +282,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/spherical_patch/spherical_segment.flml
+++ b/tests/spherical_patch/spherical_segment.flml
@@ -339,6 +339,9 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy>
+            <radial_gravity_direction_at_gauss_points/>
+          </buoyancy>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/spherical_patch/spherical_segment.flml
+++ b/tests/spherical_patch/spherical_segment.flml
@@ -335,13 +335,13 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy>
-            <radial_gravity_direction_at_gauss_points/>
-          </buoyancy>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-2d/square-2d.flml
+++ b/tests/square-2d/square-2d.flml
@@ -127,11 +127,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-2d/square-2d.flml
+++ b/tests/square-2d/square-2d.flml
@@ -131,6 +131,7 @@
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-dg/square-convection.flml
+++ b/tests/square-convection-dg/square-convection.flml
@@ -200,6 +200,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-dg/square-convection.flml
+++ b/tests/square-convection-dg/square-convection.flml
@@ -196,11 +196,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-parallel-trivial/square-convection.flml
+++ b/tests/square-convection-parallel-trivial/square-convection.flml
@@ -206,11 +206,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-parallel-trivial/square-convection.flml
+++ b/tests/square-convection-parallel-trivial/square-convection.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-parallel/square-convection.flml
+++ b/tests/square-convection-parallel/square-convection.flml
@@ -206,11 +206,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection-parallel/square-convection.flml
+++ b/tests/square-convection-parallel/square-convection.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection/square-convection.flml
+++ b/tests/square-convection/square-convection.flml
@@ -206,11 +206,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/square-convection/square-convection.flml
+++ b/tests/square-convection/square-convection.flml
@@ -210,6 +210,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-cg/standing_wave.flml
+++ b/tests/standing_wave-cg/standing_wave.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-cg/standing_wave.flml
+++ b/tests/standing_wave-cg/standing_wave.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-dg/standing_wave.flml
+++ b/tests/standing_wave-dg/standing_wave.flml
@@ -254,11 +254,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-dg/standing_wave.flml
+++ b/tests/standing_wave-dg/standing_wave.flml
@@ -258,6 +258,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-parallel/standing_wave.flml
+++ b/tests/standing_wave-parallel/standing_wave.flml
@@ -288,11 +288,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-parallel/standing_wave.flml
+++ b/tests/standing_wave-parallel/standing_wave.flml
@@ -292,6 +292,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-swe/standing_wave.flml
+++ b/tests/standing_wave-swe/standing_wave.flml
@@ -203,11 +203,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/standing_wave-swe/standing_wave.flml
+++ b/tests/standing_wave-swe/standing_wave.flml
@@ -207,6 +207,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/strong_pressure_bc_compressible/strong_pressure_bc_compressible.flml
+++ b/tests/strong_pressure_bc_compressible/strong_pressure_bc_compressible.flml
@@ -253,6 +253,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/strong_pressure_bc_compressible/strong_pressure_bc_compressible.flml
+++ b/tests/strong_pressure_bc_compressible/strong_pressure_bc_compressible.flml
@@ -249,11 +249,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/subtract_out_reference_profile/subtract_out_reference_profile_1d.flml
+++ b/tests/subtract_out_reference_profile/subtract_out_reference_profile_1d.flml
@@ -308,6 +308,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/subtract_out_reference_profile/subtract_out_reference_profile_1d.flml
+++ b/tests/subtract_out_reference_profile/subtract_out_reference_profile_1d.flml
@@ -304,11 +304,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/subtract_out_reference_profile/subtract_out_reference_profile_pseudo1d.flml
+++ b/tests/subtract_out_reference_profile/subtract_out_reference_profile_pseudo1d.flml
@@ -301,6 +301,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/subtract_out_reference_profile/subtract_out_reference_profile_pseudo1d.flml
+++ b/tests/subtract_out_reference_profile/subtract_out_reference_profile_pseudo1d.flml
@@ -297,11 +297,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_adapt-at-first-time-step/test_adapt-at-first-time-step.flml
+++ b/tests/test_adapt-at-first-time-step/test_adapt-at-first-time-step.flml
@@ -132,11 +132,11 @@ flml an edit of cube-1.flml</comment>
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_adapt-at-first-time-step/test_adapt-at-first-time-step.flml
+++ b/tests/test_adapt-at-first-time-step/test_adapt-at-first-time-step.flml
@@ -136,6 +136,7 @@ flml an edit of cube-1.flml</comment>
           <conservative_advection>
             <real_value rank="0">1</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_energy_stats/lock_exchange_2d.flml
+++ b/tests/test_energy_stats/lock_exchange_2d.flml
@@ -202,11 +202,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_energy_stats/lock_exchange_2d.flml
+++ b/tests/test_energy_stats/lock_exchange_2d.flml
@@ -206,6 +206,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_energy_stats/lock_exchange_2d_parallel.flml
+++ b/tests/test_energy_stats/lock_exchange_2d_parallel.flml
@@ -197,6 +197,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_energy_stats/lock_exchange_2d_parallel.flml
+++ b/tests/test_energy_stats/lock_exchange_2d_parallel.flml
@@ -193,11 +193,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_metric_advection_parallel/test_metric_advection_parallel.flml
+++ b/tests/test_metric_advection_parallel/test_metric_advection_parallel.flml
@@ -174,11 +174,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_metric_advection_parallel/test_metric_advection_parallel.flml
+++ b/tests/test_metric_advection_parallel/test_metric_advection_parallel.flml
@@ -178,6 +178,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_source_absorption/test_no_source_absorption.flml
+++ b/tests/test_source_absorption/test_no_source_absorption.flml
@@ -184,11 +184,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_source_absorption/test_no_source_absorption.flml
+++ b/tests/test_source_absorption/test_no_source_absorption.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_source_absorption/test_source_absorption.flml
+++ b/tests/test_source_absorption/test_source_absorption.flml
@@ -184,11 +184,11 @@
             <stress_terms>
               <stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/test_source_absorption/test_source_absorption.flml
+++ b/tests/test_source_absorption/test_source_absorption.flml
@@ -188,6 +188,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/tidal_channel/channel.flml
+++ b/tests/tidal_channel/channel.flml
@@ -226,6 +226,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/tidal_channel/channel.flml
+++ b/tests/tidal_channel/channel.flml
@@ -222,11 +222,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/tidal_diagnostics/tidal_diagnostics.flml
+++ b/tests/tidal_diagnostics/tidal_diagnostics.flml
@@ -325,13 +325,13 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy>
+              <radial_gravity_direction_at_gauss_points/>
+            </buoyancy>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy>
-            <radial_gravity_direction_at_gauss_points/>
-          </buoyancy>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/tidal_diagnostics/tidal_diagnostics.flml
+++ b/tests/tidal_diagnostics/tidal_diagnostics.flml
@@ -329,6 +329,9 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy>
+            <radial_gravity_direction_at_gauss_points/>
+          </buoyancy>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_dirichlet_3d/turbine_dirichlet_3d.flml
+++ b/tests/turbine_dirichlet_3d/turbine_dirichlet_3d.flml
@@ -246,6 +246,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_dirichlet_3d/turbine_dirichlet_3d.flml
+++ b/tests/turbine_dirichlet_3d/turbine_dirichlet_3d.flml
@@ -242,11 +242,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_dirichlet_3d_moving_mesh/turbine_dirichlet_3d.flml
+++ b/tests/turbine_dirichlet_3d_moving_mesh/turbine_dirichlet_3d.flml
@@ -259,11 +259,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_dirichlet_3d_moving_mesh/turbine_dirichlet_3d.flml
+++ b/tests/turbine_dirichlet_3d_moving_mesh/turbine_dirichlet_3d.flml
@@ -263,6 +263,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2d/onedomain_2d.flml
+++ b/tests/turbine_flux_dg_2d/onedomain_2d.flml
@@ -153,6 +153,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2d/onedomain_2d.flml
+++ b/tests/turbine_flux_dg_2d/onedomain_2d.flml
@@ -149,11 +149,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2d/turbine_flux_dg_2d.flml
+++ b/tests/turbine_flux_dg_2d/turbine_flux_dg_2d.flml
@@ -153,6 +153,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2d/turbine_flux_dg_2d.flml
+++ b/tests/turbine_flux_dg_2d/turbine_flux_dg_2d.flml
@@ -149,11 +149,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2plus1/onedomain_2plus1.flml
+++ b/tests/turbine_flux_dg_2plus1/onedomain_2plus1.flml
@@ -128,6 +128,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2plus1/onedomain_2plus1.flml
+++ b/tests/turbine_flux_dg_2plus1/onedomain_2plus1.flml
@@ -124,11 +124,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2plus1/turbine_flux_dg_2plus1.flml
+++ b/tests/turbine_flux_dg_2plus1/turbine_flux_dg_2plus1.flml
@@ -141,6 +141,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_dg_2plus1/turbine_flux_dg_2plus1.flml
+++ b/tests/turbine_flux_dg_2plus1/turbine_flux_dg_2plus1.flml
@@ -137,11 +137,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2d/onedomain_2d.flml
+++ b/tests/turbine_flux_penalty_2d/onedomain_2d.flml
@@ -123,11 +123,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2d/onedomain_2d.flml
+++ b/tests/turbine_flux_penalty_2d/onedomain_2d.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2d/turbine_flux_penalty_2d.flml
+++ b/tests/turbine_flux_penalty_2d/turbine_flux_penalty_2d.flml
@@ -123,11 +123,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2d/turbine_flux_penalty_2d.flml
+++ b/tests/turbine_flux_penalty_2d/turbine_flux_penalty_2d.flml
@@ -127,6 +127,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2plus1/onedomain_2plus1.flml
+++ b/tests/turbine_flux_penalty_2plus1/onedomain_2plus1.flml
@@ -128,6 +128,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2plus1/onedomain_2plus1.flml
+++ b/tests/turbine_flux_penalty_2plus1/onedomain_2plus1.flml
@@ -124,11 +124,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2plus1/turbine_flux_penalty_2plus1.flml
+++ b/tests/turbine_flux_penalty_2plus1/turbine_flux_penalty_2plus1.flml
@@ -141,6 +141,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/turbine_flux_penalty_2plus1/turbine_flux_penalty_2plus1.flml
+++ b/tests/turbine_flux_penalty_2plus1/turbine_flux_penalty_2plus1.flml
@@ -137,11 +137,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_dg/viscosity.flml
+++ b/tests/viscosity_2d_dg/viscosity.flml
@@ -77,11 +77,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_dg/viscosity.flml
+++ b/tests/viscosity_2d_dg/viscosity.flml
@@ -81,6 +81,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_parallel/heat.flml
+++ b/tests/viscosity_2d_p0_parallel/heat.flml
@@ -97,6 +97,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_parallel/heat.flml
+++ b/tests/viscosity_2d_p0_parallel/heat.flml
@@ -93,11 +93,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_parallel_local_assembly/heat.flml
+++ b/tests/viscosity_2d_p0_parallel_local_assembly/heat.flml
@@ -97,6 +97,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_parallel_local_assembly/heat.flml
+++ b/tests/viscosity_2d_p0_parallel_local_assembly/heat.flml
@@ -93,11 +93,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_serial/heat.flml
+++ b/tests/viscosity_2d_p0_serial/heat.flml
@@ -97,6 +97,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscosity_2d_p0_serial/heat.flml
+++ b/tests/viscosity_2d_p0_serial/heat.flml
@@ -93,11 +93,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
@@ -232,11 +232,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
@@ -236,6 +236,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
@@ -230,11 +230,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
@@ -234,6 +234,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
@@ -233,6 +233,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
@@ -229,11 +229,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
@@ -235,11 +235,11 @@
             <stress_terms>
               <partial_stress_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
@@ -239,6 +239,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/water_collapse_2d/water_collapse.flml
+++ b/tests/water_collapse_2d/water_collapse.flml
@@ -288,11 +288,11 @@
               </integrate_advection_by_parts>
               <integrate_conservation_term_by_parts/>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/water_collapse_2d/water_collapse.flml
+++ b/tests/water_collapse_2d/water_collapse.flml
@@ -292,6 +292,7 @@
           <conservative_advection>
             <real_value rank="0">0.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano1_cg/balzano1_2plus1.flml
+++ b/tests/wetting_and_drying_balzano1_cg/balzano1_2plus1.flml
@@ -299,11 +299,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano1_cg/balzano1_2plus1.flml
+++ b/tests/wetting_and_drying_balzano1_cg/balzano1_2plus1.flml
@@ -303,6 +303,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano2_cg/balzano2_2plus1.flml
+++ b/tests/wetting_and_drying_balzano2_cg/balzano2_2plus1.flml
@@ -315,6 +315,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano2_cg/balzano2_2plus1.flml
+++ b/tests/wetting_and_drying_balzano2_cg/balzano2_2plus1.flml
@@ -311,11 +311,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano3_cg_parallel/balzano1_2plus1.flml
+++ b/tests/wetting_and_drying_balzano3_cg_parallel/balzano1_2plus1.flml
@@ -313,11 +313,11 @@
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_balzano3_cg_parallel/balzano1_2plus1.flml
+++ b/tests/wetting_and_drying_balzano3_cg_parallel/balzano1_2plus1.flml
@@ -317,6 +317,7 @@
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_geometric_volume_conservation/geometric_volume_conservation_p1p1.flml
+++ b/tests/wetting_and_drying_geometric_volume_conservation/geometric_volume_conservation_p1p1.flml
@@ -274,11 +274,11 @@ Shows how numerical scheme predicts frequencey and damping rate</comment>
             <stress_terms>
               <tensor_form/>
             </stress_terms>
+            <buoyancy/>
           </continuous_galerkin>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wetting_and_drying_geometric_volume_conservation/geometric_volume_conservation_p1p1.flml
+++ b/tests/wetting_and_drying_geometric_volume_conservation/geometric_volume_conservation_p1p1.flml
@@ -278,6 +278,7 @@ Shows how numerical scheme predicts frequencey and damping rate</comment>
           <conservative_advection>
             <real_value rank="0">0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wind_stratification/channel.flml
+++ b/tests/wind_stratification/channel.flml
@@ -236,6 +236,7 @@
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
+          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>

--- a/tests/wind_stratification/channel.flml
+++ b/tests/wind_stratification/channel.flml
@@ -232,11 +232,11 @@
                 <twice/>
               </integrate_advection_by_parts>
             </advection_scheme>
+            <buoyancy/>
           </discontinuous_galerkin>
           <conservative_advection>
             <real_value rank="0">1.0</real_value>
           </conservative_advection>
-          <buoyancy/>
         </spatial_discretisation>
         <temporal_discretisation>
           <theta>


### PR DESCRIPTION
Currently when a user turns on the /geometry/spherical_earth option a number of things happen automagically, with no user control.  This branch implements the first fix for this by separating out the automatic placing of radial gravity at gauss points into its own option underneath prognostic velocities.  This explicitly states what the option will do (i.e. ignore your gravity direction for the buoyancy terms) and allows the functionality to be tested properly and independently (of the various other things that happen automatically).

A test has been added on a circle and hemisphere to check that the hydrostatic pressure is recovered when solving using P1DGP2 and P2P1. 

Green buildbot branch here: http://buildbot-ocean.ese.ic.ac.uk:8080/waterfall?show=spherical_gravity_at_gauss_point_option