### PR TITLE
Changes to allow all check_options tests to run.

### DIFF
--- a/assemble/Coriolis.F90
+++ b/assemble/Coriolis.F90
@@ -59,7 +59,7 @@ module coriolis_module
      
   private
   
-  public :: coriolis, funome, set_coriolis_parameters
+  public :: coriolis, funome, set_coriolis_parameters, coriolis_module_check_options
 
   contains
 

--- a/error_measures/Limit_metric.F90
+++ b/error_measures/Limit_metric.F90
@@ -14,7 +14,7 @@ module limit_metric_module
   private
 
   public :: limit_metric, limit_metric_elements, expected_elements, &
-    & expected_nodes, determinant
+    & expected_nodes, determinant, limit_metric_module_check_options
 
   interface expected_nodes
     module procedure expected_nodes_expected_elements, expected_nodes_metric

--- a/femtools/Field_Options.F90
+++ b/femtools/Field_Options.F90
@@ -187,6 +187,10 @@ contains
 
        complete_field_path=trim(path) // "/prescribed"
 
+    else if (have_option(trim(path) // "/aliased")) then
+
+       complete_field_path=trim(path) // "/aliased"
+
     else
       
       if (present(stat)) then

--- a/tools/make_check_options.py
+++ b/tools/make_check_options.py
@@ -51,7 +51,7 @@ for filename in fortran_files:
 
     for module in modules:
 
-        if re.search(r"^\s*subroutine\s+"+module+"_check_options\s*$",\
+        if re.search(r"^\s*subroutine\s+"+module+"_check_options\S*\s*$",\
                          fortran,\
                          re.IGNORECASE|re.MULTILINE):
             module_list.append(module)


### PR DESCRIPTION
This is probably worth a pull request. It's the code written to deal with issue #50, where check_options routines are only auto detected when written in a specific pattern, whereas other patterns are both valid fortran, and used in the code base. It'll need a buildbot queue.