### PR TITLE
Remove the asserts following cache prepopulation with openmp as there's no reason they can't be false.

### DIFF
--- a/assemble/Advection_Diffusion_CG.F90
+++ b/assemble/Advection_Diffusion_CG.F90
@@ -581,7 +581,6 @@ contains
 
 #ifdef _OPENMP
     cache_valid = prepopulate_transform_cache(positions)
-    assert(cache_valid)
 #endif
 
     call get_mesh_colouring(state, t%mesh, COLOURING_CG1, colours)

--- a/assemble/Advection_Diffusion_DG.F90
+++ b/assemble/Advection_Diffusion_DG.F90
@@ -1014,7 +1014,6 @@ contains
 
 #ifdef _OPENMP
     cache_valid = prepopulate_transform_cache(X)
-    assert(cache_valid)
 #endif
 
     call profiler_tic(t, "advection_diffusion_dg_loop")

--- a/assemble/Advection_Diffusion_FV.F90
+++ b/assemble/Advection_Diffusion_FV.F90
@@ -275,7 +275,6 @@ contains
 
 #ifdef _OPENMP
     cache_valid = prepopulate_transform_cache(coordinate)
-    assert(cache_valid)
 #endif
 
     call get_mesh_colouring(state, T%mesh, COLOURING_DG1, colours)

--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -715,7 +715,6 @@
       
 #ifdef _OPENMP
     cache_valid = prepopulate_transform_cache(x)
-    assert(cache_valid)
     if (have_coriolis) then
        call set_coriolis_parameters
     end if

--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -697,7 +697,6 @@ contains
     end if
 #ifdef _OPENMP
     cache_valid = prepopulate_transform_cache(X)
-    assert(cache_valid)
     if (have_coriolis) then
        call set_coriolis_parameters
     end if


### PR DESCRIPTION
This is a possible fix for issue #46 . 