### PR TITLE
Flredecomp file type fix

### DIFF
--- a/assemble/Coriolis.F90
+++ b/assemble/Coriolis.F90
@@ -59,7 +59,7 @@ module coriolis_module
      
   private
   
-  public :: coriolis, funome, set_coriolis_parameters
+  public :: coriolis, funome, set_coriolis_parameters, coriolis_module_check_options
 
   contains
 

--- a/error_measures/Limit_metric.F90
+++ b/error_measures/Limit_metric.F90
@@ -14,7 +14,7 @@ module limit_metric_module
   private
 
   public :: limit_metric, limit_metric_elements, expected_elements, &
-    & expected_nodes, determinant
+    & expected_nodes, determinant, limit_metric_module_check_options
 
   interface expected_nodes
     module procedure expected_nodes_expected_elements, expected_nodes_metric

--- a/femtools/Checkpoint.F90
+++ b/femtools/Checkpoint.F90
@@ -1,4 +1,4 @@
-!    Copyrigh (C) 2006 Imperial College London and others.
+!    Copyright (C) 2006 Imperial College London and others.
 !
 !    Please see the AUTHORS file in the main source directory for a full list
 !    of copyright holders.
@@ -98,7 +98,7 @@ contains
   end function do_checkpoint_simulation
 
   subroutine checkpoint_simulation(state, prefix, postfix, cp_no, protect_simulation_name, &
-    keep_initial_data, ignore_detectors, number_of_partitions)
+    keep_initial_data, ignore_detectors, number_of_partitions,file_type)
     !!< Checkpoint the whole simulation
     
     type(state_type), dimension(:), intent(in) :: state
@@ -121,6 +121,8 @@ contains
     logical, optional, intent(in) :: ignore_detectors
     !! If present, only write for processes 1:number_of_partitions (assumes the other partitions are empty)
     integer, optional, intent(in):: number_of_partitions
+    !! optional argument specifying the file type. Defaults to .flml
+    character(len = *), optional, intent(in) :: file_type
 
     character(len = PREFIX_LEN) :: lpostfix, lprefix
 
@@ -150,7 +152,7 @@ contains
     if(getrank() == 0) then
       ! Only rank zero should write out the options tree in parallel
       call checkpoint_options(lprefix, postfix = lpostfix, cp_no = cp_no, &
-        & protect_simulation_name = .not. present_and_false(protect_simulation_name))
+        & protect_simulation_name = .not. present_and_false(protect_simulation_name),file_type=file_type)
     end if
     
   end subroutine checkpoint_simulation
@@ -266,15 +268,15 @@ contains
       offset = location_to_write+(node%id_number-1)*size(node%position)*realsize
       ewrite(1,*) "after file set view position IERROR is:", IERROR
 
-      allocate(buffer(size(node%position)))
-      buffer=node%position
-      nints=size(node%position)
+                 allocate(buffer(size(node%position)))
+                 buffer=node%position
+                 nints=size(node%position)
 
-      call MPI_FILE_WRITE_AT(fhdet,offset,buffer,nints,getpreal(),status,IERROR)
+                 call MPI_FILE_WRITE_AT(fhdet,offset,buffer,nints,getpreal(),status,IERROR)
 
