### PR TITLE
Change exit state of testharness following completed test runs

### DIFF
--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -331,10 +331,6 @@ class TestHarness:
             print "Passes:   %d" % self.passcount
             print "Failures: %d" % self.failcount
             print "Warnings: %d" % self.warncount
-        
-        if self.failcount > 0:
-            print "Exiting with error since at least one failure..."
-            sys.exit(1)
 
     def threadrun(self):
         '''This is the portion of the loop which actually runs the


### PR DESCRIPTION
Prior to this merge, testharness can complete test runs but still exit with error if test it runs returns failures. This can be confusing as it suggests that testharness itself has experienced an error - a state which occurs if (for example) an invalid xml file is specified in the input. This commit removes the errant behaviour, and puts the onus on output parsers to detect whether or not tests are passing.