### PR TITLE
Add surface horizontal divergence diagnostic

### DIFF
--- a/diagnostics/Surface.F90
+++ b/diagnostics/Surface.F90
@@ -36,13 +36,14 @@ module surface_diagnostics
   use global_parameters, only : OPTION_PATH_LEN
   use spud
   use state_module
+  use sediment
   use surface_integrals
   
   implicit none
   
   private
   
-  public :: calculate_grad_normal
+  public :: calculate_grad_normal, calculate_surface_horizontal_divergence
   
 contains
   
@@ -75,5 +76,33 @@ contains
     end if
     
   end subroutine calculate_grad_normal
+
+subroutine calculate_surface_horizontal_divergence(state, s_field)
+    type(state_type), intent(in) :: state
+    type(scalar_field), intent(inout) :: s_field
+    
+    type(vector_field), pointer :: source_field
+    type(vector_field), pointer :: positions
+    
+    character(len = OPTION_PATH_LEN) :: base_path
+    integer, dimension(2) :: nsurface_ids
+    integer, dimension(:), allocatable :: surface_ids
+        
+    source_field => vector_source_field(state, s_field)
+    positions => extract_vector_field(state, "Coordinate")
+    
+    base_path = trim(complete_field_path(s_field%option_path)) // "/algorithm"    
+
+    nsurface_ids = option_shape(trim(base_path) // "/surface_ids")
+    assert(nsurface_ids(1) >= 0)
+    allocate(surface_ids(nsurface_ids(1)))
+    call get_option(trim(base_path) // "/surface_ids", surface_ids)
+      
+    call surface_horizontal_divergence(source_field, positions, s_field, surface_ids = surface_ids)
+      
+    deallocate(surface_ids)
+    
+  end subroutine calculate_surface_horizontal_divergence
+
   
 end module surface_diagnostics

--- a/schemas/diagnostic_algorithms.rnc
+++ b/schemas/diagnostic_algorithms.rnc
@@ -1502,6 +1502,23 @@ vector_scalar_time_averaged_algorithm =
       }
    )
 
+# surface algorithm
+
+surface_horizontal_divergence_algorithm = 
+   (
+      ## Algorithm calculates the horizontally restricted divergence of
+      ## a horizontal vector living on the specified surface.
+      element algorithm {
+         attribute name { "surface_horizontal_divergence" },
+         attribute material_phase_support { "single" },
+         vector_source_field,
+         element surface_ids {
+            integer_vector
+         }
+      }
+   )
+      
+
 scalar_diagnostic_algorithms = universal_numbering_diagnostic_algorithm
 scalar_diagnostic_algorithms |= viscous_dissipation_algorithm
 scalar_diagnostic_algorithms |= universal_column_id_algorithm
@@ -1509,6 +1526,7 @@ scalar_diagnostic_algorithms |= tidal_harmonic_algorithm
 scalar_diagnostic_algorithms |= tensor_second_invariant_algorithm
 scalar_diagnostic_algorithms |= strain_rate_second_invariant_algorithm
 scalar_diagnostic_algorithms |= temporalmin_algorithm
+scalar_diagnostic_algorithms |= surface_horizontal_divergence_algorithm
 scalar_diagnostic_algorithms |= scalar_temporalmax_algorithm
 scalar_diagnostic_algorithms |= scalar_time_averaged_algorithm
 scalar_diagnostic_algorithms |= scalar_period_averaged_algorithm

--- a/schemas/diagnostic_algorithms.rng
+++ b/schemas/diagnostic_algorithms.rng
@@ -2006,6 +2006,23 @@ This field needs to be interpolated between adapts.</a:documentation>
       </optional>
     </element>
   </define>
+  <!-- surface algorithm -->
+  <define name="surface_horizontal_divergence_algorithm">
+    <element name="algorithm">
+      <a:documentation>Algorithm calculates the horizontally restricted divergence of
+a horizontal vector living on the specified surface.</a:documentation>
+      <attribute name="name">
+        <value>surface_horizontal_divergence</value>
+      </attribute>
+      <attribute name="material_phase_support">
+        <value>single</value>
+      </attribute>
+      <ref name="vector_source_field"/>
+      <element name="surface_ids">
+        <ref name="integer_vector"/>
+      </element>
+    </element>
+  </define>
   <define name="scalar_diagnostic_algorithms">
     <ref name="universal_numbering_diagnostic_algorithm"/>
   </define>
@@ -2026,6 +2043,9 @@ This field needs to be interpolated between adapts.</a:documentation>
   </define>
   <define name="scalar_diagnostic_algorithms" combine="choice">
     <ref name="temporalmin_algorithm"/>
+  </define>
+  <define name="scalar_diagnostic_algorithms" combine="choice">
+    <ref name="surface_horizontal_divergence_algorithm"/>
   </define>
   <define name="scalar_diagnostic_algorithms" combine="choice">
     <ref name="scalar_temporalmax_algorithm"/>

