### PR TITLE
Fix momentum subcycling weak bcs

### DIFF
--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -3054,7 +3054,7 @@ contains
         ! filter wiggles from u
         do d =1, mesh_dim(u)
         u_cpt = extract_scalar_field_from_vector_field(u_sub,d)
-        !call limit_vb(state,u_cpt)
+        call limit_vb(state,u_cpt)
         end do
 
       end if

--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -111,9 +111,6 @@ module momentum_DG
   ! Parameters for interior penalty method
   real :: Interior_Penalty_Parameter, edge_length_power, h0
 
-  ! Flag indicating whether equations are being solved in acceleration form.
-  logical :: acceleration
-
   ! Flag indicating whether to include pressure bcs (not for cv pressure)
   logical :: l_include_pressure_bcs
   
@@ -153,11 +150,9 @@ contains
   subroutine construct_momentum_dg(u, p, rho, x, &
        & big_m, rhs, state, &
        & inverse_masslump, inverse_mass, mass, &
-       & acceleration_form, include_pressure_bcs,&
-       & subcycle_m)
+       & include_pressure_bcs, subcycle_m, subcycle_rhs)
     !!< Construct the momentum equation for discontinuous elements in
-    !!< acceleration form. If acceleration_form is present and false, the
-    !!< matrices will be constructed for use in conventional solution form.
+    !!< acceleration form.
 
     !! velocity and coordinate
     type(vector_field), intent(inout) :: u, x
@@ -170,6 +165,8 @@ contains
     type(block_csr_matrix), intent(inout), optional :: subcycle_m
     !! Momentum right hand side vector for each point.
     type(vector_field), intent(inout) :: rhs
+    !! Right hand side vector containing advection bc terms if subcycling
+    type(vector_field), intent(inout), optional :: subcycle_rhs
     !! Collection of fields defining system state.
     type(state_type) :: state
     
@@ -188,15 +185,6 @@ contains
 
     !! whether to include the dirichlet pressure bc integrals to the rhs
     logical, intent(in), optional :: include_pressure_bcs
-
-    !! Optional indicator of whether we are solving in acceleration form.
-    !!
-    !! If not solving in acceleration form then big_m will be formed with
-    !! an effective theta of 1.0 and dt of 1.0 . In addition, only boundary
-    !! terms will be inserted on the right hand side. This is sufficient to
-    !! enable the full discrete equations to be written using matrix
-    !! multiplies outside this routine.
-    logical, intent(in), optional :: acceleration_form
 
     !! Position, velocity and source fields.
     type(vector_field), pointer :: U_mesh, X_old, X_new
@@ -266,7 +254,9 @@ contains
     type(integer_set), dimension(:), pointer :: colours
     integer :: len, clr, nnid
     !! Is the transform_to_physical cache we prepopulated valid
+#ifdef _OPENMP
     logical :: cache_valid
+#endif
     integer :: num_threads
 
     ! Volume fraction fields for multi-phase flow simulation
@@ -280,9 +270,6 @@ contains
 
     call profiler_tic("construct_momentum_dg")
     assert(continuity(u)<0)
-
-    acceleration= .not. present_and_false(acceleration_form)
-    ewrite(2, *) "Acceleration form? ", acceleration
 
     if(present(include_pressure_bcs)) then
       l_include_pressure_bcs = include_pressure_bcs
@@ -495,14 +482,9 @@ contains
     on_sphere = have_option('/geometry/spherical_earth/')
 
     ! Extract model parameters from options dictionary.
-    if (acceleration) then
-       call get_option(trim(U%option_path)//&
-            &"/prognostic/temporal_discretisation/theta", theta)
-       call get_option("/timestepping/timestep", dt)
-    else
-       theta=1.0
-       dt=1.0
-    end if
+    call get_option(trim(U%option_path)//&
+        &"/prognostic/temporal_discretisation/theta", theta)
+    call get_option("/timestepping/timestep", dt)
 
     have_mass = .not. have_option(trim(u%option_path)//&
         &"/prognostic/spatial_discretisation"//&
@@ -621,12 +603,18 @@ contains
     assert(has_faces(P%mesh))
 
     call zero(big_m)
+    call zero(RHS)
+
     subcycle=.false.
     if(present(subcycle_m)) subcycle=.true.
+
     if(subcycle) then
        call zero(subcycle_m)
+       if (.not. present(subcycle_rhs)) then
+         FLAbort("Need to call construct_momentum_dg with both subcycle_m and subcycle_rhs")
+       end if
+       call zero(subcycle_rhs)
     end if
-    call zero(RHS)
     
     if(present(inverse_masslump) .and. lump_mass) then
        call allocate(inverse_masslump, u%dim, u%mesh, "InverseLumpedMass")
@@ -725,7 +713,8 @@ contains
             & alpha_u_field, Abs_wd, vvr_sf, ib_min_grad, nvfrac, &
             & inverse_mass=inverse_mass, &
             & inverse_masslump=inverse_masslump, &
-            & mass=mass, subcycle_m=subcycle_m, partial_stress=partial_stress)
+            & mass=mass, subcycle_m=subcycle_m, subcycle_rhs=subcycle_rhs, &
+            & partial_stress=partial_stress)
       end do element_loop
       !$OMP END DO
 
