### PR TITLE
Petsc master fixes

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -428,9 +428,10 @@ AC_MSG_NOTICE([Using PETSC_DIR=$PETSC_DIR])
 PETSC_LINK_LIBS=`make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
+# need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
 PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile getincludedirs`
-CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS"
-FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS"
+CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
+FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
 # Horrible hacks needed for cx1
 # Somehow /apps/intel/ict/mpi/3.1.038/lib64 gets given as /apps/intel/ict/mpi/3.1.038/lib/64
@@ -479,16 +480,11 @@ fi
 AC_LINK_IFELSE(
 [AC_LANG_SOURCE([
 program test_petsc
-#include "petscversion.h"
 #ifdef HAVE_PETSC_MODULES
   use petsc
 #endif
 implicit none
-#ifdef HAVE_PETSC_MODULES
-#include "finclude/petscdef.h"
-#else
-#include "finclude/petsc.h"
-#endif
+#include "petsc_legacy.h"
       double precision  norm
       PetscInt  i,j,II,JJ,m,n,its
       PetscInt  Istart,Iend,ione

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -425,11 +425,11 @@ if test "x$PETSC_DIR" == "x"; then
 fi
 AC_MSG_NOTICE([Using PETSC_DIR=$PETSC_DIR])
 
-PETSC_LINK_LIBS=`make -s -f petsc_makefile getlinklibs`
+PETSC_LINK_LIBS=`make -s -f petsc_makefile_old getlinklibs 2> /dev/null || make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
 # need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
-PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile getincludedirs`
+PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null || make -s -f petsc_makefile getincludedirs`
 CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
@@ -550,7 +550,7 @@ implicit none
       call MatMult(A,u,b,ierr)
 
       call KSPCreate(PETSC_COMM_WORLD,ksp,ierr)
-      call KSPSetOperators(ksp,A,A,DIFFERENT_NONZERO_PATTERN,ierr)
+      call KSPSetOperators(ksp,A,A,ierr)
       call KSPSetFromOptions(ksp,ierr)
 
       call KSPSolve(ksp,b,x,ierr)

--- a/assemble/Full_Projection.F90
+++ b/assemble/Full_Projection.F90
@@ -44,7 +44,6 @@
     use petsc_solve_state_module
     use boundary_conditions_from_options
 
-#include "petscversion.h"
 #ifdef HAVE_PETSC_MODULES
     use petsc
 #endif
@@ -52,11 +51,7 @@
     implicit none
     ! Module to provide solvers, preconditioners etc... for full_projection Solver.
     ! Not this is currently tested for Full CMC solves and Stokes flow:
-#ifdef HAVE_PETSC_MODULES
-#include "finclude/petscdef.h"
-#else
-#include "finclude/petsc.h"
-#endif
+#include "petsc_legacy.h"
     
     private
     

--- a/configure
+++ b/configure
@@ -12919,11 +12919,11 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: Using PETSC_DIR=$PETSC_DIR" >&5
 $as_echo "$as_me: Using PETSC_DIR=$PETSC_DIR" >&6;}
 
-PETSC_LINK_LIBS=`make -s -f petsc_makefile getlinklibs`
+PETSC_LINK_LIBS=`make -s -f petsc_makefile_old getlinklibs 2> /dev/null || make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
 # need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
-PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile getincludedirs`
+PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null || make -s -f petsc_makefile getincludedirs`
 CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
@@ -13060,7 +13060,7 @@ implicit none
       call MatMult(A,u,b,ierr)
 
       call KSPCreate(PETSC_COMM_WORLD,ksp,ierr)
-      call KSPSetOperators(ksp,A,A,DIFFERENT_NONZERO_PATTERN,ierr)
+      call KSPSetOperators(ksp,A,A,ierr)
       call KSPSetFromOptions(ksp,ierr)
 
       call KSPSolve(ksp,b,x,ierr)

--- a/configure
+++ b/configure
@@ -12922,9 +12922,10 @@ $as_echo "$as_me: Using PETSC_DIR=$PETSC_DIR" >&6;}
 PETSC_LINK_LIBS=`make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
+# need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
 PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile getincludedirs`
-CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS"
-FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS"
+CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
+FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
 # Horrible hacks needed for cx1
 # Somehow /apps/intel/ict/mpi/3.1.038/lib64 gets given as /apps/intel/ict/mpi/3.1.038/lib/64
@@ -12989,16 +12990,11 @@ fi
 cat > conftest.$ac_ext <<_ACEOF
 
 program test_petsc
-#include "petscversion.h"
 #ifdef HAVE_PETSC_MODULES
   use petsc
 #endif
 implicit none
-#ifdef HAVE_PETSC_MODULES
-#include "finclude/petscdef.h"
-#else
-#include "finclude/petsc.h"
-#endif
+#include "petsc_legacy.h"
       double precision  norm
       PetscInt  i,j,II,JJ,m,n,its
       PetscInt  Istart,Iend,ione

--- a/femtools/Petsc_Tools.F90
+++ b/femtools/Petsc_Tools.F90
@@ -1490,11 +1490,9 @@ contains
 ! Useful for unittesting to see that petsc gives error messages at the right moment
 #if PETSC_VERSION_MINOR>=2
 subroutine petsc_test_error_handler(comm,line, func, file, dir, n, p, mess, ctx, ierr)
-#include "finclude/petsc.h"
   MPI_Comm:: comm
 #else
 subroutine petsc_test_error_handler(line, func, file, dir, n, p, mess, ctx, ierr)
-#include "finclude/petsc.h"
 #endif
   PetscInt:: line
   character(len=*):: func, file, dir
@@ -1597,7 +1595,6 @@ end module Petsc_Tools
 ! the module (and only including petsc headers and not use petsc modules)
 ! this routine calls MatGetInfo with an implicit interface.
 subroutine myMatGetInfo(A, flag, info, ierr)
-#include "finclude/petsc.h"
 Mat, intent(in):: A
 MatInfoType, intent(in):: flag
 double precision, dimension(:), intent(out):: info

--- a/include/petsc_legacy.h
+++ b/include/petsc_legacy.h
@@ -6,9 +6,17 @@
 ! still need #ifdef PETSC_VERSION>... in the main code
 #include "petscversion.h"
 #ifdef HAVE_PETSC_MODULES
+#if PETSC_VERSION_RELEASE==0
+#include "petsc/finclude/petscdef.h"
+#else
 #include "finclude/petscdef.h"
+#endif
+#else
+#if PETSC_VERSION_RELEASE==0
+#include "petsc/finclude/petsc.h"
 #else
 #include "finclude/petsc.h"
+#endif
 #endif
 ! this is the one exception where we keep the old names for now (until
 ! we get rid of petsc 3.1 and 3.2 support). MatCreate{Seq|MPI}[B]AIJ()

--- a/main/Burgers_Equation.F90
+++ b/main/Burgers_Equation.F90
@@ -70,11 +70,12 @@
 #include "libadjoint/adj_fortran.h"
 #endif
 
-    implicit none
 
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
 
     type(state_type), dimension(:), pointer :: state
     type(state_type), target :: matrices ! We collect all the cached
@@ -101,14 +102,6 @@
       subroutine set_global_debug_level(n)
         integer, intent(in) :: n
       end subroutine set_global_debug_level
-
-      subroutine mpi_init(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_init
-
-      subroutine mpi_finalize(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_finalize
 
       subroutine python_init
       end subroutine python_init

--- a/main/Hybridized_Helmholtz_Solver.F90
+++ b/main/Hybridized_Helmholtz_Solver.F90
@@ -44,24 +44,17 @@
     use iso_c_binding
     use mangle_options_tree
     use hybridized_helmholtz
-    implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
 
     ! Interface blocks for the initialisation routines we need to call
     interface
        subroutine set_global_debug_level(n)
          integer, intent(in) :: n
        end subroutine set_global_debug_level
-
-       subroutine mpi_init(ierr)
-         integer, intent(out) :: ierr
-       end subroutine mpi_init
-
-       subroutine mpi_finalize(ierr)
-         integer, intent(out) :: ierr
-       end subroutine mpi_finalize
 
        subroutine python_init
        end subroutine python_init

--- a/main/Shallow_Water.F90
+++ b/main/Shallow_Water.F90
@@ -70,24 +70,17 @@
     use forward_main_loop
 #include "libadjoint/adj_fortran.h"
 #endif
-    implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
 
     ! Interface blocks for the initialisation routines we need to call
     interface
       subroutine set_global_debug_level(n)
         integer, intent(in) :: n
       end subroutine set_global_debug_level
-
-      subroutine mpi_init(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_init
-
-      subroutine mpi_finalize(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_finalize
 
       subroutine python_init
       end subroutine python_init

--- a/petsc_makefile
+++ b/petsc_makefile
@@ -7,5 +7,5 @@
 # Before running this makefile you need to have PETSC_DIR set and
 # (unless you're using a prefix-installed installation of PETSc)
 # PETSC_ARCH
-include ${PETSC_DIR}/conf/variables
-include ${PETSC_DIR}/conf/rules
+include ${PETSC_DIR}/lib/petsc/conf/variables
+include ${PETSC_DIR}/lib/petsc/conf/rules

--- a/petsc_makefile_old
+++ b/petsc_makefile_old
@@ -8,7 +8,6 @@
 # (unless you're using a prefix-installed installation of PETSc)
 # PETSC_ARCH
 #
-# this version assumes the *new* location of the conf/ directory (petsc release>=3.6)
-# in ${PETSC_DIR}/lib/petsc/conf/
-include ${PETSC_DIR}/lib/petsc/conf/variables
-include ${PETSC_DIR}/lib/petsc/conf/rules
+# this version assumes the *old* location of the conf/ directory (petsc release <=3.5)
+include ${PETSC_DIR}/conf/variables
+include ${PETSC_DIR}/conf/rules

--- a/reduced_modelling/Form_Pod_Basis_Main.F90
+++ b/reduced_modelling/Form_Pod_Basis_Main.F90
@@ -38,10 +38,12 @@ program form_pod_basis
   use vtk_interfaces
   use memory_diagnostics
 
-  implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
+
   type(state_type), dimension(:), allocatable :: state,state_test
   type(state_type), dimension(:,:), allocatable :: pod_state
 

--- a/tools/Test_Trace_Space.F90
+++ b/tools/Test_Trace_Space.F90
@@ -42,24 +42,17 @@
     use memory_diagnostics
     use iso_c_binding
     use mangle_options_tree
-    implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
 
     ! Interface blocks for the initialisation routines we need to call
     interface
       subroutine set_global_debug_level(n)
         integer, intent(in) :: n
       end subroutine set_global_debug_level
-
-      subroutine mpi_init(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_init
-
-      subroutine mpi_finalize(ierr)
-        integer, intent(out) :: ierr
-      end subroutine mpi_finalize
 
       subroutine python_init
       end subroutine python_init

--- a/tools/test_laplacian.F90
+++ b/tools/test_laplacian.F90
@@ -22,10 +22,11 @@ program test_laplacian
   use adapt_state_module 
   use boundary_conditions
 
-  implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
   
   character, parameter:: NEWLINE_CHAR=achar(10)
   character(len=*), parameter:: BC_PYTHON_FUNCTION= &

--- a/tools/test_laplacian_vector.F90
+++ b/tools/test_laplacian_vector.F90
@@ -23,10 +23,11 @@ program test_laplacian_vector
   use boundary_conditions
   use fldebug
 
-  implicit none
-#ifdef HAVE_PETSC
-#include "finclude/petsc.h"
+#ifdef HAVE_PETSC_MODULES
+  use petsc
 #endif
+  implicit none
+#include "petsc_legacy.h"
   
   character, parameter:: NEWLINE_CHAR=achar(10)
   character(len=*), parameter:: BC_PYTHON_FUNCTION= &

--- a/tools/test_pressure_solve.F90
+++ b/tools/test_pressure_solve.F90
@@ -17,10 +17,12 @@
     use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN
     use free_surface_module
     use FLDebug
-    implicit none
+#ifdef HAVE_PETSC_MODULES
+  use petsc
+#endif
+  implicit none
+#include "petsc_legacy.h"
 
-#include "petscversion.h"
-#include "finclude/petsc.h"
     type(state_type) :: state
     type(vector_field), target:: positions, vertical_normal
     type(scalar_field) :: psi, DistanceToTop, exact
@@ -298,12 +300,15 @@
        & exact_sol_filename, vl_as, vl_as_wsor, vl, no_vl, sor)
     use Fldebug
     use petsc_tools
-    implicit none
+#ifdef HAVE_PETSC_MODULES
+  use petsc
+#endif
+  implicit none
+#include "petsc_legacy.h"
+
     character(len=*), intent(out):: filename, exact_sol_filename
     logical, intent(out) :: vl_as, vl, no_vl, sor, vl_as_wsor
     real, intent(out) :: eps0
-
-#include "finclude/petsc.h"
 
 #if PETSC_VERSION_MINOR>=2
     PetscBool:: flag


### PR DESCRIPTION
Make fluidity build with petsc master again

This is to cope with new layout of petsc installation build from master. Changes:
* include/finclude -> include/petsc/finclude.

This means that each fortran file should have:

    #include "petsc/finclude/include_file.h"

instead of

    #include "finclude/include_file.h"

* conf -> lib/petsc/conf. This means the included makefiles in the petsc_makefile have to change

To avoid having to support both old and new conventions with lots of `#ifdef`s, this is all done in the petsc_legacy.h header file, which is now used everywhere including all the tools.