--- a/tests/surface_horizontal_divergence/Makefile
+++ b/tests/surface_horizontal_divergence/Makefile
@@ -1,0 +1,6 @@
+input: clean
+	gmsh -2 src/slope.geo
+
+clean:
+	rm -f src/*.msh *.vtu *.stat	fluidity.[le]* \
+	matrixdump matrixdump.info

--- a/tests/surface_horizontal_divergence/src/slope.geo
+++ b/tests/surface_horizontal_divergence/src/slope.geo
@@ -1,0 +1,20 @@
+Point(1)={0,0,0};
+Point(2)={1,1,0};
+Point(3)={1,2,0};
+Point(4)={0,2,0};
+
+Line(1)={1,2};
+Line(2)={2,3};
+Line(3)={3,4};
+Line(4)={4,1};
+
+Line Loop(1)={1,2,3,4};
+
+Plane Surface(1)={1};
+
+Physical Surface(1)=1;
+
+Physical Line(1)=1;
+Physical Line(2)=2;
+Physical Line(3)=3;
+Physical Line(4)=4;

--- a/tests/surface_horizontal_divergence/surface_horizontal_divergence.flml
+++ b/tests/surface_horizontal_divergence/surface_horizontal_divergence.flml
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">surface_horizontal_divergence</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="src/slope">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">3</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">0</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="CoordinateMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1.0</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1.0</real_value>
+    </finish_time>
+  </timestepping>
+  <material_phase name="Fluid">
+    <vector_field name="Velocity" rank="1">
+      <prescribed>
+        <mesh name="CoordinateMesh"/>
+        <value name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </value>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </vector_field>
+    <scalar_field name="SurfaceDivergence" rank="0">
+      <diagnostic>
+        <algorithm source_field_type="vector" material_phase_support="single" name="surface_horizontal_divergence" source_field_name="SurfaceField">
+          <surface_ids>
+            <integer_value shape="1" rank="1">1</integer_value>
+          </surface_ids>
+        </algorithm>
+        <mesh name="CoordinateMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+    <vector_field name="SurfaceField" rank="1">
+      <prescribed>
+        <mesh name="CoordinateMesh"/>
+        <value name="WholeMesh">
+          <python>
+            <string_value lines="20" type="code" language="python">def val(X,t):
+  if X[0]==X[1]:
+    return [X[0],0.0]
+  else:
+    return [0.0,0.0]</string_value>
+          </python>
+        </value>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+      </prescribed>
+    </vector_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/surface_horizontal_divergence/surface_horizontal_divergence.xml
+++ b/tests/surface_horizontal_divergence/surface_horizontal_divergence.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testproblem>
+  <name>surface_horizontal_divergence</name>
+  <owner userid="jrper"/>
+  <problem_definition length="short" nprocs="1">
+    <command_line>fluidity -v2 -l  surface_horizontal_divergence.flml</command_line>
+  </problem_definition>
+  <variables>
+    <variable name="OnSurface" language="python">import vtk
+import numpy
+
+reader=vtk.vtkXMLUnstructuredGridReader()
+reader.SetFileName('surface_horizontal_divergence_1.vtu')
+reader.Update()
+ugrid=reader.GetOutput()
+
+OnSurface=[]
+
+for i in range(ugrid.GetNumberOfPoints()):
+  p=ugrid.GetPoints().GetPoint(i)
+  OnSurface.append(1.0*(p[0]==p[1]))
+  
+OnSurface=numpy.array(OnSurface)</variable>
+    <variable name="SurfaceDivergence" language="python">import vtk
+import numpy
+
+reader=vtk.vtkXMLUnstructuredGridReader()
+reader.SetFileName('surface_horizontal_divergence_1.vtu')
+reader.Update()
+ugrid=reader.GetOutput()
+
+SurfaceDivergence=[]
+
+for i in range(ugrid.GetNumberOfPoints()):
+  SurfaceDivergence.append(ugrid.GetPointData().GetArray('SurfaceDivergence').GetValue(i))
+  
+SurfaceDivergence=numpy.array(SurfaceDivergence)</variable>
+  </variables>
+  <pass_tests>
+    <test name="testHaveData" language="python">assert len(OnSurface)&gt;0</test>
+    <test name="testSurfaceDivergence" language="python">assert all(abs(OnSurface-SurfaceDivergence)&lt;1.0e-10)</test>
+  </pass_tests>
+</testproblem>


### PR DESCRIPTION
This commit adds a new diagnostic field algorithm which collapses the last component of the coordinate field + an arbitrary vector field on a boundary surface, performs a horizontal divergence operation on this n-1 dimensional object, then continues this result back into the entire volume space.

Although the code has been written with the intention of using it to calculate a sediment bed load source term, the operator is slightly more general and thus made available outside this routine.