@@ -782,7 +771,7 @@ contains
        &pressure_bc, pressure_bc_type, &
        &turbine_conn_mesh, depth, have_wd_abs, alpha_u_field, Abs_wd, &
        &vvr_sf, ib_min_grad, nvfrac, &
-       &inverse_mass, inverse_masslump, mass, subcycle_m, partial_stress)
+       &inverse_mass, inverse_masslump, mass, subcycle_m, subcycle_rhs, partial_stress)
 
     !!< Construct the momentum equation for discontinuous elements in
     !!< acceleration form.
@@ -798,6 +787,7 @@ contains
     type(mesh_type), intent(in) :: turbine_conn_mesh
     !! 
     type(block_csr_matrix), intent(inout), optional :: subcycle_m
+    type(vector_field), intent(inout), optional :: subcycle_rhs
 
     !! Position, velocity and source fields.
     type(scalar_field), intent(in) :: buoyancy
@@ -916,6 +906,8 @@ contains
     ! go, so that we only do the calculations we really need
     real, dimension(u%dim, ele_and_faces_loc(U,ele)) :: big_m_diag_addto,&
          & rhs_addto
+    ! rhs terms for subcycling coming from advection bc terms
+    real, dimension(u%dim, ele_loc(U, ele)) :: subcycle_rhs_addto
     
     real, dimension(u%dim, u%dim, ele_and_faces_loc(U,ele), ele_and_faces_loc(U,ele)) :: big_m_tensor_addto
     logical, dimension(u%dim, u%dim) :: diagonal_block_mask, off_diagonal_block_mask
@@ -1000,11 +992,11 @@ contains
 
     big_m_diag_addto = 0.0
     big_m_tensor_addto = 0.0
+    rhs_addto = 0.0
     if(subcycle) then
        subcycle_m_tensor_addto = 0.0
+       subcycle_rhs_addto = 0.0
     end if
-
-    rhs_addto = 0.0
     
     diagonal_block_mask = .false.
     do dim = 1, u%dim
@@ -1170,10 +1162,8 @@ contains
       big_m_tensor_addto(U_, V_, :loc, :loc) = big_m_tensor_addto(U_, V_, :loc, :loc) - dt*theta*coriolis_mat
       big_m_tensor_addto(V_, U_, :loc, :loc) = big_m_tensor_addto(V_, U_, :loc, :loc) + dt*theta*coriolis_mat
 
-      if(acceleration)then
-        rhs_addto(U_, :loc) = rhs_addto(U_, :loc) + matmul(coriolis_mat, u_val(V_,:))
-        rhs_addto(V_, :loc) = rhs_addto(V_, :loc) - matmul(coriolis_mat, u_val(U_,:))
-      end if
+      rhs_addto(U_, :loc) = rhs_addto(U_, :loc) + matmul(coriolis_mat, u_val(V_,:))
+      rhs_addto(V_, :loc) = rhs_addto(V_, :loc) - matmul(coriolis_mat, u_val(U_,:))
     end if
 
     if(have_advection.and.(.not.p0).and.assemble_element) then
@@ -1284,15 +1274,14 @@ contains
             big_m_tensor_addto(dim, dim, :loc, :loc) &
                  &= big_m_tensor_addto(dim, dim, :loc, :loc) &
                  &+ dt*theta*advection_mat
+            rhs_addto(dim, :loc) = rhs_addto(dim, :loc) &
+                 &- matmul(advection_mat, u_val(dim,:))
          end if