-      ewrite(1,*) "after sync position IERROR is:", IERROR
-      deallocate(buffer)
-      node => node%next
+                 ewrite(1,*) "after sync position IERROR is:", IERROR
+                 deallocate(buffer)
+                 node => node%next
     end do positionloop_cp
 
     call update_detectors_options(trim(detectors_cp_filename) // "_det", "binary")
@@ -449,7 +451,7 @@ contains
     integer :: i, n_meshes, stat1, stat2, nparts
     type(mesh_type), pointer :: mesh, external_mesh
     logical :: from_file, extruded
-    
+
     assert(len_trim(prefix) > 0)
 
     if (present(number_of_partitions)) then
@@ -583,7 +585,7 @@ contains
           ! generally this functionality is untested.
           ewrite(0,*) "WARNING: using mesh_movement with checkpointing is untested and likely broken."
         end if
-        positions => extract_vector_field(state(i), "Coordinate")
+      positions => extract_vector_field(state(i), "Coordinate")
       end if
       do j = 1, size(state(i)%meshes)
         mesh => state(i)%meshes(j)%ptr
@@ -628,34 +630,34 @@ contains
               if(s_field%mesh == mesh) then
                 ! and either the field is prognostic, prescribed and interpolated, or diagnostic and checkpointed
                 if(have_option(trim(s_field%option_path) // "/prognostic") &
-                    & .or. (have_option(trim(s_field%option_path) // "/prescribed") &
+              & .or. (have_option(trim(s_field%option_path) // "/prescribed") &
                     & .and. interpolate_field(s_field)) & 
-                    & .or. have_option(trim(s_field%option_path) // "/diagnostic/output/checkpoint")) then
+              & .or. have_option(trim(s_field%option_path) // "/diagnostic/output/checkpoint") ) then
                   ! but not aliased
                   if(.not. aliased(s_field)) then
 
-                    if(have_option(trim(complete_field_path(s_field%option_path)) // "/exclude_from_checkpointing")) cycle
-                    ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
+              if(have_option(trim(complete_field_path(s_field%option_path)) // "/exclude_from_checkpointing")) cycle
+              ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
                     if(present_and_true(keep_initial_data) .and. (.not. needs_initial_mesh(s_field) .and. .not. have_option(trim(s_field%option_path) // "/diagnostic/output/checkpoint"))) cycle
 
                     ewrite(2, *) "Checkpointing scalar field " // trim(s_field%name) // " in state " // trim(state(i)%name) &
                         & // "on the " // trim(mesh%name)
 
-                    n_ps_fields_on_mesh = n_ps_fields_on_mesh + 1
-                    ps_fields_on_mesh(n_ps_fields_on_mesh) = s_field
+              n_ps_fields_on_mesh = n_ps_fields_on_mesh + 1
+              ps_fields_on_mesh(n_ps_fields_on_mesh) = s_field
 
-                    if(have_option(trim(s_field%option_path) // "/prognostic")) then
+              if(have_option(trim(s_field%option_path) // "/prognostic")) then
                       ewrite(2, *) "Updating initial conditions for " // trim(s_field%name)
-                      call update_initial_condition_options(trim(s_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(s_field%option_path) // "/prescribed").and. &
+                call update_initial_condition_options(trim(s_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(s_field%option_path) // "/prescribed").and.&
                         & interpolate_field(s_field)) then
                       ewrite(2, *) "Updating values for " // trim(s_field%name)
-                      call update_value_options(trim(s_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(s_field%option_path) // "/diagnostic/output/checkpoint").and. &
+                call update_value_options(trim(s_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(s_field%option_path) // "/diagnostic/output/checkpoint").and.&
 	                      & interpolate_field(s_field)) then
-                      ewrite(2, *) "... diagnostic field"
-                    else
-                      FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
+                ewrite(2, *) "... diagnostic field"
+              else
+                FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
                     end if
                   end if
                 end if
@@ -673,36 +675,34 @@ contains
               if(v_field%mesh == mesh) then
                 ! and either the field is prognostic, prescribed and interpolated, or diagnostic and checkpointed
                 if(have_option(trim(v_field%option_path) // "/prognostic") &
-                    & .or. (have_option(trim(v_field%option_path) // "/prescribed") &
+              & .or. (have_option(trim(v_field%option_path) // "/prescribed") &
                     & .and. interpolate_field(v_field)) &
-                    & .or. have_option(trim(v_field%option_path) // "/diagnostic/output/checkpoint")) then
+              & .or. have_option(trim(v_field%option_path) // "/diagnostic/output/checkpoint") ) then
                   ! but not aliased
                   if(.not. aliased(v_field)) then
 
-                    if(have_option(trim(complete_field_path(v_field%option_path)) // "/exclude_from_checkpointing")) cycle
-                    ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
+              if(have_option(trim(complete_field_path(v_field%option_path)) // "/exclude_from_checkpointing")) cycle
+              ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
                     if(present_and_true(keep_initial_data) .and. (.not. needs_initial_mesh(v_field) .and. .not. have_option(trim(v_field%option_path) // "/diagnostic/output/checkpoint"))) cycle
 
                     ewrite(2, *) "Checkpointing vector field " // trim(v_field%name) // " in state " // trim(state(i)%name) &
                         & // "on the " // trim(mesh%name)
 
-                    n_pv_fields_on_mesh = n_pv_fields_on_mesh + 1
-                    pv_fields_on_mesh(n_pv_fields_on_mesh) = v_field
+              n_pv_fields_on_mesh = n_pv_fields_on_mesh + 1
+              pv_fields_on_mesh(n_pv_fields_on_mesh) = v_field
 
-                    if(have_option(trim(v_field%option_path) // "/prognostic")) then
-                      ewrite(2, *) "Updating initial conditions for " // trim(v_field%name)
-                      call update_initial_condition_options(trim(v_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(v_field%option_path) // "/prescribed").and. &
-                        & interpolate_field(v_field)) then
-                      ewrite(2, *) "Updating values for " // trim(v_field%name)
-                      call update_value_options(trim(v_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(v_field%option_path) // "/diagnostic/output/checkpoint").and. &
-	                      & interpolate_field(v_field)) then
-                      ewrite(2, *) "... diagnostic field"
-                    else
-                      FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
-                    end if
-                  end if
+              if(have_option(trim(v_field%option_path) // "/prognostic")) then
+                call update_initial_condition_options(trim(v_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(v_field%option_path) // "/prescribed").and.&
+                       interpolate_field(v_field)) then
+                call update_value_options(trim(v_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(v_field%option_path) // "/diagnostic/output/checkpoint").and.&
+                       interpolate_field(v_field)) then
+                ewrite(2, *) "... diagnostic field"
+              else
+                FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
+              end if
+            end if
                 end if
               end if
             end if
@@ -718,34 +718,34 @@ contains
               if(t_field%mesh == mesh) then
                 ! and either the field is prognostic, prescribed and interpolated, or diagnostic and checkpointed
                 if(have_option(trim(t_field%option_path) // "/prognostic") &
-                    & .or. (have_option(trim(t_field%option_path) // "/prescribed") &
+              & .or. (have_option(trim(t_field%option_path) // "/prescribed") &
                     & .and. interpolate_field(t_field)) &
-                    & .or. have_option(trim(t_field%option_path) // "/diagnostic/output/checkpoint")) then
+              & .or. have_option(trim(t_field%option_path) // "/diagnostic/output/checkpoint") ) then
                   ! but not aliased
                   if(.not. aliased(t_field)) then
 
-                    if(have_option(trim(complete_field_path(t_field%option_path)) // "/exclude_from_checkpointing")) cycle
-                    ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
+              if(have_option(trim(complete_field_path(t_field%option_path)) // "/exclude_from_checkpointing")) cycle
+              ! needs_initial_mesh indicates the field is from_file (i.e. we're dealing with a checkpoint)
                     if(present_and_true(keep_initial_data) .and. (.not. needs_initial_mesh(t_field) .and. .not. have_option(trim(t_field%option_path) // "/diagnostic/output/checkpoint"))) cycle
-
+            
                     ewrite(2, *) "Checkpointing tensor field " // trim(t_field%name) // " in state " // trim(state(i)%name) &
                         & // "on the " // trim(mesh%name)
 
-                    n_pt_fields_on_mesh = n_pt_fields_on_mesh + 1
-                    pt_fields_on_mesh(n_pt_fields_on_mesh) = t_field
+              n_pt_fields_on_mesh = n_pt_fields_on_mesh + 1
+              pt_fields_on_mesh(n_pt_fields_on_mesh) = t_field
 
-                    if(have_option(trim(t_field%option_path) // "/prognostic")) then
+              if(have_option(trim(t_field%option_path) // "/prognostic")) then
                       ewrite(2, *) "Updating initial conditions for " // trim(t_field%name)
-                      call update_initial_condition_options(trim(t_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(t_field%option_path) // "/prescribed").and. &
+                call update_initial_condition_options(trim(t_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(t_field%option_path) // "/prescribed").and.&
                         & interpolate_field(t_field)) then
                       ewrite(2, *) "Updating values for " // trim(t_field%name)
-                      call update_value_options(trim(t_field%option_path), trim(vtu_filename), "vtu")
-                    else if (have_option(trim(t_field%option_path) // "/diagnostic/output/checkpoint").and. &
+                call update_value_options(trim(t_field%option_path), trim(vtu_filename), "vtu")
+              else if (have_option(trim(t_field%option_path) // "/diagnostic/output/checkpoint").and.&
                         & interpolate_field(t_field)) then
-                      ewrite(2, *) "... diagnostic field"
-                    else
-                      FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
+                ewrite(2, *) "... diagnostic field"
+              else
+                FLAbort("Can only checkpoint prognostic or prescribed (with interpolation options) fields.")
                     end if
                   end if
                 end if
@@ -819,7 +819,7 @@ contains
 
   end subroutine checkpoint_fields
   
-  subroutine checkpoint_options(prefix, postfix, cp_no, protect_simulation_name)
+  subroutine checkpoint_options(prefix, postfix, cp_no, protect_simulation_name,file_type)
     !!< Checkpoint the entire options tree. Outputs to an FLML file with name:
     !!<   [prefix][_cp_no][_postfix].flml
     !!< where cp_no is optional.
@@ -832,13 +832,21 @@ contains
     !! If present and .false., do not protect the simulation_name when
     !! checkpointing the options tree
     logical, optional, intent(in) :: protect_simulation_name
+    character(len = *), intent(in), optional :: file_type
 
     character(len = OPTION_PATH_LEN) :: simulation_name, options_file_filename
     logical :: lprotect_simulation_name
+    character(len=8) :: lfile_type
 
     ewrite(2, *) "Checkpointing options tree"
 
     assert(len_trim(prefix) > 0)
+
+    if (present(file_type)) then
+       lfile_type=file_type
+    else
+       lfile_type='.flml'
+    end if
 
     lprotect_simulation_name = .not. present_and_false(protect_simulation_name)
 
@@ -855,7 +863,7 @@ contains
     options_file_filename = trim(prefix)
     if(present(cp_no)) options_file_filename = trim(options_file_filename) // "_" // int2str(cp_no)
     if(present_and_nonempty(postfix)) options_file_filename = trim(options_file_filename) // "_" // trim(postfix)
-    options_file_filename = trim(options_file_filename) //  ".flml"
+    options_file_filename = trim(options_file_filename) //  trim(lfile_type)
 
     call write_options(options_file_filename)
 

--- a/femtools/Field_Options.F90
+++ b/femtools/Field_Options.F90
@@ -187,6 +187,10 @@ contains
 
        complete_field_path=trim(path) // "/prescribed"
 
+    else if (have_option(trim(path) // "/aliased")) then
+
+       complete_field_path=trim(path) // "/aliased"
+
     else
       
       if (present(stat)) then

--- a/preprocessor/Populate_State.F90
+++ b/preprocessor/Populate_State.F90
@@ -3170,9 +3170,12 @@ contains
 
   end subroutine compute_domain_statistics
   
-  subroutine populate_state_module_check_options
+  subroutine populate_state_module_check_options(stat)
 
     character(len=OPTION_PATH_LEN) :: problem_type
+    integer, intent(out), optional :: stat
+
+    if (present(stat)) stat=0
 
     ! Check mesh options
     call check_mesh_options
@@ -3180,7 +3183,7 @@ contains
     call check_geometry_options
 
     ! check problem specific options:
-    call get_option("/problem_type", problem_type)
+    call get_option("/problem_type", problem_type, default='none')
     select case (problem_type)
     case ("fluids")
     case ("oceans")
@@ -3196,8 +3199,12 @@ contains
     case ("multiphase")
        call check_multiphase_options
     case default
-       ewrite(0,*) "Problem type:", trim(problem_type)
-       FLAbort("Error unknown problem_type")
+       if (present(stat)) then
+          stat=1
+       else
+          ewrite(0,*) "Problem type:", trim(problem_type)
+          FLAbort("Error unknown problem_type")
+       end if
     end select
     ewrite(2,*) 'Done with problem type choice'
 

--- a/tools/Flredecomp.F90
+++ b/tools/Flredecomp.F90
@@ -118,8 +118,8 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
      output_file_type=input_file_type
   end if
   
-  ewrite(2, "(a)") "Input base name: " // trim(input_base)
-  ewrite(2, "(a)") "Output base name: " // trim(output_base)
+  ewrite(2, "(a)") "Input base name: " // trim(input_base), " type " // trim(input_file_type)
+  ewrite(2, "(a)") "Output base name: " // trim(output_base), " type " // trim(input_file_type)
   ewrite(2, "(a,i0)") "Input number of processes: ", input_nprocs
   ewrite(2, "(a,i0)") "Target number of processes: ", target_nprocs
   ewrite(2, "(a,i0)") "Job number of processes: ", nprocs
@@ -138,8 +138,9 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   end if
   
   ! Load the options tree
-  call load_options(trim(input_base) // trim(input_file_type))
-  if(.not. have_option("/simulation_name")) then
+  call load_options(trim(input_base) // trim(input_file_type))F
+  ! Ignore this error if we're not processing fluidity schema 
+  if(.not. have_option("/simulation_name") .and. trim(input_file_type) == "flml") then
     FLExit("Failed to find simulation name after loading options file")
   end if
 
@@ -170,6 +171,9 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   
   ! Find out how many states there are
   nstates=option_count("/material_phase")
+  ! If we're not processing fluidity schema, then we may not have states
+  ! in the same fashion as fluidity
+  if (nstates == 0 .and. .not. trim(input_file_type) == "flml") nstates = 1
   allocate(state(1:nstates))
   do i = 1, nstates
      call nullify(state(i))

--- a/tools/Flredecomp.F90
+++ b/tools/Flredecomp.F90
@@ -140,7 +140,7 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   ! Load the options tree
   call load_options(trim(input_base) // trim(input_file_type))
   ! Ignore this error if we're not processing fluidity schema 
-  if(.not. have_option("/simulation_name") .and. trim(input_file_type) == "flml") then
+  if(.not. have_option("/simulation_name") .and. trim(input_file_type) == ".flml") then
     FLExit("Failed to find simulation name after loading options file")
   end if
 
@@ -173,7 +173,7 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   nstates=option_count("/material_phase")
   ! If we're not processing fluidity schema, then we may not have states
   ! in the same fashion as fluidity
-  if (nstates == 0 .and. .not. trim(input_file_type) == "flml") nstates = 1
+  if (nstates == 0 .and. .not. trim(input_file_type) == ".flml") nstates = 1
   allocate(state(1:nstates))
   do i = 1, nstates
      call nullify(state(i))

--- a/tools/Flredecomp.F90
+++ b/tools/Flredecomp.F90
@@ -138,7 +138,7 @@ subroutine flredecomp(input_basename, input_basename_len, output_basename, outpu
   end if
   
   ! Load the options tree
-  call load_options(trim(input_base) // trim(input_file_type))F
+  call load_options(trim(input_base) // trim(input_file_type))
   ! Ignore this error if we're not processing fluidity schema 
   if(.not. have_option("/simulation_name") .and. trim(input_file_type) == "flml") then
     FLExit("Failed to find simulation name after loading options file")

--- a/tools/make_check_options.py
+++ b/tools/make_check_options.py
@@ -11,7 +11,7 @@ import StringIO
 
 # File header
 header="""
-subroutine check_options
+subroutine check_options(stat)
 
 """
 footer="""
@@ -42,6 +42,7 @@ fortran_files=glob.glob("*/*.F")+glob.glob("*/*.F90")
 module_re=re.compile(r"^\s*module\s+(\w+)\s*$",re.IGNORECASE|re.MULTILINE)
 
 module_list=[]
+module_arg_list=[]
 
 for filename in fortran_files:
 
@@ -51,9 +52,15 @@ for filename in fortran_files:
 
     for module in modules:
 
-        if re.search(r"^\s*subroutine\s+"+module+"_check_options\s*$",\
+        if re.search(r"^\s*subroutine\s+"+module+"_check_options\S*\s*$",\
                          fortran,\
                          re.IGNORECASE|re.MULTILINE):
+            if re.search(r"^\s*subroutine\s+"+module+"_check_options\S*stat\S*\s*$",\
+                         fortran,\
+                         re.IGNORECASE|re.MULTILINE):
+                module_arg_list.append('stat')
+            else:
+                module_arg_list.append('')
             module_list.append(module)
 
 for module in module_list:
@@ -62,12 +69,16 @@ for module in module_list:
 
 # Ensure that the subroutine is legal in the trivial case.
 output.write("""
+
+
+   integer, optional :: stat
+
    continue
    """)
 
-for module in module_list:
+for module,arg in zip(module_list,module_arg_list):
 
-    output.write("  call "+module+"_check_options\n")
+    output.write("  call "+module+"_check_options(%s)\n"%arg)
 
 output.write(footer)
 


### PR DESCRIPTION
This branch fixes some problems with flredecomp to allow the use of arbritrary schema. Even if the schema has changed significantly compared to the Fluidity base schema, at the very least this change allows you to still decompose a mesh without using fldecomp.

This came out of the Zoltan/PETSc/fldecomp discussion.