### PR TITLE
Modify incorrect options check.

### DIFF
--- a/preprocessor/Populate_State.F90
+++ b/preprocessor/Populate_State.F90
@@ -3325,7 +3325,8 @@ contains
           
           if (have_option("/geometry/mesh::"//trim(from_mesh_name)//&
              "/exclude_from_mesh_adaptivity") .and. .not. &
-             have_option(trim(path)//"/exclude_from_mesh_adaptivity")) then
+             have_option(trim(path)//"/exclude_from_mesh_adaptivity") .and. .not. &
+             have_option(trim(path)//"/from_mesh/extrude")) then
              ! if the from_mesh is excluded, the mesh itself also needs to be
              ewrite(-1,*) "In derivation of mesh ", trim(mesh_name), " from ", trim(from_mesh_name)
              ewrite(-1,*) "A mesh derived from a mesh with exclude_from_mesh_adaptivity needs to have this options as well."


### PR DESCRIPTION
You should be able to exclude meshes from adaptivity that are extruded from.  This pull request modifies an options check that previously prevented this.

This allows an extruded mesh to be adapted in an unstructured way (i.e. when vertically structured adaptivity is not turned on), destroying the effects of the extrusion but without crashing because there's another lower dimensional mesh hanging around.