-        if(acceleration.and..not.subcycle) then
-          rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(advection_mat, u_val(dim,:))
-        end if
       end do
 
     end if
 
-    if(have_source.and.acceleration.and.assemble_element) then
+    if(have_source .and. assemble_element) then
       ! Momentum source matrix.
       Source_mat = shape_shape(U_shape, ele_shape(Source,ele), detwei*Rho_q)
       if(lump_source) then
@@ -1309,7 +1298,7 @@ contains
       end if
     end if
 
-    if(have_gravity.and.acceleration.and.assemble_element) then
+    if(have_gravity .and. assemble_element) then
       ! buoyancy
       if(subtract_out_reference_profile) then
          coefficient_detwei = detwei*gravity_magnitude*(ele_val_at_quad(buoyancy, ele)-ele_val_at_quad(hb_density, ele))
@@ -1445,14 +1434,12 @@ contains
                     & dt*theta*Abs_lump_sphere(dim,dim2,i)
                 end do
               end do
-              if (acceleration) then
-                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - Abs_lump_sphere(dim,dim,:)*u_val(dim,:)
-                ! off block diagonal absorption terms
-                do dim2 = 1, u%dim
-                  if (dim==dim2) cycle ! The dim=dim2 terms were done above
-                  rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - Abs_lump_sphere(dim,dim2,:)*u_val(dim2,:)
-                end do
-              end if
+              rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - Abs_lump_sphere(dim,dim,:)*u_val(dim,:)
+              ! off block diagonal absorption terms
+              do dim2 = 1, u%dim
+                if (dim==dim2) cycle ! The dim=dim2 terms were done above
+                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - Abs_lump_sphere(dim,dim2,:)*u_val(dim2,:)
+              end do
             end do
           end if
           if (present(inverse_masslump) .and. pressure_corrected_absorption) then
@@ -1477,14 +1464,12 @@ contains
                 big_m_tensor_addto(dim, dim2, :loc, :loc) = big_m_tensor_addto(dim, dim2, :loc, :loc) + &
                   & dt*theta*Abs_mat_sphere(dim,dim2,:,:)
               end do
-              if (acceleration) then
-                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat_sphere(dim,dim,:,:), u_val(dim,:))
-                ! off block diagonal absorption terms
-                do dim2 = 1, u%dim
-                  if (dim==dim2) cycle ! The dim=dim2 terms were done above
-                  rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat_sphere(dim,dim2,:,:), u_val(dim2,:))
-                end do
-              end if
+              rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat_sphere(dim,dim,:,:), u_val(dim,:))
+              ! off block diagonal absorption terms
+              do dim2 = 1, u%dim
+                if (dim==dim2) cycle ! The dim=dim2 terms were done above
+                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat_sphere(dim,dim2,:,:), u_val(dim2,:))
+              end do
             end do
           end if
           Abs_lump_sphere = 0.0
@@ -1518,9 +1503,7 @@ contains
           do dim = 1, u%dim
             if (assemble_element) then
               big_m_diag_addto(dim, :loc) = big_m_diag_addto(dim, :loc) + dt*theta*abs_lump(dim,:)
-              if(acceleration) then
-                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - abs_lump(dim,:)*u_val(dim,:)
-              end if
+              rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - abs_lump(dim,:)*u_val(dim,:)
             end if
             if (present(inverse_masslump) .and. pressure_corrected_absorption) then
               assert(lump_mass)
@@ -1540,9 +1523,7 @@ contains
             if (assemble_element) then
               big_m_tensor_addto(dim, dim, :loc, :loc) = big_m_tensor_addto(dim, dim, :loc, :loc) + &
                 & dt*theta*Abs_mat(dim,:,:)
-              if(acceleration) then
-                rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat(dim,:,:), u_val(dim,:))
-              end if
+              rhs_addto(dim, :loc) = rhs_addto(dim, :loc) - matmul(Abs_mat(dim,:,:), u_val(dim,:))
             end if
             if (present(inverse_mass) .and. pressure_corrected_absorption) then
               assert(.not. lump_mass)
@@ -1768,7 +1749,7 @@ contains
                         & Rho, U, U_nl, U_mesh, P, q_mesh, surfacetension, &
                         & velocity_bc, velocity_bc_type, &
                         & pressure_bc, pressure_bc_type, hb_pressure, &
