### PR TITLE
Possible fix for prefix not getting expanded in flml schemata file on install?

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -491,7 +491,7 @@ distclean: clean
 	 include/spatialindex include/spud include/spud.h		\
 	 include/spud_enums.h include/tinystr.h include/tinyxml.h	\
 	 include/version.h include/vtk.h				\
-	 preprocessor/check_options.F90 schemas/flml			\
+	 preprocessor/check_options.F90 \
 	 preprocessor/register_diagnostics.F90 python/setup.py >	\
 	 /dev/null
 	@for i in `find ./*/ -name Makefile.in`; do rm -f `echo $$i | sed 's/.in$$//'`; done > /dev/null
@@ -615,7 +615,7 @@ install: default fltools bin/shallow_water bin/burgers_equation
 	mkdir -p $(DESTDIR)$(datadir)/fluidity
 	cp -r schemas/ $(DESTDIR)$(datadir)/fluidity/
 	mkdir -p $(DESTDIR)$(datadir)/diamond/schemata
-	sed 's/$${prefix}/$(subst /,\/,$(prefix))/g' schemas/flml > $(DESTDIR)$(datadir)/diamond/schemata/flml
+	sed 's/$${datadir}/$(subst /,\/,$(datadir))/g' schemas/flml.in > $(DESTDIR)$(datadir)/diamond/schemata/flml
 	cd python ; python setup.py install --root=$(shell echo ${DESTDIR} | sed 's/^$$/\//') --prefix="$(prefix)" $$FLUIDITY_PYTHON_INSTALL_ARGS
 	cp -r examples/ $(DESTDIR)$(docdir)/fluidity
 	find $(DESTDIR)$(docdir)/fluidity/examples -type f -exec sed -i "s/\.\.\/\.\.\/\.\.\/bin\///" '{}' \;

--- a/Makefile.in
+++ b/Makefile.in
@@ -615,7 +615,7 @@ install: default fltools bin/shallow_water bin/burgers_equation
 	mkdir -p $(DESTDIR)$(datadir)/fluidity
 	cp -r schemas/ $(DESTDIR)$(datadir)/fluidity/
 	mkdir -p $(DESTDIR)$(datadir)/diamond/schemata
-	cp schemas/flml $(DESTDIR)$(datadir)/diamond/schemata
+	sed 's/$${prefix}/$(subst /,\/,$(prefix))/g' schemas/flml > $(DESTDIR)$(datadir)/diamond/schemata/flml
 	cd python ; python setup.py install --root=$(shell echo ${DESTDIR} | sed 's/^$$/\//') --prefix="$(prefix)" $$FLUIDITY_PYTHON_INSTALL_ARGS
 	cp -r examples/ $(DESTDIR)$(docdir)/fluidity
 	find $(DESTDIR)$(docdir)/fluidity/examples -type f -exec sed -i "s/\.\.\/\.\.\/\.\.\/bin\///" '{}' \;

--- a/configure
+++ b/configure
@@ -15042,7 +15042,7 @@ fi
 
 #*******************
 
-ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py adjoint/Makefile adjoint/tests/Makefile climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile schemas/flml reduced_modelling/Makefile"
+ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py adjoint/Makefile adjoint/tests/Makefile climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile reduced_modelling/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -15774,7 +15774,6 @@ do
     "libjudy/src/JudyHS/Makefile") CONFIG_FILES="$CONFIG_FILES libjudy/src/JudyHS/Makefile" ;;
     "libwm/Makefile") CONFIG_FILES="$CONFIG_FILES libwm/Makefile" ;;
     "libvtkfortran/Makefile") CONFIG_FILES="$CONFIG_FILES libvtkfortran/Makefile" ;;
-    "schemas/flml") CONFIG_FILES="$CONFIG_FILES schemas/flml" ;;
     "reduced_modelling/Makefile") CONFIG_FILES="$CONFIG_FILES reduced_modelling/Makefile" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.in
+++ b/configure.in
@@ -1550,5 +1550,4 @@ AC_OUTPUT(Makefile
           libjudy/src/JudyHS/Makefile
           libwm/Makefile
           libvtkfortran/Makefile
-          schemas/flml
 	  reduced_modelling/Makefile)

--- a/schemas/flml.in
+++ b/schemas/flml.in
@@ -1,2 +1,2 @@
 Fluidity Markup Language
-@datadir@/fluidity/schemas/fluidity_options.rng
+${datadir}/fluidity/schemas/fluidity_options.rng

--- a/schemas/flml.in
+++ b/schemas/flml.in
@@ -1,2 +1,2 @@
 Fluidity Markup Language
-@datadir@/fluidity/schemas/fluidity_options.rng
+@prefix@/share/fluidity/schemas/fluidity_options.rng

--- a/schemas/flml.in
+++ b/schemas/flml.in
@@ -1,2 +1,2 @@
 Fluidity Markup Language
-@prefix@/share/fluidity/schemas/fluidity_options.rng
+@datadir@/fluidity/schemas/fluidity_options.rng


### PR DESCRIPTION
Not so much a pull request as a request for better suggestions/opinions.

When I configure with `--prefix=...` and make install I'm finding that the schemata file in `prefix/share/diamond/schemata/flml` is invalid because the path listed in that file still has `${prefix}` in it (to see this just run configure then look at `schemas/flml`).  This is because `schemas/flml.in` uses `@datadir@` which is not expanded out beyond `${prefix}/share`.  There is a comment in configure that suggests this is done intentionally so that users can run `make install exec_prefix=...` but that workflow wouldn't work for this file as far as I can tell as install just copies the file into the destination directory without further (post configure) modifications.

So, I'm wondering if anyone uses or is aware of the intentions of that functionality?  If not, can we just remove references to `datadir` and have configure expand `$prefix`.

In the meantime this diff does that for `schemas/flml.in`, which gets me around this problem for now.