### PR TITLE
Mac friendly configuration

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -571,3 +571,5 @@ install-user-schemata:
 	mkdir -p $(HOME)/.diamond/schemata/
 	echo "Fluidity Markup Language" > $(HOME)/.diamond/schemata/flml
 	echo "$(PWD)/schemas/fluidity_options.rng" >> $(HOME)/.diamond/schemata/flml
+
+.PHONY: install

--- a/configure
+++ b/configure
@@ -620,6 +620,7 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+SED
 HYPERLIGHT
 MEMORY_STATS
 MBA3D
@@ -15808,7 +15809,141 @@ fi
 
 #*******************
 
-ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile reduced_modelling/Makefile"
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a sed that does not truncate output" >&5
+$as_echo_n "checking for a sed that does not truncate output... " >&6; }
+if ${ac_cv_path_SED+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+            ac_script=s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/
+     for ac_i in 1 2 3 4 5 6 7; do
+       ac_script="$ac_script$as_nl$ac_script"
+     done
+     echo "$ac_script" 2>/dev/null | sed 99q >conftest.sed
+     { ac_script=; unset ac_script;}
+     if test -z "$SED"; then
+  ac_path_SED_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in sed gsed; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_SED="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_SED" || continue
+# Check for GNU ac_path_SED and select it if it is found.
+  # Check for GNU $ac_path_SED
+case `"$ac_path_SED" --version 2>&1` in
+*GNU*)
+  ac_cv_path_SED="$ac_path_SED" ac_path_SED_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo '' >> "conftest.nl"
+    "$ac_path_SED" -f conftest.sed < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_SED_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_SED="$ac_path_SED"
+      ac_path_SED_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_SED_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_SED"; then
+    as_fn_error $? "no acceptable sed could be found in \$PATH" "$LINENO" 5
+  fi
+else
+  ac_cv_path_SED=$SED
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_SED" >&5
+$as_echo "$ac_cv_path_SED" >&6; }
+ SED="$ac_cv_path_SED"
+  rm -f conftest.sed
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
+$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
+if ${ac_cv_path_GREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -z "$GREP"; then
+  ac_path_GREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in grep ggrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_GREP" || continue
+# Check for GNU ac_path_GREP and select it if it is found.
+  # Check for GNU $ac_path_GREP
+case `"$ac_path_GREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'GREP' >> "conftest.nl"
+    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_GREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_GREP="$ac_path_GREP"
+      ac_path_GREP_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_GREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_GREP"; then
+    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+  fi
+else
+  ac_cv_path_GREP=$GREP
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
+$as_echo "$ac_cv_path_GREP" >&6; }
+ GREP="$ac_cv_path_GREP"
+
+
+
+ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile reduced_modelling/Makefile tests/tools.mk"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -16539,6 +16674,7 @@ do
     "libwm/Makefile") CONFIG_FILES="$CONFIG_FILES libwm/Makefile" ;;
     "libvtkfortran/Makefile") CONFIG_FILES="$CONFIG_FILES libvtkfortran/Makefile" ;;
     "reduced_modelling/Makefile") CONFIG_FILES="$CONFIG_FILES reduced_modelling/Makefile" ;;
+    "tests/tools.mk") CONFIG_FILES="$CONFIG_FILES tests/tools.mk" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure
+++ b/configure
@@ -3040,6 +3040,25 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+case $host_os in
+     darwin* )
+	     LINUX=no
+         DARWIN=yes
+	     FCFLAGS="-DDARWIN $FCFLAGS"
+	     CXXFLAGS="-DDARWIN -fpermissive $CXXFLAGS"
+	     CPPFLAGS="-DDARWIN $CPPFLAGS"
+# Should really check for Mac OS vs. straight Darwin here, or at least test
+# that the framework is valid
+	     LIBS="$LIBS -framework Carbon";;
+     linux*  )
+       LINUX=yes
+       DARWIN=no;;
+     *       )
+       LINUX=no
+	     DARWIN=no;;
+esac
+
+
 # Find compilers
 { $as_echo "$as_me:${as_lineno-$LINENO}: *** Fishing for legacy fortran compiler." >&5
 $as_echo "$as_me: *** Fishing for legacy fortran compiler." >&6;}
@@ -10613,7 +10632,9 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
     FCFLAGS="-fbounds-check -Wall -Wimplicit-interface -Wno-surprising ${FCFLAGS}"
     CFLAGS="-fbounds-check -Wall ${CFLAGS}"
     CXXFLAGS="-fbounds-check -Wall ${CXXFLAGS}"
-    LDFLAGS="-rdynamic ${LDFLAGS}"
+    if test "$DARWIN" = "no" ; then
+        LDFLAGS="-rdynamic ${LDFLAGS}"
+    fi
   elif test "$fcompiler" = "g95" ; then
     FFLAGS="-fbounds-check -ftrace=full ${FFLAGS}"
     FCFLAGS="-fbounds-check -ftrace=full ${FCFLAGS}"

--- a/configure.in
+++ b/configure.in
@@ -80,6 +80,25 @@ FLFEMDEM="femdem"
 # Check system type
 AC_CANONICAL_HOST
 
+case $host_os in
+     darwin* ) 
+	     LINUX=no
+         DARWIN=yes
+	     FCFLAGS="-DDARWIN $FCFLAGS"
+	     CXXFLAGS="-DDARWIN -fpermissive $CXXFLAGS"
+	     CPPFLAGS="-DDARWIN $CPPFLAGS"
+# Should really check for Mac OS vs. straight Darwin here, or at least test
+# that the framework is valid
+	     LIBS="$LIBS -framework Carbon";;
+     linux*  )
+       LINUX=yes
+       DARWIN=no;;
+     *       )
+       LINUX=no
+	     DARWIN=no;;
+esac
+
+
 # Find compilers
 AC_MSG_NOTICE([*** Fishing for legacy fortran compiler.])
 AC_PROG_F77(ifort ifc efc sunf95 gfortran pgf95 pathf95 g95 f90,,f90,$PATH)
@@ -577,7 +596,9 @@ EOF
     FCFLAGS="-fbounds-check -Wall -Wimplicit-interface -Wno-surprising ${FCFLAGS}"
     CFLAGS="-fbounds-check -Wall ${CFLAGS}"
     CXXFLAGS="-fbounds-check -Wall ${CXXFLAGS}"
-    LDFLAGS="-rdynamic ${LDFLAGS}"
+    if test "$DARWIN" = "no" ; then
+        LDFLAGS="-rdynamic ${LDFLAGS}"
+    fi
   elif test "$fcompiler" = "g95" ; then
     FFLAGS="-fbounds-check -ftrace=full ${FFLAGS}"
     FCFLAGS="-fbounds-check -ftrace=full ${FCFLAGS}"

--- a/configure.in
+++ b/configure.in
@@ -1688,6 +1688,10 @@ fi
 
 #*******************
 
+
+AC_PROG_SED
+AC_PROG_GREP
+
 AC_OUTPUT(Makefile
           debug/Makefile
           bathymetry/Makefile
@@ -1719,4 +1723,5 @@ AC_OUTPUT(Makefile
           libjudy/src/JudyHS/Makefile
           libwm/Makefile
           libvtkfortran/Makefile
-	  reduced_modelling/Makefile)
+	  reduced_modelling/Makefile
+	  tests/tools.mk)

--- a/libjudy/Makefile.in
+++ b/libjudy/Makefile.in
@@ -12,3 +12,5 @@ install:
 distclean: clean
 	rm -fr config.h libtool make.log stamp-h1 src/obj src/Judy1/Judy1TablesGen src/JudyL/JudyLTablesGen
 
+.PHONY: install
+

--- a/libwm/Makefile.in
+++ b/libwm/Makefile.in
@@ -52,7 +52,11 @@ TESTLIBS = $(shell echo @LIBS@ | sed 's@./lib/lib\([a-z]*\)\.a@-l\1@g')
 # These are all the objects that are supposed to go into the makefile
 OBJS = Wm4Command.o Wm4FoundationPCH.o \
 Wm4Math.o Wm4Memory.o \
-Wm4System.o Wm4Vector2.o Wm4Vector3.o
+Wm4System.o Wm4Vector2.o Wm4Vector3.o \
+Wm4Intersector.o Wm4Intersector1.o \
+Wm4IntrQuad2Quad2.o \
+Wm4IntrTetrahedron3Tetrahedron3.o \
+Wm4IntrTriangle2Triangle2.o
 
 .SUFFIXES: .f90 .F90 .c .o .a
 

--- a/libwm/Wm4Intersector.cpp
+++ b/libwm/Wm4Intersector.cpp
@@ -106,5 +106,8 @@ class Intersector<double,Vector2d>;
 
 template WM4_FOUNDATION_ITEM
 class Intersector<double,Vector3d>;
+
+template WM4_FOUNDATION_ITEM
+class Intersector<long double,Vector3<long double> >;
 //----------------------------------------------------------------------------
 }

--- a/libwm/Wm4Intersector.h
+++ b/libwm/Wm4Intersector.h
@@ -83,6 +83,5 @@ typedef Intersector<double, Vector3<double> > Intersector3d;
 
 }
 
-#include "Wm4Intersector.cpp"
 
 #endif

--- a/libwm/Wm4Intersector1.h
+++ b/libwm/Wm4Intersector1.h
@@ -71,6 +71,4 @@ typedef Intersector1<double> Intersector1d;
 
 }
 
-#include "Wm4Intersector1.cpp"
-
 #endif

--- a/libwm/Wm4IntrQuad2Quad2.h
+++ b/libwm/Wm4IntrQuad2Quad2.h
@@ -61,6 +61,4 @@ typedef IntrQuad2Quad2<double> IntrQuad2Quad2d;
 
 }
 
-#include "Wm4IntrQuad2Quad2.cpp"
-
 #endif

--- a/libwm/Wm4IntrTetrahedron3Tetrahedron3.h
+++ b/libwm/Wm4IntrTetrahedron3Tetrahedron3.h
@@ -58,6 +58,4 @@ typedef IntrTetrahedron3Tetrahedron3<double> IntrTetrahedron3Tetrahedron3d;
 
 }
 
-#include "Wm4IntrTetrahedron3Tetrahedron3.cpp"
-
 #endif

--- a/libwm/Wm4IntrTriangle2Triangle2.h
+++ b/libwm/Wm4IntrTriangle2Triangle2.h
@@ -106,6 +106,4 @@ typedef IntrTriangle2Triangle2<long double> IntrTriangle2Triangle2ld;
 
 }
 
-#include "Wm4IntrTriangle2Triangle2.cpp"
-
 #endif

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/Makefile
@@ -2,6 +2,8 @@ SHELL = sh
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_fv
 
+include ../tools.mk
+
 # options for 1d mesh interval script for different mesh resolutions
 LEFT_X    = 0.0
 RIGHT_X   = 44.5
@@ -16,7 +18,13 @@ input: clean
 	interval --dx=$(MESH_SIZE_A) $(LEFT_X) $(RIGHT_X) $(SIM)_A
 	interval --dx=$(MESH_SIZE_B) $(LEFT_X) $(RIGHT_X) $(SIM)_B
 	interval --dx=$(MESH_SIZE_C) $(LEFT_X) $(RIGHT_X) $(SIM)_C
-	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D
+	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D	
+	cp $(SIM)_A.flml $(SIM)_B.flml
+	cp $(SIM)_A.flml $(SIM)_C.flml
+	cp $(SIM)_A.flml $(SIM)_D.flml
+	$(SED) -i 's/_A/_B/' $(SIM)_B.flml
+	$(SED) -i 's/_A/_C/' $(SIM)_C.flml
+	$(SED) -i 's/_A/_D/' $(SIM)_D.flml
 
 clean:
 	rm -f $(SIM)*.ele
@@ -39,3 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
+	rm -f $(SIM)_{BCD}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/add_src_directly_1d_2grp_hom_zerobc_eig_fv.xml
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/add_src_directly_1d_2grp_hom_zerobc_eig_fv.xml
@@ -8,27 +8,9 @@
   <problem_definition length="short" nprocs="1">
     <command_line>
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_fv_A.flml 
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_fv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_fv_B.flml
-sed -i 's/_A/_B/' add_src_directly_1d_2grp_hom_zerobc_eig_fv_B.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_fv_B.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_fv_B.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_fv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_fv_C.flml
-sed -i 's/_A/_C/' add_src_directly_1d_2grp_hom_zerobc_eig_fv_C.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_fv_C.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_fv_C.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_fv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_fv_D.flml
-sed -i 's/_A/_D/' add_src_directly_1d_2grp_hom_zerobc_eig_fv_D.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_fv_D.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_fv_D.flml       
     </command_line>
     <!-- Two field diffusion eigenvalue problem with one material, two groups no upscatter with all zero BC using a 1d geometry compared to PANTHER reference solution for the Eigenvalue and also the fine mesh linear fv solution for different mesh resolutions. This tests adding the src directly to the rhs. -->
   </problem_definition>

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/Makefile
@@ -2,6 +2,8 @@ SHELL = sh
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1cg
 
+include ../tools.mk
+
 # options for 1d mesh interval script for different mesh resolutions
 LEFT_X    = 0.0
 RIGHT_X   = 44.5
@@ -16,7 +18,13 @@ input: clean
 	interval --dx=$(MESH_SIZE_A) $(LEFT_X) $(RIGHT_X) $(SIM)_A
 	interval --dx=$(MESH_SIZE_B) $(LEFT_X) $(RIGHT_X) $(SIM)_B
 	interval --dx=$(MESH_SIZE_C) $(LEFT_X) $(RIGHT_X) $(SIM)_C
-	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D
+	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D	
+	cp $(SIM)_A.flml $(SIM)_B.flml
+	cp $(SIM)_A.flml $(SIM)_C.flml
+	cp $(SIM)_A.flml $(SIM)_D.flml
+	$(SED) -i 's/_A/_B/' $(SIM)_B.flml
+	$(SED) -i 's/_A/_C/' $(SIM)_C.flml
+	$(SED) -i 's/_A/_D/' $(SIM)_D.flml
 
 clean:
 	rm -f $(SIM)*.ele
@@ -39,3 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
+	rm -f $(SIM)_{BCD}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg.xml
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg.xml
@@ -8,27 +8,9 @@
   <problem_definition length="short" nprocs="1">
     <command_line>
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_A.flml 
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_B.flml
-sed -i 's/_A/_B/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_B.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_B.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_B.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_C.flml
-sed -i 's/_A/_C/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_C.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_C.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_C.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_D.flml
-sed -i 's/_A/_D/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_D.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_D.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cg_D.flml       
     </command_line>
     <!-- Two field diffusion eigenvalue problem with one material, two groups no upscatter with all zero BC using a 1d geometry compared to PANTHER reference solution for the Eigenvalue and also the fine mesh linear cg solution for different mesh resolutions. This tests adding the src directly to the rhs. -->
   </problem_definition>

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/Makefile
@@ -2,6 +2,8 @@ SHELL = sh
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1cv
 
+include ../tools.mk
+
 # options for 1d mesh interval script for different mesh resolutions
 LEFT_X    = 0.0
 RIGHT_X   = 44.5
@@ -16,7 +18,13 @@ input: clean
 	interval --dx=$(MESH_SIZE_A) $(LEFT_X) $(RIGHT_X) $(SIM)_A
 	interval --dx=$(MESH_SIZE_B) $(LEFT_X) $(RIGHT_X) $(SIM)_B
 	interval --dx=$(MESH_SIZE_C) $(LEFT_X) $(RIGHT_X) $(SIM)_C
-	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D
+	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D	
+	cp $(SIM)_A.flml $(SIM)_B.flml
+	cp $(SIM)_A.flml $(SIM)_C.flml
+	cp $(SIM)_A.flml $(SIM)_D.flml
+	$(SED) -i 's/_A/_B/' $(SIM)_B.flml
+	$(SED) -i 's/_A/_C/' $(SIM)_C.flml
+	$(SED) -i 's/_A/_D/' $(SIM)_D.flml
 
 clean:
 	rm -f $(SIM)*.ele
@@ -39,3 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
+	rm -f $(SIM)_{BCD}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv.xml
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv.xml
@@ -8,27 +8,9 @@
   <problem_definition length="short" nprocs="1">
     <command_line>
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_A.flml 
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_B.flml
-sed -i 's/_A/_B/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_B.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_B.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_B.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_C.flml
-sed -i 's/_A/_C/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_C.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_C.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_C.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_D.flml
-sed -i 's/_A/_D/' add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_D.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_D.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1cv_D.flml       
     </command_line>
     <!-- Two field diffusion eigenvalue problem with one material, two groups no upscatter with all zero BC using a 1d geometry compared to PANTHER reference solution for the Eigenvalue and also the fine mesh linear cv solution for different mesh resolutions. This tests adding the src directly to the rhs. -->
   </problem_definition>

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/Makefile
@@ -2,6 +2,8 @@ SHELL = sh
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1dg
 
+include ../tools.mk
+
 # options for 1d mesh interval script for different mesh resolutions
 LEFT_X    = 0.0
 RIGHT_X   = 44.5
@@ -16,7 +18,13 @@ input: clean
 	interval --dx=$(MESH_SIZE_A) $(LEFT_X) $(RIGHT_X) $(SIM)_A
 	interval --dx=$(MESH_SIZE_B) $(LEFT_X) $(RIGHT_X) $(SIM)_B
 	interval --dx=$(MESH_SIZE_C) $(LEFT_X) $(RIGHT_X) $(SIM)_C
-	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D
+	interval --dx=$(MESH_SIZE_D) $(LEFT_X) $(RIGHT_X) $(SIM)_D	
+	cp $(SIM)_A.flml $(SIM)_B.flml
+	cp $(SIM)_A.flml $(SIM)_C.flml
+	cp $(SIM)_A.flml $(SIM)_D.flml
+	$(SED) -i 's/_A/_B/' $(SIM)_B.flml
+	$(SED) -i 's/_A/_C/' $(SIM)_C.flml
+	$(SED) -i 's/_A/_D/' $(SIM)_D.flml
 
 clean:
 	rm -f $(SIM)*.ele
@@ -39,3 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
+	rm -f $(SIM)_{BCD}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg.xml
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg.xml
@@ -8,27 +8,9 @@
   <problem_definition length="short" nprocs="1">
     <command_line>
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_A.flml 
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_B.flml
-sed -i 's/_A/_B/' add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_B.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_B.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_B.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_C.flml
-sed -i 's/_A/_C/' add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_C.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_C.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_C.flml
-
-cp add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_A.flml add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_D.flml
-sed -i 's/_A/_D/' add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_D.flml
-
 ../../bin/fluidity add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_D.flml 
-
-rm -f add_src_directly_1d_2grp_hom_zerobc_eig_p1dg_D.flml       
     </command_line>
     <!-- Two field diffusion eigenvalue problem with one material, two groups no upscatter with all zero BC using a 1d geometry compared to PANTHER reference solution for the Eigenvalue and also the fine mesh linear dg solution for different mesh resolutions. This tests adding the src directly to the rhs. -->
   </problem_definition>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -68,7 +68,7 @@ p2p1_gauss_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]
     <test name="p1dgp2_gauss_3d_pressure" language="python">assert p1dgp2_gauss_3d_pressure_error/p1dgp2_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p1dgp2_nodal_3d_velocity" language="python">assert abs(p1dgp2_nodal_3d_velocity_error - 0.15) &lt; 1.e-2</test>
     <test name="p1dgp2_gauss_3d_velocity" language="python">assert p1dgp2_gauss_3d_velocity_error/p1dgp2_nodal_3d_velocity_error &lt; 1.e-6</test>
-    <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.e-2</test>
+    <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.1e-2</test>
     <test name="p2p1_gauss_3d_pressure" language="python">assert p2p1_gauss_3d_pressure_error/p2p1_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_3d_velocity" language="python">assert abs(p2p1_nodal_3d_velocity_error - 1.31) &lt; 1.e-2</test>
     <test name="p2p1_gauss_3d_velocity" language="python">assert p2p1_gauss_3d_velocity_error/p2p1_nodal_3d_velocity_error &lt; 1.e-6</test>

--- a/tests/geopressure_convergence/Makefile
+++ b/tests/geopressure_convergence/Makefile
@@ -1,3 +1,5 @@
+include ../tools.mk
+
 default: input
 
 input:
@@ -7,14 +9,14 @@ input:
 	../../bin/triangle2gmsh square-32
 	../../bin/triangle2gmsh square-64
 	cp geopressure_8.flml geopressure_16.flml 
-	sed -i "s/"geopressure_8"/"geopressure_16"/g" geopressure_16.flml 
-	sed -i "s/square-8/square-16/g" geopressure_16.flml 
+	$(SED) -i "s/"geopressure_8"/"geopressure_16"/g" geopressure_16.flml 
+	$(SED) -i "s/square-8/square-16/g" geopressure_16.flml 
 	cp geopressure_8.flml geopressure_32.flml 
-	sed -i "s/"geopressure_8"/"geopressure_32"/g" geopressure_32.flml 
-	sed -i "s/square-8/square-32/g" geopressure_32.flml 
+	$(SED) -i "s/"geopressure_8"/"geopressure_32"/g" geopressure_32.flml 
+	$(SED) -i "s/square-8/square-32/g" geopressure_32.flml 
 	cp geopressure_8.flml geopressure_64.flml 
-	sed -i "s/"geopressure_8"/"geopressure_64"/g" geopressure_64.flml 
-	sed -i "s/square-8/square-64/g" geopressure_64.flml
+	$(SED) -i "s/"geopressure_8"/"geopressure_64"/g" geopressure_64.flml 
+	$(SED) -i "s/square-8/square-64/g" geopressure_64.flml
 
 
 clean: clean-mesh clean-run-debug

--- a/tests/geopressure_convergence_p1/Makefile
+++ b/tests/geopressure_convergence_p1/Makefile
@@ -1,3 +1,5 @@
+include ../tools.mk
+
 default: input
 
 input:
@@ -7,14 +9,14 @@ input:
 	../../bin/triangle2gmsh square-32
 	../../bin/triangle2gmsh square-64
 	cp geopressure_8.flml geopressure_16.flml 
-	sed -i "s/"geopressure_8"/"geopressure_16"/g" geopressure_16.flml 
-	sed -i "s/square-8/square-16/g" geopressure_16.flml 
+	$(SED) -i "s/"geopressure_8"/"geopressure_16"/g" geopressure_16.flml 
+	$(SED) -i "s/square-8/square-16/g" geopressure_16.flml 
 	cp geopressure_8.flml geopressure_32.flml 
-	sed -i "s/"geopressure_8"/"geopressure_32"/g" geopressure_32.flml 
-	sed -i "s/square-8/square-32/g" geopressure_32.flml 
+	$(SED) -i "s/"geopressure_8"/"geopressure_32"/g" geopressure_32.flml 
+	$(SED) -i "s/square-8/square-32/g" geopressure_32.flml 
 	cp geopressure_8.flml geopressure_64.flml 
-	sed -i "s/"geopressure_8"/"geopressure_64"/g" geopressure_64.flml 
-	sed -i "s/square-8/square-64/g" geopressure_64.flml
+	$(SED) -i "s/"geopressure_8"/"geopressure_64"/g" geopressure_64.flml 
+	$(SED) -i "s/square-8/square-64/g" geopressure_64.flml
 
 
 clean: clean-mesh clean-run-debug

--- a/tests/geopressure_convergence_p3/Makefile
+++ b/tests/geopressure_convergence_p3/Makefile
@@ -1,3 +1,5 @@
+include ../tools.mk
+
 FLMLMODEL1 = geopressure_8
 FLMLMODEL2 = geopressure_16
 FLMLMODEL3 = geopressure_32
@@ -12,14 +14,14 @@ input:
 	../../bin/triangle2gmsh square-32
 	../../bin/triangle2gmsh square-64
 	cp $(FLMLMODEL1).flml $(FLMLMODEL2).flml 
-	sed -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL2)"/g" $(FLMLMODEL2).flml 
-	sed -i "s/square-8/square-16/g" $(FLMLMODEL2).flml 
+	$(SED) -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL2)"/g" $(FLMLMODEL2).flml 
+	$(SED) -i "s/square-8/square-16/g" $(FLMLMODEL2).flml 
 	cp $(FLMLMODEL1).flml $(FLMLMODEL3).flml 
-	sed -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL3)"/g" $(FLMLMODEL3).flml 
-	sed -i "s/square-8/square-32/g" $(FLMLMODEL3).flml 
+	$(SED) -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL3)"/g" $(FLMLMODEL3).flml 
+	$(SED) -i "s/square-8/square-32/g" $(FLMLMODEL3).flml 
 	cp $(FLMLMODEL1).flml $(FLMLMODEL4).flml 
-	sed -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL4)"/g" $(FLMLMODEL4).flml 
-	sed -i "s/square-8/square-64/g" $(FLMLMODEL4).flml 
+	$(SED) -i "s/"$(FLMLMODEL1)"/"$(FLMLMODEL4)"/g" $(FLMLMODEL4).flml 
+	$(SED) -i "s/square-8/square-64/g" $(FLMLMODEL4).flml 
 
 clean: clean-mesh clean-run-debug
 	rm -f $(FLMLMODEL2).flml

--- a/tests/petsc_readnsolve/Makefile
+++ b/tests/petsc_readnsolve/Makefile
@@ -1,3 +1,5 @@
+include ../tools.mk
+
 input: clean
 	gmsh -3 -bin src/standing_wave.geo -o standing_wave.msh
 
@@ -11,3 +13,7 @@ clean:
 	rm -f velocity_matrixdump pressure_matrixdump
 	rm -rf standing_wave_[0-9]*
 	rm -rf *flredecomp*
+
+mesh_rename:
+	$(SED) --in-place s/failing_velocity_flredecomp_CoordinateMesh/flredecomp_CoordinateMesh/g standing_wave_failing_velocity_flredecomp.flml;
+	$(SED) --in-place s/failing_pressure_flredecomp_CoordinateMesh/flredecomp_CoordinateMesh/g standing_wave_failing_pressure_flredecomp.flml;

--- a/tests/petsc_readnsolve/petsc_readnsolve.xml
+++ b/tests/petsc_readnsolve/petsc_readnsolve.xml
@@ -8,8 +8,7 @@
     <command_line>mpiexec ../../bin/flredecomp -i 1 -o 4 -v -l standing_wave_failing_velocity standing_wave_failing_velocity_flredecomp;
 mpiexec ../../bin/flredecomp -i 1 -o 4 -v -l standing_wave_failing_pressure standing_wave_failing_pressure_flredecomp;
 mpiexec ../../bin/flredecomp -i 1 -o 4 -v -l standing_wave standing_wave_flredecomp;
-sed --in-place s/failing_velocity_flredecomp_CoordinateMesh/flredecomp_CoordinateMesh/g standing_wave_failing_velocity_flredecomp.flml;
-sed --in-place s/failing_pressure_flredecomp_CoordinateMesh/flredecomp_CoordinateMesh/g standing_wave_failing_pressure_flredecomp.flml;
+make mesh_rename
 rm -f *failing_velocity_flredecomp_CoordinateMesh* *failing_pressure_flredecomp_CoordinateMesh*
 ( mpiexec fluidity -v2 -l standing_wave_failing_velocity_flredecomp.flml 2&gt;&amp;1 ) &gt; /dev/null;
 mv matrixdump velocity_matrixdump;

--- a/tests/python_shape_dshape_test/Makefile
+++ b/tests/python_shape_dshape_test/Makefile
@@ -1,0 +1,14 @@
+include ../tools.mk
+
+input: clean meshes copy_tests
+
+meshes:
+	cd src; make
+
+copy_tests:
+	cp test_A.swml test_B.swml; ${SED} -i 's/_A/_B/' test_B.swml
+	cp test_A.swml test_C.swml; ${SED} -i 's/_A/_C/' test_C.swml
+	cp test_A.swml test_D.swml; ${SED} -i 's/_A/_D/' test_D.swml
+
+clean:
+	rm -f *.vtu *.stat src/*.bound src/*.ele src/*.node test_[BCD].swml

--- a/tests/python_shape_dshape_test_2d/Makefile
+++ b/tests/python_shape_dshape_test_2d/Makefile
@@ -1,0 +1,14 @@
+include ../tools.mk
+
+input: clean meshes copy_tests
+
+meshes:
+	cd src; make
+
+copy_tests:
+	cp test_A.swml test_B.swml; ${SED} -i 's/_A/_B/' test_B.swml
+	cp test_A.swml test_C.swml; ${SED} -i 's/_A/_C/' test_C.swml
+	cp test_A.swml test_D.swml; ${SED} -i 's/_A/_D/' test_D.swml
+
+clean:
+	rm -f *.vtu *.stat src/*.edge src/*.ele src/*.msh src/*.node test_[BCD].swml

--- a/tests/tools.mk.in
+++ b/tests/tools.mk.in
@@ -1,0 +1,2 @@
+FC = @FC@
+SED= @SED@


### PR DESCRIPTION
A collection of changes to configure etc. to make building on Mac OSX easier. These come in two flavours:
1) Changes required due to a BSD-based environment in which the gnu toolchain may be harder to find, for which there are variations in compiler flags
2) Changes to deal with the possibility of a case-insensitive file system.

There are also two changes to tests proposed, one to deal with problems accessing lib spud from inside the embedded python interpreter and a tolerance relaxation to one of @cianwilson's tests.

@tmbgreaves Could I get a buildbot queue for this as well please?