-                        & subcycle_m_tensor_addto, nvfrac, &
+                        & subcycle_m_tensor_addto, subcycle_rhs_addto, nvfrac, &
                         & ele2grad_mat=ele2grad_mat, kappa_mat=kappa_mat, &
                         & inverse_mass_mat=inverse_mass_mat, &
                         & viscosity=viscosity, viscosity_mat=viscosity_mat)
@@ -1781,7 +1762,7 @@ contains
                         & Rho, U, U_nl, U_mesh, P, q_mesh, surfacetension, &
                         & velocity_bc, velocity_bc_type, &
                         & pressure_bc, pressure_bc_type, hb_pressure, &
-                        & subcycle_m_tensor_addto, nvfrac)
+                        & subcycle_m_tensor_addto, subcycle_rhs_addto, nvfrac)
             end if
         end if
 
@@ -1878,15 +1859,13 @@ contains
         ! Insert viscosity in matrix.
         big_m_tensor_addto = big_m_tensor_addto + Viscosity_mat*theta*dt
         
-        if (acceleration) then
-          do dim1=1,U%dim
-            do dim2=1, U%dim
-              rhs_addto(dim1, :) = rhs_addto(dim1, :) &
-                   - matmul(Viscosity_mat(dim1,dim2,:,:), &
-                   node_val(U, dim2, local_glno))
-            end do
+        do dim1=1,U%dim
+          do dim2=1, U%dim
+            rhs_addto(dim1, :) = rhs_addto(dim1, :) &
+                 - matmul(Viscosity_mat(dim1,dim2,:,:), &
+                 node_val(U, dim2, local_glno))
           end do
-        end if
+        end do
         
      end if !have_viscosity
     
@@ -1927,6 +1906,7 @@ contains
              call addto(subcycle_m, u_ele, local_glno,&
                   &subcycle_m_tensor_addto(:,:,:loc,:), &
                   &block_mask=diagonal_block_mask)
+             call addto(subcycle_rhs, u_ele, subcycle_rhs_addto)
           end if
           if(.not. partial_stress .and. have_coriolis) then
             ! add in coupling between different components, but only within the element
@@ -2050,7 +2030,7 @@ contains
        & U_nl, U_mesh, P, q_mesh, surfacetension, &
        & velocity_bc, velocity_bc_type, &
        & pressure_bc, pressure_bc_type, hb_pressure, &
-       & subcycle_m_tensor_addto, nvfrac, &
+       & subcycle_m_tensor_addto, subcycle_rhs_addto, nvfrac, &
        & ele2grad_mat, kappa_mat, inverse_mass_mat, &
        & viscosity, viscosity_mat)
     !!< Construct the DG element boundary integrals on the ni-th face of
@@ -2062,7 +2042,7 @@ contains
     integer, intent(in) :: ele, face, face_2, ni
     real, dimension(:,:,:,:), intent(inout) :: big_m_tensor_addto
     real, dimension(:,:,:,:), intent(inout) :: subcycle_m_tensor_addto
-    real, dimension(:,:) :: rhs_addto
+    real, dimension(:,:), intent(inout) :: rhs_addto, subcycle_rhs_addto
     real, dimension(:,:,:), intent(inout) :: Grad_U_mat, Div_U_mat
     ! We pass these additional fields to save on state lookups.
     type(vector_field), intent(in) :: X, U, U_nl
@@ -2307,9 +2287,7 @@ contains
 
       do dim = 1, u%dim
       
-        ! Insert advection in matrix.
-    
-        ! Outflow boundary integral.
+         ! Insert advection in matrix.
          if(subcycle) then
             subcycle_m_tensor_addto(dim, dim, u_face_l, u_face_l) = &
                  &subcycle_m_tensor_addto(dim, dim, u_face_l, u_face_l) + &
@@ -2319,6 +2297,13 @@ contains
                subcycle_m_tensor_addto(dim, dim, u_face_l, start:finish) = &
                     &subcycle_m_tensor_addto(dim, dim, u_face_l, start:finish)&
                     &+nnAdvection_in
+            else
+               ! on a Dirichlet boundary, the incoming advection term
+               ! on the lhs is replaced by the same term on the right using
+               ! the boundary value - outgoing term is the same as always
+               ! (meaning no dirichlet bc is applied on outgoing facets)
+               subcycle_rhs_addto(dim,u_face_l) = subcycle_rhs_addto(dim,u_face_l) &
+                    -matmul(nnAdvection_in,ele_val(velocity_bc,dim,face))
             end if
          else
             big_m_tensor_addto(dim, dim, u_face_l, u_face_l) = &
@@ -2329,28 +2314,17 @@ contains
                big_m_tensor_addto(dim, dim, u_face_l, start:finish) = &
                     big_m_tensor_addto(dim, dim, u_face_l, start:finish) + &
                     nnAdvection_in*dt*theta
-            end if
-        
-            if (.not.dirichlet(dim)) then
-               ! For interior interfaces this is the upwinding term. For a
-               ! Neumann boundary it's necessary to apply downwinding here
-               ! to maintain the surface integral. Fortunately, since
-               ! face_2==face for a boundary this is automagic.
-
-               if (acceleration) then
-                  rhs_addto(dim,u_face_l) = rhs_addto(dim,u_face_l) &
-                       ! Outflow boundary integral.
-                       -matmul(nnAdvection_out,face_val(U,dim,face))&
-                       ! Inflow boundary integral.
-                       -matmul(nnAdvection_in,face_val(U,dim,face_2))
-               end if
-               
-            else
 
                rhs_addto(dim,u_face_l) = rhs_addto(dim,u_face_l) &
-                    ! Outflow boundary integral.
                     -matmul(nnAdvection_out,face_val(U,dim,face))&
-                    ! Inflow boundary integral.
+                    -matmul(nnAdvection_in,face_val(U,dim,face_2))
+            else
+               ! on a Dirichlet boundary, the incoming advection term
+               ! on the lhs is replaced by the same term on the right using
+               ! the boundary value - outgoing term is the same as always
+               ! (meaning no dirichlet bc is applied on outgoing facets)
+               rhs_addto(dim,u_face_l) = rhs_addto(dim,u_face_l) &
+                    -matmul(nnAdvection_out,face_val(U,dim,face))&
                     -matmul(nnAdvection_in,ele_val(velocity_bc,dim,face))
             end if
          end if
@@ -3029,10 +3003,11 @@ contains
 
   end subroutine construct_momentum_interface_dg
     
-  subroutine subcycle_momentum_dg(u, mom_rhs, subcycle_m, inverse_mass, state)
+  subroutine subcycle_momentum_dg(u, mom_rhs, subcycle_m, subcycle_rhs, inverse_mass, state)
     type(vector_field), intent(inout) :: u
     type(vector_field), intent(inout):: mom_rhs
     type(block_csr_matrix), intent(in):: subcycle_m, inverse_mass
+    type(vector_field), intent(in):: subcycle_rhs
     type(state_type), intent(inout):: state
       
     type(vector_field) :: u_sub, m_delta_u, delta_u
@@ -3079,15 +3054,17 @@ contains
         ! filter wiggles from u
         do d =1, mesh_dim(u)
         u_cpt = extract_scalar_field_from_vector_field(u_sub,d)
-        call limit_vb(state,u_cpt)
+        !call limit_vb(state,u_cpt)
         end do
 
       end if
 
  
-      ! du = advection * u
+      ! du = advection * u - f_adv
       call mult(delta_u, subcycle_m, u_sub)
-      ! M*du/dt = M*du/dt - advection * u
+      ! -f_adv for bc terms
+      call addto(delta_u, subcycle_rhs, scale=-1.0)
+      ! M*du/dt = M*du/dt - advection * u + f_adv
       call addto(m_delta_u, delta_u, scale=-1.0/subcycles)
 
       ! we're only interested in m_delta_u, so we may leave early:
@@ -3099,11 +3076,6 @@ contains
       ! u = u - dt/s * du
       call addto(u_sub, delta_u, scale=-dt/subcycles)
       call halo_update(u_sub)
-
- 
-     ! strictly speaking we should have another halo_update here, but
-      ! we can assume that the limiting inside halo 1 elements can be
-      ! performed locally
 
     end do
 
@@ -3117,7 +3089,7 @@ contains
     !   big_m = M + dt*theta*K, where K are any terms not included in subcycling (viscosity, coriolis etc.)
     !   mom_rhs = f - K u^n
     ! This is what we want to solve:
-    !   M (u^sub - u^n)/dt + A u^n = 0, assuming one subcycle here
+    !   M (u^sub - u^n)/dt + A u^n = f_adv, assuming one subcycle here
     !   M (u^n+1 - u^sub)/dt + K u^n+theta = f
     ! The last eqn can be rewritten:
     !   M (u^n+1 - u^n)/dt - M (u^sub - u^n)/dt + K u^n + dt*theta*K (u^n+1-u^n)/dt = f

--- a/assemble/Momentum_Equation.F90
+++ b/assemble/Momentum_Equation.F90
@@ -201,7 +201,10 @@
          type(vector_field), dimension(1:size(state)):: mom_rhs
          ! Projection RHS
          type(scalar_field) :: projec_rhs
+         ! RHS for continuity equation
          type(scalar_field), dimension(1:size(state)):: ct_rhs
+         ! RHS for subcycling containing advection bc terms
+         type(vector_field), dimension(1:size(state)):: subcycle_rhs
 
          ! Do we want to assemble the KMK stabilisation matrix?
          logical :: assemble_kmk
@@ -582,6 +585,7 @@
                   ! subcycle_m currently only contains advection, so diagonal=.true.
                   call allocate(subcycle_m(istate), u_sparsity, (/u%dim, u%dim/), &
                      diagonal=.true., name = "subcycle_m")
+                  call allocate(subcycle_rhs(istate), u%dim, u%mesh, "SubCycleMomentumRHS")
                end if
             else
                ! Create a sparsity if necessary or pull it from state:
@@ -631,7 +635,7 @@
                      inverse_masslump=inverse_masslump(istate), &
                      inverse_mass=inverse_mass(istate), &
                      include_pressure_bcs=.not. cv_pressure, &
-                     subcycle_m=subcycle_m(istate))
+                     subcycle_m=subcycle_m(istate), subcycle_rhs=subcycle_rhs(istate))
                else
                   call construct_momentum_dg(u, p, density, x, &
                      big_m(istate), mom_rhs(istate), state(istate), &
@@ -1052,7 +1056,7 @@
                   end if
 
                   call advance_velocity(state, istate, x, u, p_theta, big_m, ct_m, &
-                                        mom_rhs, subcycle_m, inverse_mass)
+                                        mom_rhs, subcycle_m, subcycle_rhs, inverse_mass)
 
                   if(prognostic_p) then
                      call assemble_projection(state, istate, u, old_u, p, cmc_m, reassemble_cmc_m, cmc_global, ctp_m, &
@@ -1252,7 +1256,7 @@
                                     &"/discontinuous_galerkin")) then
 
                call finalise_state(state, istate, u, mass, inverse_mass, inverse_masslump, &
-                                   big_m, mom_rhs, ct_rhs, subcycle_m)
+                                   big_m, mom_rhs, ct_rhs, subcycle_m, subcycle_rhs)
 
             end if
 
@@ -1516,7 +1520,7 @@
       end subroutine solve_poisson_pressure
 
 
-      subroutine advance_velocity(state, istate, x, u, p_theta, big_m, ct_m, mom_rhs, subcycle_m, inverse_mass)
+      subroutine advance_velocity(state, istate, x, u, p_theta, big_m, ct_m, mom_rhs, subcycle_m, subcycle_rhs, inverse_mass)
          !!< Solve momentum equation using pressure guess and advance velocity from u^{n} to u^{*}
 
          ! An array of buckets full of fields
@@ -1536,8 +1540,9 @@
 
          type(vector_field), dimension(:), intent(inout) :: mom_rhs
 
-         ! Matrix for split explicit advection
+         ! Matrix and rhs for split explicit advection
          type(block_csr_matrix), dimension(:), intent(in) :: subcycle_m
+         type(vector_field), dimension(:), intent(in) :: subcycle_rhs
 
          !! Local variables
          ! Change in velocity
@@ -1559,7 +1564,8 @@
 
          ! Apply advection subcycling
          if(subcycle(istate)) then
-            call subcycle_momentum_dg(u, mom_rhs(istate), subcycle_m(istate), inverse_mass(istate), state(istate))
+            call subcycle_momentum_dg(u, mom_rhs(istate), subcycle_m(istate), &
+              subcycle_rhs(istate), inverse_mass(istate), state(istate))
          end if
 
          if (associated(ct_m(istate)%ptr)) then
@@ -1878,7 +1884,7 @@
 
 
       subroutine finalise_state(state, istate, u, mass, inverse_mass, inverse_masslump, &
-                               big_m, mom_rhs, ct_rhs, subcycle_m)
+                               big_m, mom_rhs, ct_rhs, subcycle_m, subcycle_rhs)
          !!< Does some finalisation steps to the velocity field and deallocates some memory
          !!< allocated for the specified state.
 
@@ -1900,8 +1906,9 @@
          ! Momentum RHS
          type(vector_field), dimension(:), intent(inout) :: mom_rhs
          type(scalar_field), dimension(:), intent(inout) :: ct_rhs
-         ! Matrix for split explicit advection
+         ! Matrix and rhs for split explicit advection
          type(block_csr_matrix), dimension(:), intent(inout) :: subcycle_m
+         type(vector_field), dimension(:), intent(inout) :: subcycle_rhs
 
          ! Local variables for reduced model
          integer :: d
@@ -1927,7 +1934,7 @@
             ! Filter wiggles from u
             do d = 1, mesh_dim(u)
                u_cpt = extract_scalar_field_from_vector_field(u, d)
-               call limit_vb(state(istate), u_cpt)
+               !call limit_vb(state(istate), u_cpt)
             end do
          end if
          call profiler_toc(u, "assembly")
@@ -1947,6 +1954,7 @@
          call deallocate(big_m(istate))
          if(subcycle(istate)) then
             call deallocate(subcycle_m(istate))
+            call deallocate(subcycle_rhs(istate))
          end if
 
       end subroutine finalise_state

--- a/assemble/Momentum_Equation.F90
+++ b/assemble/Momentum_Equation.F90
@@ -1934,7 +1934,7 @@
             ! Filter wiggles from u
             do d = 1, mesh_dim(u)
                u_cpt = extract_scalar_field_from_vector_field(u, d)
-               !call limit_vb(state(istate), u_cpt)
+               call limit_vb(state(istate), u_cpt)
             end do
          end if
          call profiler_toc(u, "assembly")

--- a/tests/friction-slope-swe/friction-slope-swe.xml
+++ b/tests/friction-slope-swe/friction-slope-swe.xml
@@ -33,7 +33,7 @@ endtime = stat['ElapsedTime']['value'][-1]</variable>
     <test name="TestUmin" language="python">assert(umin&gt;0.999)</test>
     <test name="TestUmax" language="python">assert(umax&lt;1.021)</test>
     <test name="TestErrorMax" language="python">assert(errormax&lt;0.025)</test>
-    <test name="TestVmax" language="python">assert(vmax&lt;1.e-5)</test>
+    <test name="TestVmax" language="python">assert(vmax&lt;2.e-5)</test>
     <test name="TestErrorL2" language="python">area=1.e5*1.e3
 assert(errorl2&lt;1.e-5*area)</test>
     <test name="TestEndTime" language="python">assert(endtime&lt;1.0e6)<comment>Make sure we reach a steady state</comment></test>

--- a/tests/friction-slope-swe/friction.flml
+++ b/tests/friction-slope-swe/friction.flml
@@ -232,6 +232,11 @@
           <relaxation>
             <real_value rank="0">0.5</real_value>
           </relaxation>
+          <discontinuous_galerkin>
+            <maximum_courant_number_per_subcycle>
+              <real_value rank="0">0.1</real_value>
+            </maximum_courant_number_per_subcycle>
+          </discontinuous_galerkin>
         </temporal_discretisation>
         <solver>
           <iterative_method name="gmres">
@@ -353,6 +358,23 @@ Therefore, with p=0 at x=L:
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="PressureMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+    <scalar_field name="DG_CourantNumber" rank="0">
+      <diagnostic>
+        <algorithm name="Internal" material_phase_support="multiple"/>
+        <mesh name="VelocityMesh"/>
         <output/>
         <stat/>
         <convergence>


### PR DESCRIPTION
Fix weak bcs for momentum subcycling.
    
Previously the necessary terms associated with a weak Dirichlet bc for advection on the rhs (the ones containing the actual bc values) where left out entirely when using subcycling. These are now applied as a rhs term during the subcycling.
    
This potentially changes any run with DG subcycling for momentum with a weak Dirichlet inflow condition. Since the condition for the normal component is also imposed via the continuity equation, it may have done roughly the right thing for cases where advection is not dominant at the open boundary. However local artefacts would still have been likely - apparent through an increased pressure along the open boundary, and a noisy velocity.

Switch on subcycling in friction-slope-swe test (this test would fail previously with subcycling).

Remove acceleration logical in momentum_dg that was never used, i.e. always assumed true, to simplify the code a little.