### PR TITLE
Use statement cleanup

### DIFF
--- a/assemble/Adapt_Integration.F90
+++ b/assemble/Adapt_Integration.F90
@@ -29,19 +29,19 @@
 
 module adapt_integration
 
+  use fldebug
   use data_structures
   use quadrature
   use elements
-  use fldebug
-  use fields
-  use halos
-  use limit_metric_module
-  use meshdiagnostics
-  use node_locking
   use spud
+  use fields
+  use vtk_interfaces
+  use halos
+  use meshdiagnostics
+  use limit_metric_module
+  use node_locking
   use surface_id_interleaving
   use tictoc
-  use vtk_interfaces
 
   implicit none
   

--- a/assemble/Adapt_State.F90
+++ b/assemble/Adapt_State.F90
@@ -28,56 +28,53 @@
 #include "fdebug.h"
 
 module adapt_state_module
-! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler
+  use global_parameters, only : OPTION_PATH_LEN, periodic_boundary_option_path, adaptivity_mesh_name, domain_bbox, topology_mesh_name
   use quadrature
   use elements
+  use mpi_interfaces
+  use parallel_tools
+  use data_structures
   use sparse_tools
+  use eventcounter
+  use intersection_finder_module
   use fields
   use state_module
-!
+  use halos
+  use field_options
+  use boundary_conditions
+  use detector_data_types
+  use pickers
+  use interpolation_module
+  use hadapt_metric_based_extrude
+  use tictoc
   use adaptivity_1d
   use adapt_integration, only : adapt_mesh_3d => adapt_mesh
+  use fefields
   use adaptive_timestepping
+  use detector_parallel
+  use diagnostic_variables
   use checkpoint
+  use edge_length_module
+  use boundary_conditions_from_options
+  use diagnostic_fields_wrapper_new, only : calculate_diagnostic_variables_new => calculate_diagnostic_variables
+  use hadapt_extrude
+  use reserve_state_module
+  use fields_halos
+  use populate_state_module
   use diagnostic_fields_wrapper
   use discrete_properties_module
-  use edge_length_module
-  use eventcounter
-  use field_options
-  use global_parameters, only : OPTION_PATH_LEN, periodic_boundary_option_path, adaptivity_mesh_name, domain_bbox, topology_mesh_name
-  use hadapt_extrude
-  use hadapt_metric_based_extrude
-  use halos
-  use fefields
   use interpolation_manager
-  use interpolation_module
   use mba_adapt_module
   use mba2d_integration
   use mba3d_integration
-  use metric_assemble
   use anisotropic_gradation, only: use_anisotropic_gradation
-  use parallel_tools
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use populate_state_module
   use project_metric_to_surface_module
-  use reserve_state_module
+  use metric_assemble
   use sam_integration
-  use tictoc
   use timeloop_utilities
-  use fields_halos
-  use data_structures
-  use detector_data_types
-  use detector_parallel
-  use diagnostic_variables
-  use intersection_finder_module
-  use diagnostic_variables
-  use diagnostic_fields_wrapper_new, only : calculate_diagnostic_variables_new => calculate_diagnostic_variables
-  use pickers
   use write_gmsh
 #ifdef HAVE_ZOLTAN
   use zoltan_integration
-  use mpi_interfaces
 #endif
 
   implicit none

--- a/assemble/Adapt_State_Prescribed.F90
+++ b/assemble/Adapt_State_Prescribed.F90
@@ -29,19 +29,19 @@
 
 module adapt_state_prescribed_module
 
-  use embed_python
-  use field_options
-  use fields
   use global_parameters, only : OPTION_PATH_LEN
-  use interpolation_manager
-  use node_boundary
+  use embed_python
+  use spud
+  use fields
+  use state_module
+  use field_options
   use boundary_conditions
+  use node_boundary
   use boundary_conditions_from_options
-  use populate_state_module
   use mesh_files
   use reserve_state_module
-  use spud
-  use state_module
+  use populate_state_module
+  use interpolation_manager
 
   implicit none
   

--- a/assemble/Adapt_State_Unittest.F90
+++ b/assemble/Adapt_State_Unittest.F90
@@ -29,16 +29,16 @@
 
 module adapt_state_unittest_module
   
-  use adapt_integration, adapt_mesh_3d => adapt_mesh
-  use mba2d_integration
   use eventcounter
-  use field_options
   use fields
-  use interpolation_module
-  use node_boundary
   use state_module
-  use adapt_state_module
+  use adapt_integration, adapt_mesh_3d => adapt_mesh
+  use node_boundary
+  use field_options
+  use interpolation_module
+  use mba2d_integration
   use sam_integration
+  use adapt_state_module
  
   implicit none
   

--- a/assemble/Adaptivity_1D.F90
+++ b/assemble/Adaptivity_1D.F90
@@ -29,8 +29,8 @@
 
 module adaptivity_1d
   
-  use fields
   use fldebug
+  use fields
   use hadapt_metric_based_extrude
   use node_locking
   use tictoc

--- a/assemble/Advection_Diffusion_CG.F90
+++ b/assemble/Advection_Diffusion_CG.F90
@@ -29,30 +29,28 @@
 
 module advection_diffusion_cg
   
-  ! keep in this order, please:
-  use quadrature
-  use elements
-  use sparse_tools
-  use fields
-  !
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use field_options
   use fldebug
   use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN, COLOURING_CG1
-  use profiler
+  use quadrature
+  use elements
   use spud
-  use petsc_solve_state_module
-  use state_module
-  use upwind_stabilisation
-  use sparsity_patterns_meshes
-  use porous_media
-  use multiphase_module
-  use sparse_tools_petsc
-  use colouring
 #ifdef _OPENMP
   use omp_lib
 #endif
+  use sparse_tools
+  use fields
+  use profiler
+  use sparse_tools_petsc
+  use state_module
+  use boundary_conditions
+  use field_options
+  use sparsity_patterns_meshes
+  use boundary_conditions_from_options
+  use petsc_solve_state_module
+  use upwind_stabilisation
+  use porous_media
+  use multiphase_module
+  use colouring
   
   implicit none
   

--- a/assemble/Advection_Diffusion_DG.F90
+++ b/assemble/Advection_Diffusion_DG.F90
@@ -29,39 +29,39 @@
 module advection_diffusion_DG
   !!< This module contains the Discontinuous Galerkin form of the advection
   !!< -diffusion equation for scalars.
-  use elements
-  use sparse_tools
-  use fetools
-  use dgtools
-  use fields
-  use fefields
-  use state_module
-  use shape_functions
-  use transform_elements
-  use vector_tools
-  use field_derivatives
   use fldebug
-  use vtk_interfaces
-  use Coordinates
-  use petsc_solve_state_module
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use field_options
-  use spud
-  use upwind_stabilisation
-  use slope_limiters_dg
-  use sparsity_patterns
-  use sparse_matrices_fields
-  use sparsity_patterns_meshes
-  use diagnostic_fields, only: calculate_diagnostic_variable
+  use vector_tools
   use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN, COLOURING_DG2, &
-       COLOURING_DG0
-  use porous_media
-  use colouring
-  use Profiler
+COLOURING_DG0
+  use elements
+  use spud
 #ifdef _OPENMP
   use omp_lib
 #endif
+  use sparse_tools
+  use shape_functions
+  use transform_elements
+  use fetools
+  use dgtools
+  use fields
+  use profiler
+  use state_module
+  use vtk_interfaces
+  use field_options
+  use sparse_matrices_fields
+  use fefields
+  use boundary_conditions
+  use field_derivatives
+  use coordinates
+  use sparsity_patterns
+  use sparsity_patterns_meshes
+  use petsc_solve_state_module
+  use boundary_conditions_from_options
+  use upwind_stabilisation
+  use slope_limiters_dg
+  use diagnostic_fields, only: calculate_diagnostic_variable
+  use porous_media
+  use colouring
 
   implicit none
 

--- a/assemble/Advection_Diffusion_FV.F90
+++ b/assemble/Advection_Diffusion_FV.F90
@@ -29,28 +29,39 @@
 module advection_diffusion_fv
   !!< This module contains the finite volume form of the advection
   !!< -diffusion equation for scalars.
-  use quadrature
-  use elements
-  use sparse_tools
-  use fields
-  
-  use fetools
-  use state_module
-  use shape_functions
-  use transform_elements
   use fldebug
-  use petsc_solve_state_module
-  use boundary_conditions
-  use boundary_conditions_from_options
+  use vector_tools
+  use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN, COLOURING_DG2, &
+COLOURING_DG0
+  use elements
   use spud
-  use field_options
-  use sparsity_patterns_meshes
-  use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN, COLOURING_DG1
-  use profiler
-  use colouring
 #ifdef _OPENMP
   use omp_lib
 #endif
+  use sparse_tools
+  use shape_functions
+  use transform_elements
+  use fetools
+  use fields
+  use profiler
+  use state_module
+  use boundary_conditions
+  use sparsity_patterns
+  use dgtools
+  use vtk_interfaces
+  use field_options
+  use sparse_matrices_fields
+  use fefields
+  use field_derivatives
+  use coordinates
+  use sparsity_patterns_meshes
+  use petsc_solve_state_module
+  use boundary_conditions_from_options
+  use upwind_stabilisation
+  use slope_limiters_dg
+  use diagnostic_fields, only: calculate_diagnostic_variable
+  use porous_media
+  use colouring
   
   implicit none
 

--- a/assemble/Assemble_CMC.F90
+++ b/assemble/Assemble_CMC.F90
@@ -30,17 +30,17 @@
 module assemble_CMC
 
   use fldebug
-  use state_module
-  use sparse_tools
-  use sparse_tools_petsc
   use spud
-  use fields
+  use global_parameters, only: OPTION_PATH_LEN
+  use sparse_tools
   use fields_base
-  use fefields
+  use linked_lists
+  use fields
+  use sparse_tools_petsc
+  use state_module
   use sparse_matrices_fields
   use field_options
-  use global_parameters, only: OPTION_PATH_LEN
-  use linked_lists
+  use fefields
   
   implicit none 
 

--- a/assemble/Biology.F90
+++ b/assemble/Biology.F90
@@ -30,17 +30,17 @@ module biology
   !!< This module implements a simple PZND (phytoplankton, zooplankton,
   !!< nutrient, detritus) model in ICOM.
   use spud
-  use state_module
-  use fields
+  use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN, PYTHON_FUNC_LEN
   use sparse_tools
   use fetools
+  use fields
+  use state_module
   use boundary_conditions
-  use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN, PYTHON_FUNC_LEN
   use solvers
   use python_state
   use sparsity_patterns_meshes
-  use fefields
   use field_options
+  use fefields
 
   implicit none
 

--- a/assemble/Burgers_Assembly.F90
+++ b/assemble/Burgers_Assembly.F90
@@ -25,11 +25,11 @@
   !    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
   !    USA
 module burgers_assembly
-  use fields
-  use sparse_tools
   use spud
+  use sparse_tools
   use transform_elements
   use fetools
+  use fields
   implicit none
 
   private

--- a/assemble/Compressible_Projection.F90
+++ b/assemble/Compressible_Projection.F90
@@ -28,16 +28,16 @@
 
 module compressible_projection
   use fldebug
-  use state_module
-  use sparse_tools
   use spud
+  use global_parameters, only: OPTION_PATH_LEN
+  use sparse_tools
   use fields
+  use state_module
   use sparse_matrices_fields
   use field_options
-  use equation_of_state, only: compressible_eos, compressible_material_eos
-  use global_parameters, only: OPTION_PATH_LEN
   use fefields, only: compute_cv_mass
   use state_fields_module
+  use equation_of_state, only: compressible_eos, compressible_material_eos
   use upwind_stabilisation
   use multiphase_module
   implicit none 

--- a/assemble/Coriolis.F90
+++ b/assemble/Coriolis.F90
@@ -29,10 +29,10 @@
 
 module coriolis_module
 
-  use embed_python 
   use fldebug
-  use parallel_tools, only: abort_if_in_parallel_region
   use global_parameters, only : current_time, PYTHON_FUNC_LEN
+  use embed_python 
+  use parallel_tools, only: abort_if_in_parallel_region
   use spud
   
   implicit none

--- a/assemble/Diagnostic_Fields_Matrices.F90
+++ b/assemble/Diagnostic_Fields_Matrices.F90
@@ -30,27 +30,27 @@
 module diagnostic_fields_matrices
   !!< A module to link to diagnostic variable calculations.
 
-  use global_parameters, only:FIELD_NAME_LEN 
+  use global_parameters, only:FIELD_NAME_LEN
+  use futils
+  use spud
+  use parallel_tools
+  use sparse_tools
+  use transform_elements
+  use fetools
+  use parallel_fields, only: zero_non_owned
   use fields
   use sparse_matrices_fields
-  use field_derivatives
   use state_module
-  use futils
-  use fetools
-  use spud
-  use parallel_fields, only: zero_non_owned
+  use halos
+  use field_derivatives
+  use sparsity_patterns, only: make_sparsity
+  use sparsity_patterns_meshes
+  use state_fields_module
+  use solvers
   use divergence_matrix_cv, only: assemble_divergence_matrix_cv
   use divergence_matrix_cg, only: assemble_divergence_matrix_cg, assemble_compressible_divergence_matrix_cg
   use gradient_matrix_cg, only: assemble_gradient_matrix_cg
-  use parallel_tools
-  use sparsity_patterns, only: make_sparsity
-  use state_fields_module
-  use solvers
-  use transform_elements
-  use sparse_tools
-  use sparsity_patterns_meshes
   use state_matrices_module
-  use halos
 
   implicit none
 

--- a/assemble/Diagnostic_fields_wrapper.F90
+++ b/assemble/Diagnostic_fields_wrapper.F90
@@ -31,31 +31,31 @@ module diagnostic_fields_wrapper
   !!< A module to link to diagnostic variable calculations.
 
   use global_parameters, only: FIELD_NAME_LEN, timestep
-  use fields
-  use sparse_matrices_fields
-  use field_derivatives
-  use state_module
   use futils
-  use fetools
   use spud
   use parallel_tools
-  use diagnostic_fields, only: calculate_diagnostic_variable
-  use multimaterial_module, only: calculate_material_mass, &
-                                  calculate_bulk_material_pressure, &
-                                  calculate_sum_material_volume_fractions, &
-                                  calculate_material_volume
-  use free_surface_module, only: calculate_diagnostic_free_surface, &
-                                 calculate_diagnostic_wettingdrying_alpha
-  use tidal_module, only: calculate_diagnostic_equilibrium_pressure
+  use fetools
+  use fields
+  use sparse_matrices_fields
+  use state_module
+  use field_derivatives
   use field_options, only: do_not_recalculate
-  use vorticity_diagnostics
-  use diagnostic_fields_matrices
+  use diagnostic_fields, only: calculate_diagnostic_variable
   use equation_of_state
+  use multiphase_module
+  use diagnostic_fields_matrices
+  use multimaterial_module, only: calculate_material_mass, &
+       calculate_bulk_material_pressure, &
+       calculate_sum_material_volume_fractions, &
+       calculate_material_volume
+  use tidal_module, only: calculate_diagnostic_equilibrium_pressure
+  use free_surface_module, only: calculate_diagnostic_free_surface, &
+       calculate_diagnostic_wettingdrying_alpha
+  use vorticity_diagnostics
   use momentum_diagnostic_fields
   use spontaneous_potentials, only: calculate_formation_conductivity
   use sediment_diagnostics
   use geostrophic_pressure
-  use multiphase_module
   
   implicit none
 

--- a/assemble/Discrete_Properties.F90
+++ b/assemble/Discrete_Properties.F90
@@ -28,12 +28,12 @@
 #include "fdebug.h"
 
 module discrete_properties_module
-  use state_module
-  use solenoidal_interpolation_module
-  use fields
   use spud
   use global_parameters, only : OPTION_PATH_LEN
+  use fields
+  use state_module
   use field_options
+  use solenoidal_interpolation_module
   
   implicit none
   

--- a/assemble/Divergence_Matrix_CG.F90
+++ b/assemble/Divergence_Matrix_CG.F90
@@ -29,17 +29,17 @@
 
 module divergence_matrix_cg
 
-  use quadrature
-  use fields
-  use field_derivatives
-  use state_module
-  use futils
-  use fetools
-  use spud
-  use boundary_conditions
   use global_parameters, only: OPTION_PATH_LEN
-  use transform_elements
   use fldebug
+  use quadrature
+  use futils
+  use spud
+  use transform_elements
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
+  use field_derivatives
   use field_options, only: complete_field_path
   use upwind_stabilisation
   use equation_of_state

--- a/assemble/Divergence_Matrix_CV.F90
+++ b/assemble/Divergence_Matrix_CV.F90
@@ -27,25 +27,25 @@
 #include "fdebug.h"
 
 module divergence_matrix_cv
+  use global_parameters, only: OPTION_PATH_LEN
   use quadrature
-  use fields
-  use field_derivatives
-  use state_module
   use futils
-  use fetools
   use spud
   use cv_faces
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
+  use field_derivatives
   use cv_shape_functions
+  use field_options, only: get_coordinate_field
   use cvtools
-  use cv_fields
+  use cv_options
   use cv_upwind_values
   use cv_face_values
-  use cv_options
-  use diagnostic_fields, only: calculate_diagnostic_variable
-  use boundary_conditions
-  use global_parameters, only: OPTION_PATH_LEN
-  use field_options, only: get_coordinate_field
   use sparsity_patterns_meshes
+  use diagnostic_fields, only: calculate_diagnostic_variable
+  use cv_fields
   use multiphase_module
   implicit none
 

--- a/assemble/Drag.F90
+++ b/assemble/Drag.F90
@@ -26,15 +26,15 @@
 !    USA
 #include "fdebug.h"
 module drag_module
-use fields_data_types
-use fields
-use state_module
-use boundary_conditions
-use fetools
 use global_parameters, only : OPTION_PATH_LEN
 use spud
 use sparse_tools
+use fetools
+use fields
 use sparse_tools_petsc
+use state_module
+use boundary_conditions
+
 implicit none
 
 private

--- a/assemble/Explicit_ALE.F90
+++ b/assemble/Explicit_ALE.F90
@@ -1,24 +1,23 @@
 #include "confdefs.h"
 #include "fdebug.h"
 module ale_module
+  use fldebug
+  use global_parameters, only: OPTION_PATH_LEN, dt
   use quadrature
   use elements
-  use FLDebug
-  use fldebug
-  use fields
-  use fefields,only: compute_lumped_mass
-  use fetools, only: X_, Y_, Z_
   use spud
-  use state_module
-  use transform_elements
-  use boundary_conditions
-  use global_parameters, only: OPTION_PATH_LEN, dt
-  use form_metric_field
-  use metric_assemble
-  use edge_length_module
-  use solidconfiguration
-  use fields_manipulation
   use eventcounter
+  use transform_elements
+  use fetools, only: X_, Y_, Z_
+  use fields_manipulation
+  use fields
+  use state_module
+  use fefields,only: compute_lumped_mass
+  use boundary_conditions
+  use form_metric_field
+  use edge_length_module
+  use metric_assemble
+  use solidconfiguration
 
   private
   real,              save :: toler_coarse,toler_fine,w1,w2,w3,w4,w5,fmin,minfchg,dx,dy,dz

--- a/assemble/Field_Equations_CV.F90
+++ b/assemble/Field_Equations_CV.F90
@@ -29,34 +29,34 @@
 module field_equations_cv
   !!< This module contains the assembly subroutines for advection
   !!< using control volumes
+  use spud
+  use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
+  use cv_faces
+  use parallel_tools, only: getprocno
+  use transform_elements, only: transform_cvsurf_to_physical, &
+       transform_cvsurf_facet_to_physical
   use fields
   use sparse_matrices_fields
-  use sparsity_patterns_meshes
   use state_module
-  use spud
+  use sparsity_patterns_meshes
   use cv_shape_functions
-  use cv_faces
+  use field_options
   use cvtools
-  use cv_fields
+  use cv_options
+  use boundary_conditions
+  use halos
   use cv_upwind_values
   use cv_face_values
-  use diagnostic_fields, only: calculate_diagnostic_variable
-  use cv_options
-  use diagnostic_variables, only: field_tag
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use divergence_matrix_cv, only: assemble_divergence_matrix_cv
-  use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
   use fefields, only: compute_cv_mass
-  use petsc_solve_state_module
-  use transform_elements, only: transform_cvsurf_to_physical, &
-                                transform_cvsurf_facet_to_physical
-  use parallel_tools, only: getprocno
-  use halos
-  use field_options
   use state_fields_module
-  use porous_media
+  use diagnostic_fields, only: calculate_diagnostic_variable
+  use cv_fields
+  use diagnostic_variables, only: field_tag
+  use boundary_conditions_from_options
   use multiphase_module
+  use divergence_matrix_cv, only: assemble_divergence_matrix_cv
+  use petsc_solve_state_module
+  use porous_media
 
   implicit none
 

--- a/assemble/Foam_Drainage.F90
+++ b/assemble/Foam_Drainage.F90
@@ -30,14 +30,13 @@
 module foam_drainage
   ! This module contains the options used for Foam drainage
   use fldebug
-  use state_module
-  use fields     
   use spud
+  use fields
+  use state_module
   use field_options
-  use cv_upwind_values 
-  use diagnostic_fields_matrices
+  use cv_upwind_values
   use state_fields_module
-
+  use diagnostic_fields_matrices
 
   implicit none
 

--- a/assemble/Foam_Flow.F90
+++ b/assemble/Foam_Flow.F90
@@ -30,29 +30,27 @@
 module foam_flow_module
   ! This module contains the options used to solve Laplace's equation for arbitrary geometries and BC's in Fluidity and to calculate the foam velocity
   use fldebug
-  use state_module
-  use fields
   use spud
-  use field_options
-  use FEtools
+  use global_parameters, only : OPTION_PATH_LEN, FIELD_NAME_LEN
+  use vector_tools
+  use quadrature
   use elements
   use sparse_tools
-  use vtk_interfaces
   use transform_elements
+  use fetools
+  use fields
+  use state_module
+  use field_options
+  use vtk_interfaces
   use sparsity_patterns
+  use sparse_matrices_fields
   use solvers
   use boundary_conditions
-  use quadrature
-  use global_parameters, only : OPTION_PATH_LEN, FIELD_NAME_LEN
-  use petsc_solve_state_module
   use sparsity_patterns_meshes
-  use sparse_matrices_fields
-  use vector_tools
+  use petsc_solve_state_module
   use field_derivatives
-  use state_matrices_module
   use gradient_matrix_cg, only: assemble_gradient_matrix_cg
-
-
+  use state_matrices_module
 
   implicit none
 

--- a/assemble/Free_Surface.F90
+++ b/assemble/Free_Surface.F90
@@ -27,26 +27,26 @@
 #include "fdebug.h"
 
 module free_surface_module
+use integer_set_module
 use data_structures
-use fields
-use state_module
-use sparse_tools
-use sparse_matrices_fields
-use boundary_conditions
 use spud
-use vertical_extrapolation_module
 use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
 use parallel_tools
-use halos
+use sparse_tools
 use eventcounter
-use integer_set_module
+use cv_faces
+use fields
+use state_module
+use sparse_matrices_fields
+use boundary_conditions
+use vertical_extrapolation_module
+use halos
 use field_options
 use physics_from_options
 use tidal_module, only: calculate_diagnostic_equilibrium_pressure
-use sparsity_patterns_meshes
 use sparsity_patterns
+use sparsity_patterns_meshes
 use solvers
-use cv_faces
 use cv_shape_functions
 implicit none
 

--- a/assemble/Full_Projection.F90
+++ b/assemble/Full_Projection.F90
@@ -27,26 +27,28 @@
 #include "fdebug.h"
 
   module Full_Projection
-    use FLDebug
-    use elements
-    use Petsc_tools
-    use Solvers
-    use Signal_Vars
-    use Sparse_Tools
-    use sparse_tools_petsc
-    use Sparse_matrices_fields
-    use Fields_Base
-    use Global_Parameters
-    use spud
-    use halos
-    use Multigrid
-    use state_module
-    use petsc_solve_state_module
-    use boundary_conditions_from_options
 
+ 
+    use fldebug
+    use global_parameters
+    use elements
+    use spud
 #ifdef HAVE_PETSC_MODULES
     use petsc
 #endif
+    use sparse_tools
+    use fields_base
+    use petsc_tools
+    use signal_vars
+    use sparse_tools_petsc
+    use sparse_matrices_fields
+    use state_module
+    use halos
+    use multigrid
+    use solvers
+    use petsc_solve_state_module
+    use boundary_conditions_from_options
+
 
     implicit none
     ! Module to provide solvers, preconditioners etc... for full_projection Solver.

--- a/assemble/Geostrophic_Pressure.F90
+++ b/assemble/Geostrophic_Pressure.F90
@@ -28,39 +28,38 @@
 #include "fdebug.h"
 
 module geostrophic_pressure
-
-  use assemble_cmc
-  use boundary_conditions
-  use boundary_conditions_from_options 
-  use conservative_interpolation_module
-  use coriolis_module, only : two_omega => coriolis
-  use data_structures
-  use dgtools
-  use divergence_matrix_cg
-  use eventcounter
-  use fefields
-  use field_options
-  use quadrature
-  use elements
-  use fields
   use fldebug
   use global_parameters, only : empty_path, FIELD_NAME_LEN, OPTION_PATH_LEN
-  use hydrostatic_pressure
-  use momentum_cg
-  use momentum_dg
-  use petsc_solve_state_module
-  use pickers
-  use solvers
-  use state_fields_module
-  use sparse_matrices_fields
+  use spud
+  use data_structures
   use sparse_tools
+  use quadrature
+  use eventcounter
+  use elements
+  use unittest_tools
+  use fields
+  use state_module
+  use field_options
+  use sparse_matrices_fields
+  use vtk_interfaces
+  use fefields
+  use assemble_cmc
+  use boundary_conditions
+  use dgtools
+  use solvers
   use sparsity_patterns
   use sparsity_patterns_meshes
-  use spud
-  use state_module
-  use surfacelabels  
-  use unittest_tools
-  use vtk_interfaces
+  use state_fields_module
+  use surfacelabels
+  use boundary_conditions_from_options
+  use pickers
+  use conservative_interpolation_module
+  use coriolis_module, only : two_omega => coriolis
+  use divergence_matrix_cg
+  use hydrostatic_pressure
+  use petsc_solve_state_module
+  use momentum_cg
+  use momentum_dg
 
   implicit none
   

--- a/assemble/Gradient_Matrix_CG.F90
+++ b/assemble/Gradient_Matrix_CG.F90
@@ -29,17 +29,17 @@
 
 module gradient_matrix_cg
 
-  use quadrature
-  use fields
-  use field_derivatives
-  use state_module
-  use futils
-  use fetools
-  use spud
-  use boundary_conditions
   use global_parameters, only: OPTION_PATH_LEN
-  use transform_elements
   use fldebug
+  use quadrature
+  use futils
+  use spud
+  use transform_elements
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
+  use field_derivatives
   use field_options, only: complete_field_path
 
   implicit none

--- a/assemble/Hybridized_Helmholtz.F90
+++ b/assemble/Hybridized_Helmholtz.F90
@@ -30,22 +30,22 @@
 
 module hybridized_helmholtz
     use spud
+    use FLDebug
+    use global_parameters, only: option_path_len
+    use FUtils, only : real_vector, real_matrix
+    use vector_tools, only: solve
     use fields
     use state_module
-    use FLDebug
-    use populate_state_module
     use write_state_module
-    use populate_state_module
-    use timeloop_utilities
     use sparsity_patterns_meshes
     use sparse_matrices_fields
     use solvers
     use diagnostic_variables
-    use diagnostic_fields_wrapper
+    use populate_state_module
+    use populate_state_module
+    use timeloop_utilities
     use assemble_cmc
-    use FUtils, only : real_vector, real_matrix
-    use global_parameters, only: option_path_len
-    use vector_tools, only: solve
+    use diagnostic_fields_wrapper
     use manifold_projections
     implicit none
 

--- a/assemble/Hydrostatic_Pressure.F90
+++ b/assemble/Hydrostatic_Pressure.F90
@@ -31,25 +31,22 @@
 
 module hydrostatic_pressure
 
-! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler 
+  use fldebug
   use quadrature
   use elements
-  use sparse_tools
-  use fields
-  use state_module
-!
-
-  use fldebug
-  use transform_elements
   use parallel_tools
   use spud
+  use sparse_tools
+  use shape_functions
+  use transform_elements
+  use fields
+  use profiler
+  use state_module
   use boundary_conditions
   use vertical_extrapolation_module
-  use state_matrices_module
   use upwind_stabilisation
-  use profiler
-  use shape_functions
   use solvers
+  use state_matrices_module
   
   implicit none
 

--- a/assemble/Implicit_Solids.F90
+++ b/assemble/Implicit_Solids.F90
@@ -29,53 +29,50 @@
 #define INLINE_MATMUL
 
 module implicit_solids
-! these 5 need to be on top and in this order, 
-! so as not to confuse silly old intel compiler 
+  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN, &
+PYTHON_FUNC_LEN, dt, timestep, current_time
+  use fldebug
+  use vector_tools
   use quadrature
+  use futils
   use elements
+  use spud
+  use parallel_tools
+  use data_structures
   use sparse_tools
-  use fields
-  use state_module
-!
-  use vtk_interfaces
   use linked_lists
-  use intersection_finder_module
+  use tensors
+  use adjacency_lists
+  use fields_manipulation
+  use transform_elements
+  use fields_manipulation
   use tetrahedron_intersection_module
   use unify_meshes_module
   use unittest_tools
-  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN, &
-       PYTHON_FUNC_LEN, dt, timestep, current_time
-  use spud
-  use timeloop_utilities
+  use supermesh_construction
+  use intersection_finder_module
+  use fetools
+  use state_module
+  use vtk_interfaces
+  use sparse_matrices_fields
+  use halos
   use fefields, only: compute_lumped_mass
-  use parallel_tools
-  use diagnostic_variables
-  use qmesh_module
-  use mesh_files
-  use read_triangle
-  use fields_manipulation
+  use timeloop_utilities
+  use boundary_conditions
+  use field_derivatives
+  use meshdiagnostics
   use solvers
   use pickers_inquire
-  use transform_elements
-  use field_derivatives
-  use FLDebug
-  use supermesh_construction
-  use futils
-  use meshdiagnostics
   use sparsity_patterns
-  use vector_tools
-  use tensors
-  use fetools
-  use interpolation_module
-  use adjacency_lists
-  use sparse_matrices_fields
-  use bound_field_module
-  use halos
-  use diagnostic_fields
-  use boundary_conditions
-  use data_structures
-  use edge_length_module
   use detector_tools, only: set_detector_coords_from_python
+  use diagnostic_variables
+  use edge_length_module
+  use mesh_files
+  use read_triangle
+  use interpolation_module
+  use diagnostic_fields
+  use qmesh_module
+  use bound_field_module
 
   implicit none
 

--- a/assemble/Interpolation_manager.F90
+++ b/assemble/Interpolation_manager.F90
@@ -29,21 +29,21 @@
 
 module interpolation_manager
 
+  use spud
+  use global_parameters, only : OPTION_PATH_LEN, periodic_boundary_option_path
+  use linked_lists
+  use supermesh_construction
+  use intersection_finder_module
+  use fields
+  use state_module
+  use field_options
+  use vtk_interfaces
   use interpolation_module
   use conservative_interpolation_module
   use dg_interpolation_module
-  use state_module
-  use fields
-  use spud
-  use global_parameters, only : OPTION_PATH_LEN, periodic_boundary_option_path
-  use supermesh_construction
-  use field_options
-  use intersection_finder_module
-  use linked_lists
-  use boundary_conditions_from_options
   use tictoc
+  use boundary_conditions_from_options
   use populate_state_module
-  use vtk_interfaces
   use geostrophic_pressure
   use pseudo_consistent_interpolation
   

--- a/assemble/LES.F90
+++ b/assemble/LES.F90
@@ -28,16 +28,16 @@
 
 module les_module
   !!< This module contains several subroutines and functions used to implement LES models
-  use state_module
-  use fields
-  use field_options
   use spud
   use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
-  use smoothing_module
   use vector_tools
   use fetools
-  use state_fields_module
+  use fields
+  use state_module
+  use field_options
   use solvers
+  use smoothing_module
+  use state_fields_module
   implicit none
 
   private

--- a/assemble/Manifold_Projections.F90
+++ b/assemble/Manifold_Projections.F90
@@ -26,9 +26,8 @@
 !    USA
 #include "fdebug.h"
 module manifold_projections
-  use state_module
   use fields
-  use fields_base
+  use state_module
 
   implicit none
   

--- a/assemble/Mba2d_Integration.F90
+++ b/assemble/Mba2d_Integration.F90
@@ -1,28 +1,28 @@
 #include "fdebug.h"
 
 module mba2d_integration
+  use global_parameters, only : current_debug_level
   use quadrature
   use elements
+  use eventcounter
+  use quicksort
+  use data_structures
+  use metric_tools
   use fields
   use state_module
-  use interpolation_module
   use meshdiagnostics
   use vtk_interfaces
-  use eventcounter
-  use node_boundary
-  use metric_tools
-  use limit_metric_module
-  use mba_adapt_module
-  use node_locking
   use halos
-  use quicksort
-  use surface_id_interleaving
-  use data_structures
-  use global_parameters, only : current_debug_level
-  use adapt_integration
+  use node_boundary
+  use interpolation_module
+  use limit_metric_module
 #ifdef HAVE_MBA_2D
   use mba2d_module
 #endif
+  use mba_adapt_module
+  use node_locking
+  use surface_id_interleaving
+  use adapt_integration
   implicit none
   
   private

--- a/assemble/Mba3d_Integration.F90
+++ b/assemble/Mba3d_Integration.F90
@@ -29,19 +29,19 @@
 
 module mba3d_integration 
 
-  use adapt_integration
+  use global_parameters, only : real_8
   use quadrature
   use elements
+  use spud
   use fields
-  use global_parameters, only : real_8
   use halos
   use limit_metric_module
   use node_locking
+  use surface_id_interleaving
+  use adapt_integration
 #ifdef HAVE_MBA_3D
   use mba3d_mba_nodal
 #endif
-  use spud
-  use surface_id_interleaving
 
   implicit none
   

--- a/assemble/MeshMovement.F90
+++ b/assemble/MeshMovement.F90
@@ -2,27 +2,27 @@
 
 module meshmovement
 
-  use elements
-  use solvers
-  use global_numbering
-  use shape_functions
-  use fields
-  use fefields
-  use fields_base
-  use element_numbering
-  use field_derivatives
-  use state_module
-  use fetools
-  use sparsity_patterns
   use global_parameters
-  use FLDebug
-  use sparse_tools
-  use vtk_interfaces
-  use unittest_tools
+  use fldebug
+  use element_numbering
+  use elements
+  use shape_functions
   use spud
-  use sparsity_patterns_meshes
+  use sparse_tools
+  use fields_base
+  use global_numbering
   use eventcounter
+  use fetools
+  use unittest_tools
+  use fields
+  use state_module
+  use vtk_interfaces
   use sparse_matrices_fields
+  use solvers
+  use fefields
+  use field_derivatives
+  use sparsity_patterns
+  use sparsity_patterns_meshes
 
   implicit none
   integer,save :: MeshCount=0

--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -29,45 +29,45 @@
 
   module momentum_cg
 
-    use fields
-    use state_module
     use spud
     use fldebug
-    use sparse_tools
-    use boundary_conditions
-    use boundary_conditions_from_options
-    use solvers
-    use petsc_solve_state_module
-    use sparse_tools_petsc
-    use sparse_matrices_fields
-    use field_options
-    use halos
     use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN, timestep, &
          COLOURING_CG1
-    use elements
-    use transform_elements, only: transform_to_physical
-    use coriolis_module
-    use vector_tools
-    use fetools
-    use upwind_stabilisation
-    use les_module
-    use smoothing_module
-    use metric_tools
-    use field_derivatives
-    use state_fields_module
-    use state_matrices_module
-    use sparsity_patterns_meshes
-    use fefields
-    use rotated_boundary_conditions
-    use Coordinates
-    use multiphase_module
-    use edge_length_module
-    use physics_from_options
-    use colouring
-    use Profiler
 #ifdef _OPENMP
     use omp_lib
 #endif
+    use sparse_tools
+    use vector_tools
+    use elements
+    use transform_elements, only: transform_to_physical
+    use fetools
+    use metric_tools
+    use fields
+    use profiler
+    use sparse_tools_petsc
+    use state_module
+    use boundary_conditions
+    use sparse_matrices_fields
+    use halos
+    use solvers
+    use field_options
+    use sparsity_patterns_meshes
+    use physics_from_options
+    use smoothing_module
+    use fefields
+    use state_fields_module
+    use field_derivatives
+    use coordinates
+    use boundary_conditions_from_options
+    use petsc_solve_state_module
+    use coriolis_module
+    use upwind_stabilisation
+    use les_module
+    use multiphase_module
+    use state_matrices_module
+    use rotated_boundary_conditions
+    use edge_length_module
+    use colouring
 
     implicit none
 

--- a/assemble/Momentum_DG.F90
+++ b/assemble/Momentum_DG.F90
@@ -29,43 +29,43 @@
 module momentum_DG
   ! This module contains the Discontinuous Galerkin form of the momentum
   ! equation. 
-  use elements
-  use sparse_tools
-  use fetools
-  use fefields
-  use fields
-  use sparse_matrices_fields
-  use state_module
-  use shape_functions
-  use transform_elements
-  use vector_tools
-  use field_derivatives
   use fldebug
-  use vtk_interfaces
-  use Coordinates
-  use spud
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use solvers
-  use dgtools
+  use vector_tools
   use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN, COLOURING_DG2, &
-       COLOURING_DG0
-  use coriolis_module
-  use halos
-  use sparsity_patterns
-  use petsc_tools
-  use turbine
-  use diagnostic_fields
-  use slope_limiters_dg
-  use smoothing_module
-  use fields_manipulation
-  use field_options
-  use sparsity_patterns_meshes
-  use colouring
-  use Profiler
+COLOURING_DG0
+  use elements
+  use spud
 #ifdef _OPENMP
   use omp_lib
 #endif
+  use sparse_tools
+  use shape_functions
+  use transform_elements
+  use fetools
+  use fields_manipulation
+  use fields
+  use profiler
+  use petsc_tools
+  use sparse_matrices_fields
+  use state_module
+  use vtk_interfaces
+  use halos
+  use field_options
+  use fefields
+  use boundary_conditions
+  use field_derivatives
+  use coordinates
+  use solvers
+  use dgtools
+  use sparsity_patterns
+  use smoothing_module
+  use sparsity_patterns_meshes
+  use boundary_conditions_from_options
+  use coriolis_module
+  use turbine
+  use diagnostic_fields
+  use slope_limiters_dg
+  use colouring
   use multiphase_module
 
 

--- a/assemble/Momentum_Diagnostic_Fields.F90
+++ b/assemble/Momentum_Diagnostic_Fields.F90
@@ -27,19 +27,18 @@
 #include "fdebug.h"
 
 module momentum_diagnostic_fields
-  use FLDebug
-  use equation_of_state
+  use fldebug
+  use spud
+  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
   use fields
   use state_module
-  use spud
-  use state_module
+  use equation_of_state
   use field_priority_lists
-  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
-  use multimaterial_module
   use multiphase_module
-  use diagnostic_fields_wrapper_new
   use k_epsilon
   use initialise_fields_module
+  use multimaterial_module
+  use diagnostic_fields_wrapper_new
   implicit none
 
   interface calculate_densities

--- a/assemble/Momentum_Equation.F90
+++ b/assemble/Momentum_Equation.F90
@@ -29,50 +29,50 @@
 
    module momentum_equation
 
-      use fields
-      use state_module
       use spud
       use fldebug
-      use momentum_cg
+      use parallel_tools
+      use sparse_tools
+      use linked_lists
+      use fields
+      use profiler
+      use sparse_tools_petsc
+      use state_module
+      use field_options
+      use boundary_conditions
+      use sparsity_patterns_meshes
+      use sparse_matrices_fields
+      use vtk_interfaces
+      use dgtools, only: dg_apply_mass
+      use state_fields_module
+      use field_priority_lists
+      use solvers
+      use diagnostic_fields, only: calculate_diagnostic_variable
+      use multiphase_module
       use divergence_matrix_cv
       use divergence_matrix_cg
+      use coordinates
+      use tidal_module
+      use boundary_conditions_from_options
+      use free_surface_module
+      use petsc_solve_state_module
+      use state_matrices_module
+      use rotated_boundary_conditions
+      use momentum_cg
+      use slope_limiters_dg
       use momentum_dg
       use assemble_cmc
-      use field_priority_lists
       use momentum_diagnostic_fields, only: calculate_momentum_diagnostics
-      use field_options
       use compressible_projection
-      use boundary_conditions
-      use boundary_conditions_from_options
-      use sparse_matrices_fields
-      use sparse_tools
-      use sparse_tools_petsc
-      use free_surface_module
-      use solvers
       use full_projection
-      use petsc_solve_state_module
-      use Profiler
-      use geostrophic_pressure
       use hydrostatic_pressure
+      use geostrophic_pressure
       use vertical_balance_pressure
       use foam_drainage, only: calculate_drainage_source_absor
       use oceansurfaceforcing
       use drag_module
-      use parallel_tools
-      use linked_lists
-      use sparsity_patterns_meshes
-      use state_matrices_module
-      use vtk_interfaces
-      use rotated_boundary_conditions
       use reduced_model_runtime
-      use state_fields_module
-      use Tidal_module
-      use Coordinates
-      use diagnostic_fields, only: calculate_diagnostic_variable
-      use dgtools, only: dg_apply_mass
-      use slope_limiters_dg
       use implicit_solids
-      use multiphase_module
       use pressure_dirichlet_bcs_cv
       use shallow_water_equations
 

--- a/assemble/Multimaterials.F90
+++ b/assemble/Multimaterials.F90
@@ -30,16 +30,17 @@ module multimaterial_module
   !! This module contains the options and material properties used
   !! when running a multimaterial simulation.
   use fldebug
-  use state_module
-  use fields
   use spud
-  use fefields, only: compute_cv_mass
   use global_parameters, only: OPTION_PATH_LEN
-  use field_priority_lists
+  use fields
+  use state_module
   use field_options
-  use diagnostic_fields_matrices
+  use fefields, only: compute_cv_mass
+  use field_priority_lists
   use cv_upwind_values
   use equation_of_state, only: compressible_material_eos
+  use diagnostic_fields_matrices
+
   implicit none
 
   interface calculate_bulk_property

--- a/assemble/Multiphase.F90
+++ b/assemble/Multiphase.F90
@@ -30,16 +30,16 @@
    module multiphase_module
       !! This module contains various subroutines and functions for 
       !! multiphase flow simulations
-      use fldebug
-      use state_module
-      use fields
+      use fldebug 
       use spud
       use global_parameters, only: OPTION_PATH_LEN
-      use field_priority_lists
-      use field_options
       use fetools
-      use sparse_tools_petsc
+      use fields
       use profiler
+      use sparse_tools_petsc
+      use state_module
+      use field_options
+      use field_priority_lists
 
       implicit none
 

--- a/assemble/Node_Locking.F90
+++ b/assemble/Node_Locking.F90
@@ -29,11 +29,11 @@
 
 module node_locking
 
-  use embed_python
-  use fields
   use fldebug
   use global_parameters, only : PYTHON_FUNC_LEN
+  use embed_python
   use spud
+  use fields
   
   implicit none
   

--- a/assemble/OceanSurfaceForcing.F90
+++ b/assemble/OceanSurfaceForcing.F90
@@ -27,14 +27,14 @@
 #include "fdebug.h"
 
 module OceanSurfaceForcing
-  use elements
-  use state_module
-  use fields
-  use fetools
-  use transform_elements
   use global_parameters, only : OPTION_PATH_LEN, pi
-  use boundary_conditions
+  use elements
   use spud
+  use transform_elements
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
   use coordinates
   
   implicit none

--- a/assemble/Petsc_Solve_State.F90
+++ b/assemble/Petsc_Solve_State.F90
@@ -36,12 +36,12 @@ module petsc_solve_state_module
 !!< in state is fluidity specific and should therefore not be dealt with
 !!< in femtools/.
 use spud
+use global_parameters, only: OPTION_PATH_LEN
 use sparse_tools
 use fields
-use solvers
 use sparse_tools_petsc
 use state_module
-use global_parameters, only: OPTION_PATH_LEN
+use solvers
 use field_options
 ! modules from assemble:
 use free_surface_module

--- a/assemble/Porous_Media.F90
+++ b/assemble/Porous_Media.F90
@@ -32,10 +32,10 @@ module porous_media
    !!< Module containing porous media related procedures.
 
    use global_parameters, only: OPTION_PATH_LEN
-   use fields
-   use state_module
    use futils
    use spud
+   use fields
+   use state_module
 
    implicit none
    

--- a/assemble/Pressure_Dirichlet_BCS_CV.F90
+++ b/assemble/Pressure_Dirichlet_BCS_CV.F90
@@ -28,25 +28,25 @@
 
 module pressure_dirichlet_bcs_cv
 
+  use global_parameters, only: OPTION_PATH_LEN
   use quadrature
-  use fields
-  use field_derivatives
-  use state_module
   use futils
-  use fetools
   use spud
   use cv_faces
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
+  use field_derivatives
   use cv_shape_functions
+  use field_options, only: get_coordinate_field
   use cvtools
-  use cv_fields
+  use cv_options
   use cv_upwind_values
   use cv_face_values
-  use cv_options
-  use diagnostic_fields, only: calculate_diagnostic_variable
-  use boundary_conditions
-  use global_parameters, only: OPTION_PATH_LEN
-  use field_options, only: get_coordinate_field
   use sparsity_patterns_meshes
+  use diagnostic_fields, only: calculate_diagnostic_variable
+  use cv_fields
   use multiphase_module
 
   implicit none

--- a/assemble/Pseudo_supermesh.F90
+++ b/assemble/Pseudo_supermesh.F90
@@ -15,14 +15,14 @@ module pseudo_supermesh
 !!< nodal placement for heuristic statements
 !!< about local node density.
 
-  use adapt_state_unittest_module, only : adapt_state => adapt_state_unittest
   use fields
-  use interpolation_module
   use vtk_interfaces
-  use conformity_measurement
   use merge_tensors
+  use interpolation_module
   use edge_length_module
   use limit_metric_module
+  use conformity_measurement
+  use adapt_state_unittest_module, only : adapt_state => adapt_state_unittest
   implicit none
 
   contains

--- a/assemble/Reduced_Model_Runtime.F90
+++ b/assemble/Reduced_Model_Runtime.F90
@@ -27,16 +27,16 @@
 #include "fdebug.h"
 
 module reduced_model_runtime
-  use state_module
   use spud
-  use vtk_interfaces
-  use FLDebug
+  use fldebug
   use sparse_tools
-  use sparse_tools_petsc
-  use sparse_matrices_fields
-  use fields
-  use field_options
   use vector_tools
+  use fields
+  use sparse_tools_petsc
+  use state_module
+  use vtk_interfaces
+  use sparse_matrices_fields
+  use field_options
   implicit none
   
   private

--- a/assemble/Sam_integration.F90
+++ b/assemble/Sam_integration.F90
@@ -29,33 +29,32 @@
 
 module sam_integration
 
+  use global_parameters, only : OPTION_PATH_LEN, FIELD_NAME_LEN
   use quadrature
   use elements
-  use fields
-  use field_options
-  use state_module
-  use surfacelabels
-  use global_parameters, only : OPTION_PATH_LEN, FIELD_NAME_LEN
-  use halos
   use spud
-  use metric_tools
   use mpi_interfaces
-  use node_boundary
   use parallel_tools
-  use boundary_conditions
-  use boundary_conditions_from_options
-  use populate_state_module
-  use reserve_state_module
-  use surface_id_interleaving
-  use tictoc
   use memory_diagnostics
-  
   use data_structures
-  use detector_data_types
-  use diagnostic_variables
-  use pickers
   use ieee_arithmetic
-  use detector_tools  
+  use metric_tools
+  use fields
+  use state_module
+  use field_options
+  use halos
+  use surfacelabels
+  use node_boundary
+  use boundary_conditions
+  use tictoc
+  use detector_data_types
+  use boundary_conditions_from_options
+  use reserve_state_module
+  use pickers
+  use detector_tools
+  use diagnostic_variables
+  use populate_state_module
+  use surface_id_interleaving
 
   implicit none
   

--- a/assemble/Saturation_Distribution_Search_HookeJeeves.F90
+++ b/assemble/Saturation_Distribution_Search_HookeJeeves.F90
@@ -33,15 +33,14 @@ module saturation_distribution_search_hookejeeves
   !!< The immediate application for this is as a quasi-inversion method for
   !!< determining water distribution within a reservoir during production
   
-  use diagnostic_fields_wrapper_new
-  use fields
-  use fields_base, only: ele_nodes
-  use field_options
   use fldebug
   use global_parameters, only: OPTION_PATH_LEN
-  use spontaneous_potentials
   use spud
+  use fields
   use state_module
+  use diagnostic_fields_wrapper_new
+  use field_options
+  use spontaneous_potentials
   use write_state_module
   use momentum_equation
 

--- a/assemble/Slope_limiters_DG.F90
+++ b/assemble/Slope_limiters_DG.F90
@@ -27,17 +27,17 @@
 #include "fdebug.h"
 
 module slope_limiters_dg
-use fields
-use state_module
-use ieee_arithmetic
 use fldebug_parameters
+use ieee_arithmetic
 use spud
 use elements
 use eventcounter
+use transform_elements
+use fields
+use state_module
+use vtk_interfaces
 use state_fields_module
 use bound_field_module
-use vtk_interfaces
-use transform_elements
 implicit none
 
 private

--- a/assemble/Solenoidal_interpolation.F90
+++ b/assemble/Solenoidal_interpolation.F90
@@ -4,30 +4,30 @@
 
 module solenoidal_interpolation_module
 
-  use fields
-  use sparse_tools
-  use supermesh_construction
+  use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
   use futils
-  use transform_elements
-  use sparsity_patterns
+  use spud
+  use sparse_tools
   use vector_tools
   use tensors
+  use transform_elements
+  use supermesh_construction
   use fetools
-  use sparse_tools
-  use interpolation_module
-  use solvers
-  use spud
-  use assemble_cmc
-  use sparse_matrices_fields
+  use fields
+  use sparsity_patterns
   use boundary_conditions
-  use boundary_conditions_from_options
-  use momentum_cg, only: correct_masslumped_velocity, add_kmk_matrix, add_kmk_rhs, assemble_kmk_matrix
-  use momentum_dg, only: correct_velocity_dg
+  use interpolation_module
+  use sparse_matrices_fields
+  use solvers
   use fefields
+  use assemble_cmc
+  use dgtools
+  use boundary_conditions_from_options
   use divergence_matrix_cv, only: assemble_divergence_matrix_cv
   use divergence_matrix_cg, only: assemble_divergence_matrix_cg
-  use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
-  use dgtools
+  use momentum_cg, only: correct_masslumped_velocity, add_kmk_matrix, add_kmk_rhs, assemble_kmk_matrix
+  use momentum_cg
+  use momentum_dg, only: correct_velocity_dg
   implicit none
 
   private

--- a/assemble/Solid_Configuration.F90
+++ b/assemble/Solid_Configuration.F90
@@ -3,18 +3,18 @@
 
 module solidconfiguration
   use fldebug
-  use fields
-  use fefields,only: compute_lumped_mass
-  use fetools, only: X_, Y_, Z_
   use spud
-  use state_module
-  use transform_elements
-  use boundary_conditions
   use global_parameters, only: OPTION_PATH_LEN, dt, current_time
-  use write_triangle
   use parallel_tools
   use vector_tools, only: det
+  use transform_elements
+  use fetools, only: X_, Y_, Z_
+  use fields
+  use state_module
   use vtk_interfaces, only: vtk_write_fields
+  use fefields,only: compute_lumped_mass
+  use boundary_conditions
+  use write_triangle
   implicit none
 
   private

--- a/assemble/Spontaneous_Potentials.F90
+++ b/assemble/Spontaneous_Potentials.F90
@@ -34,14 +34,14 @@ module spontaneous_potentials
   !!< porous media.
 
   use fldebug
-  use state_module
-  use fields
   use spud
+  use fields
+  use state_module
   use field_options
   use solvers
   use boundary_conditions
-  use boundary_conditions_from_options
   use sparsity_patterns_meshes
+  use boundary_conditions_from_options
 
   implicit none
   

--- a/assemble/State_Matrices.F90
+++ b/assemble/State_Matrices.F90
@@ -28,16 +28,16 @@
 module state_matrices_module
   !!< Module containing general tools for discretising Finite Element problems.
 
+  use global_parameters, only: FIELD_NAME_LEN
+  use spud
+  use eventcounter
   use fields
   use state_module
-  use global_parameters, only: FIELD_NAME_LEN
   use sparsity_patterns_meshes
+  use field_options
   use divergence_matrix_cv, only: assemble_divergence_matrix_cv
   use divergence_matrix_cg, only: assemble_divergence_matrix_cg
   use gradient_matrix_cg, only: assemble_gradient_matrix_cg
-  use eventcounter
-  use field_options
-  use spud
   implicit none
 
   interface get_divergence_matrix_cv

--- a/assemble/Surface_Id_Interleaving.F90
+++ b/assemble/Surface_Id_Interleaving.F90
@@ -29,10 +29,10 @@
 
 module surface_id_interleaving
 
-  use fields
   use fldebug
   use mpi_interfaces
   use parallel_tools
+  use fields
 
   implicit none
 

--- a/assemble/Timeloop_utilities.F90
+++ b/assemble/Timeloop_utilities.F90
@@ -27,14 +27,14 @@
 #include "fdebug.h"
 
 module timeloop_utilities
-  use state_module
-  use FEFields
-  use fields
   use spud
+  use global_parameters, only: simulation_start_cpu_time,&
+& simulation_start_wall_time, OPTION_PATH_LEN
+  use fields
+  use state_module
+  use fefields
   use signal_vars
   use timers
-  use global_parameters, only: simulation_start_cpu_time,&
-       & simulation_start_wall_time, OPTION_PATH_LEN
   implicit none
   
   private

--- a/assemble/Upwind_Stabilisation.F90
+++ b/assemble/Upwind_Stabilisation.F90
@@ -30,10 +30,11 @@ module upwind_stabilisation
   !!< This module provides routines for the upwind stabilisation of
   !!< advection_diffusion equations.
 
-  use fields
-  use metric_tools
   use spud
   use shape_functions
+  use metric_tools
+  use fields
+
 
   implicit none
 

--- a/assemble/Vertical_Balance_Pressure.F90
+++ b/assemble/Vertical_Balance_Pressure.F90
@@ -33,17 +33,17 @@ module vertical_balance_pressure
 
   use fldebug
   use elements
-  use sparse_tools
-  use fields
-  use state_module
-  use transform_elements
   use parallel_tools
   use spud
-  use boundary_conditions
-  use state_matrices_module
-  use upwind_stabilisation
+  use sparse_tools
+  use transform_elements
+  use fields
   use profiler
+  use state_module
+  use boundary_conditions
+  use upwind_stabilisation
   use solvers
+  use state_matrices_module
   implicit none
 
   public calculate_vertical_balance_pressure, &

--- a/assemble/Vorticity_Diagnostics.F90
+++ b/assemble/Vorticity_Diagnostics.F90
@@ -29,13 +29,13 @@
 
 module vorticity_diagnostics
 
+  use fldebug
   use coriolis_module
+  use fields
+  use state_module
   use field_derivatives
   use field_options
-  use fields
-  use fldebug
   use state_fields_module
-  use state_module
 
   implicit none
   

--- a/assemble/Zoltan_callbacks.F90
+++ b/assemble/Zoltan_callbacks.F90
@@ -6,43 +6,20 @@ module zoltan_callbacks
 #ifdef HAVE_ZOLTAN
 
   use zoltan
-  use zoltan_global_variables
-
-  ! Needed for zoltan_cb_owned_node_count
-  use halos, only: halo_nowned_nodes, halo_node_owner, halo_node_owners, get_owned_nodes, halo_universal_number
-  use metric_tools
-
-  ! Needed for zoltan_cb_get_owned_nodes
-  ! - added get_owned_nodes, halo_universal_number to use halos
-  use sparse_tools, only: row_length
-
-  ! Needed for zoltan_cb_get_num_edges
   use global_parameters, only: real_size, OPTION_PATH_LEN
-  use parallel_tools, only: getrank, getnprocs, getprocno, MPI_COMM_FEMTOOLS
-
-  ! Needed for zoltan_cb_get_edge_list
-  ! - added halo_node_owners to use halos
-  use mpi_interfaces
-
-  ! Needed for zoltan_cb_pack_node_sizes
-  ! - added real_size to use global_parameters
   use data_structures
-
-  ! Needed for zoltan_cb_pack_nodes
-  ! - use the whole of data structures now
-
-  ! Needed for zoltan_cb_pack_field_sizes
+  use mpi_interfaces
+  use parallel_tools, only: getrank, getnprocs, getprocno, MPI_COMM_FEMTOOLS
+  use sparse_tools, only: row_length
+  use metric_tools
   use state_module
-  use zoltan_detectors
-
-  ! Needed for zoltan_cb_pack_fields
-  ! - added remove_det_from_current_det_list to use diagnostic variables
+  use halos_derivation, only: ele_owner
+  use halos, only: halo_nowned_nodes, halo_node_owner, halo_node_owners, get_owned_nodes, halo_universal_number
   use detector_data_types, only: detector_type
+  use zoltan_global_variables
   use detector_tools
   use detector_parallel
-
-  ! Needed for zoltan_cb_unpack_fields
-  use halos_derivation, only: ele_owner
+  use zoltan_detectors
 
   implicit none
   

--- a/assemble/Zoltan_detectors.F90
+++ b/assemble/Zoltan_detectors.F90
@@ -6,14 +6,13 @@ module zoltan_detectors
 #ifdef HAVE_ZOLTAN
 
   use zoltan, only: zoltan_int
-  use zoltan_global_variables, only: zoltan_global_uen_to_new_local_numbering, zoltan_global_old_local_numbering_to_uen, zoltan_global_new_positions
   use data_structures, only: has_key, fetch
-
   use detector_data_types
+  use fields
+  use zoltan_global_variables, only: zoltan_global_uen_to_new_local_numbering, zoltan_global_old_local_numbering_to_uen, zoltan_global_new_positions
   use detector_tools
   use detector_parallel
 
-  use fields
 
   implicit none
 

--- a/assemble/Zoltan_global_variables.F90
+++ b/assemble/Zoltan_global_variables.F90
@@ -5,24 +5,14 @@ module zoltan_global_variables
 
 #ifdef HAVE_ZOLTAN
 
-  ! Needed for zoltan_cb_owned_node_count
-  use halos, only: halo_type
-
-  ! Needed for zoltan_cb_get_owned_nodes
-  use sparse_tools, only: csr_sparsity
-
-  ! Needed for zoltan_cb_get_edge_list
-  use fields, only: scalar_field, vector_field, mesh_type
-
-  ! Needed for zoltan_cb_pack_node_sizes
-  use zoltan, only: zoltan_int, zoltan_float
   use data_structures, only: integer_set, integer_hash_table
-
-  ! Needed for zoltan_cb_pack_field_size
-  use state_module, only: state_type
-  use detector_data_types, only: detector_linked_list
-
   use global_parameters, only: OPTION_PATH_LEN
+  use sparse_tools, only: csr_sparsity
+  use fields, only: scalar_field, vector_field, mesh_type
+  use zoltan, only: zoltan_int, zoltan_float
+  use state_module, only: state_type
+  use halos, only: halo_type
+  use detector_data_types, only: detector_linked_list
 
   implicit none
 

--- a/assemble/Zoltan_integration.F90
+++ b/assemble/Zoltan_integration.F90
@@ -4,47 +4,42 @@
 module zoltan_integration
 
 #ifdef HAVE_ZOLTAN
-! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler 
+  use global_parameters, only: real_size, OPTION_PATH_LEN, topology_mesh_name
   use quadrature
   use elements
+  use mpi_interfaces
+  use data_structures
+  use parallel_tools
+  use memory_diagnostics
   use sparse_tools
+  use linked_lists
+  use halos_ownership
+  use parallel_fields
+  use metric_tools
   use fields
   use state_module
-
   use field_options
-  use mpi_interfaces
-  use halos
-  use parallel_fields
-  use sparsity_patterns_meshes
   use vtk_interfaces
   use zoltan
-  use linked_lists
-  use global_parameters, only: real_size, OPTION_PATH_LEN, topology_mesh_name
-  use data_structures
-  use populate_state_module
-  use reserve_state_module
-  use boundary_conditions_from_options
-  use boundary_conditions
-  use metric_tools
-  use c_interfaces
-  use surface_id_interleaving
-  use halos_ownership
-  use memory_diagnostics
-  use detector_data_types
-  use detector_tools
-  use detector_parallel
-  use pickers
-  use hadapt_advancing_front
-  use parallel_tools
-  use fields_halos
-  use adapt_integration
-
-! adding to use the ele_owner function
   use halos_derivation
-  
+  use halos
+  use sparsity_patterns_meshes
+  use reserve_state_module
+  use boundary_conditions
+  use c_interfaces
+  use detector_data_types
+  use boundary_conditions_from_options
+  use detector_tools
+  use pickers
+  use detector_parallel
+  use hadapt_advancing_front
+  use fields_halos
+  use populate_state_module
+  use surface_id_interleaving
+  use adapt_integration
   use zoltan_global_variables
-  use zoltan_callbacks
   use zoltan_detectors
+  use zoltan_callbacks
 
   implicit none
 

--- a/assemble/qmesh.F90
+++ b/assemble/qmesh.F90
@@ -29,18 +29,18 @@
 
 module qmesh_module
 
+  use fldebug
+  use spud
   use fields
-  use FLDebug
-  use Form_Metric_Field
-  use edge_length_module
-  use field_derivatives
-  use metric_assemble
   use state_module
   use vtk_interfaces
-  use spud
+  use field_derivatives
+  use form_metric_field
+  use edge_length_module
   use tictoc
-    
-implicit none
+  use metric_assemble
+  
+  implicit none
 
   private
   

--- a/diagnostics/Binary_Operators.F90
+++ b/diagnostics/Binary_Operators.F90
@@ -29,13 +29,13 @@
 
 module binary_operators
 
-  use diagnostic_source_fields
-  use field_options
-  use fields
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN
   use spud
+  use fields
   use state_module
+  use field_options
+  use diagnostic_source_fields
   
   implicit none
   

--- a/diagnostics/Diagnostic_Fields_New.F90.in
+++ b/diagnostics/Diagnostic_Fields_New.F90.in
@@ -29,13 +29,13 @@
 
 module diagnostic_fields_new
 
-  use field_options
-  use fields
   use fldebug
-  use futils
   use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN
+  use futils
   use spud
+  use fields
   use state_module
+  use field_options
 
 USE_MODULES
   

--- a/diagnostics/Diagnostic_Source_Fields.F90
+++ b/diagnostics/Diagnostic_Source_Fields.F90
@@ -29,11 +29,11 @@
 
 module diagnostic_source_fields
 
-  use field_options
-  use fields
   use global_parameters, only : OPTION_PATH_LEN
   use spud
+  use fields
   use state_module
+  use field_options
 
   implicit none
  

--- a/diagnostics/Differential_Operators.F90
+++ b/diagnostics/Differential_Operators.F90
@@ -29,26 +29,24 @@
 
 module differential_operator_diagnostics
 
-! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler 
+  use fldebug
+  use global_parameters, only : OPTION_PATH_LEN
   use quadrature
   use elements
+  use spud
   use sparse_tools
+  use eventcounter
   use fields
   use state_module
-!
-  use diagnostic_source_fields
-  use divergence_matrix_cg
-  use eventcounter
-  use field_derivatives
   use field_options
-  use fldebug
-  use geostrophic_pressure
-  use global_parameters, only : OPTION_PATH_LEN
-  use solvers
+  use diagnostic_source_fields
+  use field_derivatives
   use sparse_matrices_fields
   use sparsity_patterns_meshes
-  use spud
   use state_fields_module
+  use divergence_matrix_cg
+  use solvers
+  use geostrophic_pressure
 
   implicit none
   

--- a/diagnostics/Field_Copies.F90
+++ b/diagnostics/Field_Copies.F90
@@ -29,21 +29,21 @@
 
 module field_copies_diagnostics
 
-  use diagnostic_source_fields
-  use field_options
-  use fields
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN
-  use smoothing_module
-  use solvers
-  use sparse_tools
-  use sparsity_patterns_meshes
   use spud
-  use state_module
-  use transform_elements
-  use state_fields_module
-  use sparse_matrices_fields
   use fldebug
+  use sparse_tools
+  use transform_elements
+  use fields
+  use state_module
+  use field_options
+  use diagnostic_source_fields
+  use sparse_matrices_fields
+  use solvers
+  use smoothing_module
+  use sparsity_patterns_meshes
+  use state_fields_module
 
   implicit none
   

--- a/diagnostics/Mass_Matrix_Diagnostics.F90
+++ b/diagnostics/Mass_Matrix_Diagnostics.F90
@@ -31,13 +31,13 @@ module mass_matrix_diagnostics
    
    !!< Module containing mass matrix related diagnostic algorithms.
 
-   use field_options
-   use fields
    use fldebug
    use global_parameters, only : OPTION_PATH_LEN
    use spud
+   use fields
+   use state_module 
+   use field_options
    use state_fields_module
-   use state_module
 
    implicit none
    

--- a/diagnostics/Mesh_Diagnostics.F90
+++ b/diagnostics/Mesh_Diagnostics.F90
@@ -28,14 +28,14 @@
 
 module mesh_diagnostics
 
-  use diagnostic_source_fields
-  use field_options
-  use fields
   use fldebug
-  use state_module
   use spud
   use global_parameters, only: FIELD_NAME_LEN
   use halos_numbering
+  use fields
+  use state_module
+  use field_options
+  use diagnostic_source_fields
 
   implicit none
   

--- a/diagnostics/Metric_Diagnostics.F90
+++ b/diagnostics/Metric_Diagnostics.F90
@@ -28,19 +28,19 @@
 
 module metric_diagnostics
 
+  use fldebug
+  use quicksort
+  use spud
+  use vector_tools
+  use metric_tools
+  use fields
+  use state_module
+  use field_options
   use conformity_measurement
   use diagnostic_source_fields
   use edge_length_module
   use field_derivatives
-  use field_options
-  use fields
   use form_metric_field
-  use fldebug
-  use metric_tools
-  use quicksort
-  use state_module
-  use spud
-  use vector_tools
 
   implicit none
   

--- a/diagnostics/Momentum_Diagnostics.F90
+++ b/diagnostics/Momentum_Diagnostics.F90
@@ -29,22 +29,22 @@
 
 module momentum_diagnostics
 
+  use fldebug
+  use global_parameters, only : OPTION_PATH_LEN
+  use spud
+  use fields
+  use state_module
   use boundary_conditions
   use coriolis_module, only : two_omega => coriolis
+  use field_options
   use diagnostic_source_fields
   use field_derivatives
-  use field_options
-  use fields
-  use fldebug
-  use geostrophic_pressure
-  use global_parameters, only : OPTION_PATH_LEN
-  use multimaterial_module
   use solvers
   use sparsity_patterns_meshes
-  use spud
   use state_fields_module
-  use state_module
   use sediment, only : get_n_sediment_fields, get_sediment_item
+  use geostrophic_pressure
+  use multimaterial_module
   
   implicit none
   

--- a/diagnostics/Multiphase_Diagnostics.F90
+++ b/diagnostics/Multiphase_Diagnostics.F90
@@ -30,13 +30,13 @@
 module multiphase_diagnostics
    !!< Module containing all generic multiphase-related diagnostic algorithms.
 
-   use field_options
-   use fields
    use fldebug
    use global_parameters, only : OPTION_PATH_LEN
    use spud
-   use state_fields_module
+   use fields
    use state_module
+   use field_options
+   use state_fields_module
 
    implicit none
    

--- a/diagnostics/Parallel_Diagnostics.F90
+++ b/diagnostics/Parallel_Diagnostics.F90
@@ -2,8 +2,8 @@
 
 module parallel_diagnostics
 
-  use fields
   use fldebug
+  use fields
   use halos
 
   implicit none

--- a/diagnostics/Python_Diagnostics.F90
+++ b/diagnostics/Python_Diagnostics.F90
@@ -29,11 +29,11 @@
 
 module python_diagnostics
 
-  use fields
   use fldebug
   use global_parameters, only : PYTHON_FUNC_LEN, OPTION_PATH_LEN
-  use python_state
   use spud
+  use fields
+  use python_state
   use state_module
 
   implicit none

--- a/diagnostics/Simple_Diagnostics.F90
+++ b/diagnostics/Simple_Diagnostics.F90
@@ -28,17 +28,17 @@
 #include "fdebug.h"
 
 module simple_diagnostics
-  use diagnostic_source_fields
-  use field_options
-  use fields_manipulation
-  use initialise_fields_module
-  use fields
+
   use fldebug
   use global_parameters, only : timestep, OPTION_PATH_LEN
   use spud
-  use state_fields_module
+  use fields
   use state_module
+  use field_options
+  use diagnostic_source_fields
   use vtk_cache_module
+  use initialise_fields_module
+  use state_fields_module
 
   implicit none
 

--- a/diagnostics/Surface.F90
+++ b/diagnostics/Surface.F90
@@ -29,13 +29,13 @@
 
 module surface_diagnostics
 
-  use diagnostic_source_fields
-  use field_options
-  use fields
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN
   use spud
+  use fields
   use state_module
+  use field_options
+  use diagnostic_source_fields
   use sediment
   use surface_integrals
   

--- a/diagnostics/Tidal_Diagnostics.F90
+++ b/diagnostics/Tidal_Diagnostics.F90
@@ -28,18 +28,19 @@
 #include "fdebug.h"
 
 module tidal_diagnostics
-  use diagnostic_source_fields
-  use field_options
-  use fields_manipulation
-  use initialise_fields_module
-  use fields
+
   use fldebug
   use global_parameters, only : timestep, OPTION_PATH_LEN, current_time
   use spud
-  use state_fields_module
+  use fields
   use state_module
-  use Tidal_module
+  use field_options
+  use diagnostic_source_fields
+  use initialise_fields_module
+  use state_fields_module
+  use tidal_module
   use write_state_module, only: do_write_state
+
   implicit none
 
   private

--- a/error_measures/Anisotropic_ZZ.F90
+++ b/error_measures/Anisotropic_ZZ.F90
@@ -6,31 +6,31 @@ module anisotropic_zz_module
 ! If you understand the algorithm, the code is trivial,
 ! but not vice versa!
 
-  use fields
+  use global_parameters
+  use quicksort
   use sparse_tools
-  use adjacency_lists
   use vector_tools
+  use tensors
+  use adjacency_lists
   use transform_elements
   use fetools
-  use tensors
-  use conformity_measurement
   use metric_tools
-  use quicksort
-  use sparsity_patterns
-  use diagnostic_fields
+  use fields
   use state_module
-  use global_parameters
+  use state_module
   use field_options
   use meshdiagnostics
   use vtk_interfaces
-  use bounding_box_metric
-  use state_module
   use merge_tensors
-  use edge_length_module
-  use form_metric_field
   use vtk_interfaces
   use halos
   use limit_metric_module
+  use conformity_measurement
+  use sparsity_patterns
+  use diagnostic_fields
+  use edge_length_module
+  use bounding_box_metric
+  use form_metric_field
   
   implicit none
 

--- a/error_measures/Anisotropic_gradation_metric.F90
+++ b/error_measures/Anisotropic_gradation_metric.F90
@@ -2,17 +2,17 @@
 
 module anisotropic_gradation
 
-  use fields
   use spud
-  use initialise_fields_module
-  use adjacency_lists
   use sparse_tools
-  use linked_lists
-  use gradation_metric
-  use merge_tensors
   use vector_tools
+  use adjacency_lists
+  use linked_lists
   use metric_tools
+  use fields
   use state_module
+  use initialise_fields_module
+  use merge_tensors
+  use gradation_metric
   use form_metric_field
 
   implicit none

--- a/error_measures/Aspect_ratios.F90
+++ b/error_measures/Aspect_ratios.F90
@@ -2,10 +2,10 @@
 
 module aspect_ratios_module
 
-  use fields
-  use metric_tools
   use spud
   use vector_tools
+  use metric_tools
+  use fields
 
   implicit none
 

--- a/error_measures/Assemble_metric.F90
+++ b/error_measures/Assemble_metric.F90
@@ -2,31 +2,30 @@
 
 module metric_assemble
 
-  use VTK_interfaces
+  use spud
+  use parallel_tools
+  use metric_tools
+  use state_module
+  use vtk_interfaces
+  use merge_tensors
+  use halos
   use surfacelabels
-!  use fields
   use field_derivatives
   use form_metric_field
-  use merge_tensors
   use edge_length_module
+  use aspect_ratios_module
   use interpolation_metric
   use goals
-  use goal_metric
   use gradation_metric
+  use goal_metric
   use bounding_box_metric
   use boundary_metric
   use geometric_constraints_metric
   use limit_metric_module
-  use metric_tools
-  use state_module
-  use halos
-  use spud
-  use parallel_tools
   use metric_advection
   use anisotropic_gradation
   use richardson_metric_module
   use anisotropic_zz_module
-  use aspect_ratios_module
   use reference_meshes
   use hadapt_metric_based_extrude, only: get_1d_mesh, recombine_metric, get_1d_tensor
   

--- a/error_measures/Boundary_metric.F90
+++ b/error_measures/Boundary_metric.F90
@@ -1,10 +1,12 @@
 #include "fdebug.h"
 
 module boundary_metric
-  use node_boundary, only: initialise_boundcount, node_lies_on_boundary
+
+  use global_parameters, only: domain_bbox
   use unittest_tools, only: get_mat_diag
   use fields
-  use global_parameters, only: domain_bbox
+  use node_boundary, only: initialise_boundcount, node_lies_on_boundary
+
   implicit none
 
   logical, save :: use_boundary_metric = .false.

--- a/error_measures/Bounding_box_metric.F90
+++ b/error_measures/Bounding_box_metric.F90
@@ -7,14 +7,15 @@ module bounding_box_metric
 !!< for the domain. Adaptivity really, really
 !!< doesn't like it, otherwise.
 
-  use vtk_interfaces
-  use edge_length_module
-  use merge_tensors
+  use spud
+  use global_parameters, only: domain_bbox
   use unittest_tools
   use metric_tools
   use fields
-  use spud
-  use global_parameters, only: domain_bbox
+  use vtk_interfaces
+  use edge_length_module
+  use merge_tensors
+
   implicit none
 
   logical, save :: use_bounding_box_metric = .true.

--- a/error_measures/Conformity_measurement.F90
+++ b/error_measures/Conformity_measurement.F90
@@ -7,16 +7,16 @@ module conformity_measurement
 !! International Journal for Numerical Methods in Engineering
 !! 2004, vol 61, issue 15
 
-  use fields
   use vector_tools
   use transform_elements
   use unittest_tools
+  use fetools
+  use metric_tools
+  use fields
   use state_module
   use fefields
   use meshdiagnostics
-  use fetools
   use merge_tensors
-  use metric_tools
   use limit_metric_module
 
   implicit none

--- a/error_measures/Edge_lengths.F90
+++ b/error_measures/Edge_lengths.F90
@@ -2,9 +2,9 @@
 
 module edge_length_module
 
-  use metric_tools
   use fldebug
   use unittest_tools
+  use metric_tools
   use fields
 
   implicit none

--- a/error_measures/Field_preprocessing.F90
+++ b/error_measures/Field_preprocessing.F90
@@ -2,11 +2,12 @@
 
 module field_preprocessing_module
 
+  use spud
+  use global_parameters
   use fields
   use smoothing_module
-  use spud
   use field_options
-  use global_parameters
+
   implicit none
 
   private

--- a/error_measures/Form_metric.F90
+++ b/error_measures/Form_metric.F90
@@ -3,16 +3,16 @@
 
 module form_metric_field
 
-  use fields
   use vector_tools
-  use unittest_tools
-  use merge_tensors
-  use metric_tools
-  use recovery_estimator
-  use vtk_interfaces, only: vtk_write_fields
   use global_parameters, only : OPTION_PATH_LEN
-  use state_module
   use spud
+  use unittest_tools
+  use metric_tools
+  use fields
+  use merge_tensors
+  use state_module
+  use vtk_interfaces, only: vtk_write_fields
+  use recovery_estimator
   use field_options
   
   implicit none

--- a/error_measures/Geometric_constraints_metric.F90
+++ b/error_measures/Geometric_constraints_metric.F90
@@ -4,17 +4,18 @@ module geometric_constraints_metric
 !!< This module wraps Gerard's geometric constraints
 !!< code and applied it during metric formation.
 
-  use vtk_interfaces
+  use parallel_tools
   use metric_tools
+  use fields
+  use state_module
+  use vtk_interfaces
   use merge_tensors
   use edge_length_module
-  use fields
+  use halos
   use node_boundary
   use form_metric_field
   use gradation_metric
-  use parallel_tools
-  use halos
-  use state_module
+
   implicit none
 
   logical :: use_geometric_constraints_metric = .false.

--- a/error_measures/Goal_metric.F90
+++ b/error_measures/Goal_metric.F90
@@ -4,22 +4,23 @@
 module goal_metric
 !!< Simple goal-based metric formation.
 
-  use elements
-  use fields
-  use edge_length_module, only: get_edge_lengths
-  use field_derivatives, only: compute_hessian, patch_type, get_patch_node
-  use state_module, only: state_type, extract_scalar_field, extract_vector_field, insert
   use global_parameters, only: dt, FIELD_NAME_LEN, OPTION_PATH_LEN
-  use form_metric_field, only: form_metric
-  use merge_tensors, only: merge_tensor_fields
+  use futils, only: count_chars, multiindex
+  use elements
+  use spud
   use transform_elements, only: transform_to_physical
   use fetools, only: shape_shape
-  use vtk_interfaces, only: vtk_write_fields
   use metric_tools, only: error_bound_name
-  use futils, only: count_chars, multiindex
+  use fields
+  use edge_length_module, only: get_edge_lengths
+  use state_module, only: state_type, extract_scalar_field, extract_vector_field, insert
+  use merge_tensors, only: merge_tensor_fields
+  use vtk_interfaces, only: vtk_write_fields
+  use field_derivatives, only: compute_hessian, patch_type, get_patch_node
+  use form_metric_field, only: form_metric
   use goals
   use gradation_metric, only: form_gradation_metric
-  use spud
+
   implicit none
 
   !! Use goal-based metric method, or

--- a/error_measures/Goals.F90
+++ b/error_measures/Goals.F90
@@ -4,16 +4,17 @@ module goals
 !!< A repository of goals and their gradients,
 !!< suitable for use with goal-based optimisation.
 
-  use elements
-  use fields
-  use fetools
-  use fefields
-  use state_module
-  use field_derivatives
-  use unittest_tools, only: get_matrix_identity
-  use vector_tools
-  use spud
   use fldebug
+  use vector_tools
+  use elements
+  use spud
+  use fetools
+  use unittest_tools, only: get_matrix_identity
+  use fields
+  use state_module
+  use fefields
+  use field_derivatives
+
   implicit none
 
   public :: goal_temp, goal_temp_grad, &

--- a/error_measures/Gradation_metric.F90
+++ b/error_measures/Gradation_metric.F90
@@ -11,13 +11,14 @@ module gradation_metric
 
   use unittest_tools
   use adjacency_lists
-  use vtk_interfaces
-  use node_boundary
   use linked_lists
   use metric_tools
-  use edge_length_module
   use fields
+  use vtk_interfaces
+  use node_boundary
+  use edge_length_module
   use field_derivatives
+
   implicit none
 
   ! These are the DEFAULTS ONLY IF YOU DON'T CALL

--- a/error_measures/Huang_metric.F90
+++ b/error_measures/Huang_metric.F90
@@ -3,16 +3,16 @@
 module huang_metric_module
 ! 10.1016/j.jcp.2004.10.024
 
+  use fldebug
+  use vector_tools
+  use global_parameters, only: domain_volume, OPTION_PATH_LEN
+  use spud
+  use metric_tools
   use fields
   use state_module
   use vtk_interfaces
-  use form_metric_field
-  use vector_tools
-  use global_parameters, only: domain_volume, OPTION_PATH_LEN
-  use fldebug
-  use spud
-  use metric_tools
   use field_options
+  use form_metric_field
 
   implicit none
 

--- a/error_measures/Interpolation_metric.F90
+++ b/error_measures/Interpolation_metric.F90
@@ -7,20 +7,19 @@ module interpolation_metric
 !!<   finite element calculations", Pain et. al,
 !!<  Comput. Methods Apll. Mech Engrg. 190 (2001) 3771-3796
 
-  use VTK_interfaces
-  use state_module
-  !use fields
-  use field_derivatives
-  use form_metric_field
-  use merge_tensors
-  use edge_length_module
-  use aspect_ratios_module
+  use spud
   use metric_tools
   use parallel_fields
-  use spud
-  use field_options
-  use field_preprocessing_module
+  use state_module
+  use vtk_interfaces
+  use merge_tensors
   use halos
+  use field_derivatives
+  use field_options
+  use form_metric_field
+  use edge_length_module
+  use aspect_ratios_module
+  use field_preprocessing_module
   use project_metric_to_surface_module
   
   implicit none

--- a/error_measures/Limit_metric.F90
+++ b/error_measures/Limit_metric.F90
@@ -2,12 +2,12 @@
 
 module limit_metric_module
 
-  use elements
-  use fields
   use fldebug
-  use meshdiagnostics
-  use spud
   use vector_tools, only : determinant => det
+  use elements
+  use spud
+  use fields
+  use meshdiagnostics
 
   implicit none
 

--- a/error_measures/Mba_adapt.F90
+++ b/error_measures/Mba_adapt.F90
@@ -1,14 +1,14 @@
 #include "fdebug.h"
 
 module mba_adapt_module
+  use eventcounter
+  use metric_tools
   use fields
   use state_module
-  use interpolation_module
   use meshdiagnostics
   use vtk_interfaces
-  use eventcounter
   use node_boundary
-  use metric_tools
+  use interpolation_module
   use limit_metric_module
 #ifdef HAVE_MBA_2D
   use mba2d_module

--- a/error_measures/Metric_advection.F90
+++ b/error_measures/Metric_advection.F90
@@ -27,42 +27,43 @@
 #include "fdebug.h"
 
 module metric_advection
+
+  use fldebug
+  use vector_tools
+  use global_parameters, only: OPTION_PATH_LEN
+  use futils, only: int2str
   use elements
+  use spud
+  use parallel_tools, only: getprocno
   use sparse_tools
+  use shape_functions
+  use cv_faces
+  use transform_elements
   use fetools
+  use unittest_tools
   use fields
   use state_module
-  use shape_functions
-  use transform_elements
-  use vector_tools
-  use fldebug
   use vtk_interfaces
+  use sparse_matrices_fields
   use solvers
   use boundary_conditions
-  use spud
   use merge_tensors
   use edge_length_module
   use sparsity_patterns
-  use sparse_matrices_fields
-  use CV_Shape_Functions
-  use CV_Faces
-  use CVTools
-  use CV_Upwind_Values
-  use CV_Face_Values
-  use CV_Options
+  use cv_shape_functions
+  use field_options, only: get_coordinate_field
+  use cvtools
+  use cv_options
+  use cv_upwind_values
+  use cv_face_values
+  use sparsity_patterns_meshes
+  use fefields, only: compute_cv_mass
+  use state_fields_module, only: get_cv_mass
   use diagnostic_variables, only: field_tag
   use diagnostic_fields, only: calculate_diagnostic_variable
-  use global_parameters, only: OPTION_PATH_LEN
-  use state_fields_module, only: get_cv_mass
-  use parallel_tools, only: getprocno
   use form_metric_field
   use populate_state_module
-  use unittest_tools
   use adaptive_timestepping
-  use field_options, only: get_coordinate_field
-  use sparsity_patterns_meshes
-  use futils, only: int2str
-  use fefields, only: compute_cv_mass
 
   implicit none
 

--- a/error_measures/Project_metric_to_surface.F90
+++ b/error_measures/Project_metric_to_surface.F90
@@ -2,18 +2,19 @@
 
 module project_metric_to_surface_module
 
-  use fields
+  use quicksort
+  use spud
   use sparse_tools
   use vector_tools
+  use fields
   use merge_tensors
-  use quicksort
   use state_module
+  use vtk_interfaces
   use hadapt_advancing_front
   use boundary_conditions
   use field_options
   use edge_length_module
-  use vtk_interfaces
-  use spud
+
   implicit none
 
   public :: project_metric_to_surface, vertically_align_metric, incorporate_bathymetric_metric

--- a/error_measures/Reference_Meshes.F90
+++ b/error_measures/Reference_Meshes.F90
@@ -2,14 +2,14 @@
 
 module reference_meshes
   
-  use conformity_measurement
-  use fields
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN
-  use interpolation_module
-  use merge_tensors
   use spud
+  use fields
+  use merge_tensors
   use state_module
+  use conformity_measurement
+  use interpolation_module
   
   implicit none
   

--- a/error_measures/Richardson_metric.F90
+++ b/error_measures/Richardson_metric.F90
@@ -2,17 +2,17 @@
 
 module richardson_metric_module
 
-  use edge_length_module
-  use field_options
-  use fields
   use global_parameters, only : OPTION_PATH_LEN
+  use spud
+  use vector_tools
+  use unittest_tools
+  use metric_tools
+  use fields
+  use edge_length_module
+  use state_module
+  use field_options
   use limit_metric_module
   use merge_tensors
-  use metric_tools
-  use unittest_tools
-  use spud
-  use state_module
-  use vector_tools
   
   implicit none
 

--- a/femtools/Adaptive_Timestepping.F90
+++ b/femtools/Adaptive_Timestepping.F90
@@ -30,16 +30,15 @@
 module adaptive_timestepping
   !!< Contains new style adaptive timestepping routines
   
-  use diagnostic_fields
-  use fields
-  use fields_data_types
-  use field_options
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN, FIELD_NAME_LEN
-  use signal_vars, only : SIG_INT
-  use state_module
   use spud
   use unittest_tools
+  use fields
+  use state_module
+  use field_options
+  use signal_vars, only : SIG_INT
+  use diagnostic_fields
    
   implicit none
   

--- a/femtools/Adaptive_interpolation.F90
+++ b/femtools/Adaptive_interpolation.F90
@@ -2,28 +2,28 @@
 
 module adaptive_interpolation_module
 
-  use quadrature
-  use elements
-  use fields
-  use sparse_tools
-  use supermesh_construction
-  use futils
-  use transform_elements
-  use meshdiagnostics
-  use sparsity_patterns
   use vector_tools
-  use tensors
-  use fetools
-  use sparse_tools
-  use solvers
-  use adjacency_lists
-  use vtk_interfaces
-  use unittest_tools
+  use quadrature
+  use futils
+  use elements
   use spud
   use quicksort
-  use intersection_finder_module
+  use sparse_tools
+  use tensors
+  use sparse_tools
+  use transform_elements
+  use adjacency_lists
+  use unittest_tools
   use linked_lists
+  use supermesh_construction
+  use fetools
+  use intersection_finder_module
+  use fields
+  use meshdiagnostics
+  use sparsity_patterns
+  use vtk_interfaces
   use sparse_matrices_fields
+  use solvers
   implicit none
 
   integer :: max_ai_degree=14

--- a/femtools/Adjacency_Lists.F90
+++ b/femtools/Adjacency_Lists.F90
@@ -29,12 +29,12 @@
 module adjacency_lists
   ! **********************************************************************
   !! Module to construct mesh adjacency lists.
-  use sparse_tools
   use FLDebug
-  use fields_base
-  use fields_data_types
-  use element_numbering
   use futils
+  use sparse_tools
+  use element_numbering
+  use fields_data_types
+  use fields_base
   implicit none
 
   interface MakeLists

--- a/femtools/Bound_field.F90
+++ b/femtools/Bound_field.F90
@@ -30,19 +30,19 @@
 module bound_field_module
 
   use FLDebug
-  use fields
   use spud
   use global_parameters, only : FIELD_NAME_LEN, real_8
-  use field_options
-  use sparse_matrices_fields
   use quicksort
+  use parallel_tools
   use sparse_tools
-  use sparsity_patterns
   use transform_elements
   use fetools
-  use halos
   use parallel_fields
-  use parallel_tools
+  use fields
+  use field_options
+  use sparse_matrices_fields
+  use sparsity_patterns
+  use halos
   implicit none
 
   type(scalar_field), save :: func_target_field, func_lumped_mass

--- a/femtools/Boundary_Conditions.F90
+++ b/femtools/Boundary_Conditions.F90
@@ -26,14 +26,14 @@
 !    USA
 #include "fdebug.h"
 module boundary_conditions
-use fields_data_types
-use fields
-use sparse_tools
-use sparse_tools_petsc
-use state_module
-use spud
-use global_parameters, only: OPTION_PATH_LEN
-implicit none
+  use spud
+  use global_parameters, only: OPTION_PATH_LEN
+  use sparse_tools
+  use fields_data_types
+  use fields
+  use sparse_tools_petsc
+  use state_module
+  implicit none
     
   interface add_boundary_condition
      module procedure add_scalar_boundary_condition, &

--- a/femtools/CVTools.F90
+++ b/femtools/CVTools.F90
@@ -27,13 +27,14 @@
 #include "fdebug.h"
 module cvtools
   !!< Module containing general tools for discretising Control Volume problems.
+
   use spud
-  use state_module
   use fldebug
   use vector_tools
-  use futils, only: int2str
-  use field_options, only: complete_field_path
   use global_parameters, only: OPTION_PATH_LEN, FIELD_NAME_LEN
+  use futils, only: int2str
+  use state_module
+  use field_options, only: complete_field_path
 
   implicit none
 

--- a/femtools/CV_Face_Values.F90
+++ b/femtools/CV_Face_Values.F90
@@ -28,16 +28,16 @@
 module cv_face_values
   !!< Module containing general tools for discretising Control Volume problems.
   use spud
-  use fields
+  use fldebug
   use sparse_tools
   use element_numbering
-  use state_module
-  use fldebug
-  use cv_shape_functions
-  use cv_faces
-  use cv_options
   use vector_tools
+  use cv_faces
   use transform_elements
+  use fields
+  use state_module
+  use cv_shape_functions
+  use cv_options
   use field_derivatives, only: grad
 
   implicit none

--- a/femtools/CV_Fields.F90
+++ b/femtools/CV_Fields.F90
@@ -28,11 +28,11 @@
 module cv_fields
   !!< Module containing general tools for discretising Control Volume problems.
   use spud
-  use state_module
   use fldebug
+  use fields
+  use state_module
   use cvtools
   use diagnostic_fields
-  use fields
 
   implicit none
 

--- a/femtools/CV_Options.F90
+++ b/femtools/CV_Options.F90
@@ -29,11 +29,11 @@ module cv_options
   !!< Module containing general tools for discretising Control Volume problems.
   use spud
   use fldebug
-  use cvtools, only: complete_cv_field_path
-  use field_options, only: complete_field_path
   use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
-  use element_numbering, only: FAMILY_SIMPLEX, FAMILY_CUBE
   use futils
+  use element_numbering, only: FAMILY_SIMPLEX, FAMILY_CUBE
+  use field_options, only: complete_field_path
+  use cvtools, only: complete_cv_field_path
 
   implicit none
 

--- a/femtools/CV_Shape_Functions.F90
+++ b/femtools/CV_Shape_Functions.F90
@@ -29,8 +29,8 @@
 module cv_shape_functions
   !!< Generate shape functions for elements of arbitrary polynomial degree.
   use FLDebug
-  use cv_faces, only: cv_faces_type
   use shape_functions
+  use cv_faces, only: cv_faces_type
   implicit none
   
   private

--- a/femtools/CV_Upwind_Values.F90
+++ b/femtools/CV_Upwind_Values.F90
@@ -27,24 +27,24 @@
 #include "fdebug.h"
 module cv_upwind_values
   !!< Module containing general tools for discretising Control Volume problems.
+  use fldebug
+  use vector_tools, only: norm2, cross_product, scalar_triple_product
+  use global_parameters, only: OPTION_PATH_LEN
   use quadrature
   use elements
   use spud
-  use fields
   use sparse_tools
-  use state_module
-  use fldebug
-  use cv_shape_functions, only: make_cvbdy_element_shape
   use cv_faces
+  use transform_elements, only: transform_cvsurf_facet_to_physical
+  use fields
+  use state_module
+  use cv_shape_functions, only: make_cvbdy_element_shape
   use cvtools, only: complete_cv_field_path
   use cv_options
-  use vector_tools, only: norm2, cross_product, scalar_triple_product
-  use transform_elements, only: transform_cvsurf_facet_to_physical
-  use field_derivatives, only: grad
-  use global_parameters, only: OPTION_PATH_LEN
   use boundary_conditions, only: get_periodic_boundary_condition, &
                                  get_entire_boundary_condition, &
                                  get_boundary_condition_nodes
+  use field_derivatives, only: grad
 
   implicit none
 

--- a/femtools/Checkpoint.F90
+++ b/femtools/Checkpoint.F90
@@ -30,21 +30,20 @@
 module checkpoint
   !!< Checkpointing routines
 
-  use fields
-  use fields_data_types
-  use field_options
   use fldebug
-  use futils
   use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN, simulation_start_time
-  use halos
+  use futils
+  use mpi_interfaces
   use parallel_tools
   use spud
+  use fields
   use state_module
+  use field_options
   use vtk_interfaces
+  use halos
   use mesh_files
   use detector_data_types
   use diagnostic_variables
-  use mpi_interfaces
 
   implicit none
 

--- a/femtools/Colouring.F90
+++ b/femtools/Colouring.F90
@@ -27,16 +27,14 @@
 #include "fdebug.h"
 
 module colouring
-  use fields
-  use fields_manipulation
-  use fields_base
-  use field_options, only : find_linear_parent_mesh
   use data_structures
-  use sparse_tools
   use global_parameters, only : topology_mesh_name, NUM_COLOURINGS, &
        COLOURING_CG1, COLOURING_DG0, COLOURING_DG2, &
        COLOURING_DG1
+  use sparse_tools
+  use fields
   use state_module, only : state_type, extract_mesh
+  use field_options, only : find_linear_parent_mesh
   use sparsity_patterns_meshes, only : get_csr_sparsity_secondorder, &
        get_csr_sparsity_firstorder
   implicit none

--- a/femtools/Conservative_interpolation.F90
+++ b/femtools/Conservative_interpolation.F90
@@ -5,35 +5,35 @@
 module conservative_interpolation_module
 
   use FLDebug
+  use vector_tools
+  use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN
   use quadrature
-  use elements
-  use fields
-  use sparse_tools
-  use supermesh_construction
   use futils
+  use elements
+  use spud
+  use data_structures
+  use sparse_tools
+  use tensors
+  use sparse_tools
   use transform_elements
+  use adjacency_lists
+  use unittest_tools
+  use linked_lists
+  use tetrahedron_intersection_module
+  use supermesh_construction
+  use fetools
+  use intersection_finder_module
+  use fields
   use meshdiagnostics
   use sparsity_patterns
-  use vector_tools
-  use tensors
-  use fetools
-  use sparse_tools
-  use interpolation_module
-  use solvers
-  use adjacency_lists
   use vtk_interfaces
-  use unittest_tools
-  use spud
-  use global_parameters, only : FIELD_NAME_LEN, OPTION_PATH_LEN
-  use intersection_finder_module
-  use linked_lists
-  use sparse_matrices_fields
-  use bound_field_module
   use halos
-  use diagnostic_fields
-  use tetrahedron_intersection_module
   use boundary_conditions
-  use data_structures
+  use interpolation_module
+  use sparse_matrices_fields
+  use solvers
+  use bound_field_module
+  use diagnostic_fields
   implicit none
 
   interface interpolation_galerkin

--- a/femtools/Coordinates.F90
+++ b/femtools/Coordinates.F90
@@ -30,15 +30,14 @@
 module Coordinates
   use FLDebug
   use vector_tools
-  use fields
+  use iso_c_binding
   use global_parameters
   use spud
-  use halos
   use halos_base
+  use fields
   use sparse_tools_petsc
   use state_module
-  use global_parameters, only: surface_radius
-  use iso_c_binding
+  use halos
 
   implicit none
   

--- a/femtools/DG_interpolation.F90
+++ b/femtools/DG_interpolation.F90
@@ -2,27 +2,27 @@
 
 module dg_interpolation_module
 
+  use vector_tools
   use quadrature
-  use fields
-  use sparse_tools
-  use supermesh_construction
   use futils
+  use spud
+  use sparse_tools
+  use tensors
+  use sparse_tools
   use transform_elements
+  use adjacency_lists
+  use unittest_tools
+  use linked_lists
+  use supermesh_construction
+  use fetools
+  use intersection_finder_module
+  use fields
   use meshdiagnostics
   use sparsity_patterns
-  use vector_tools
-  use tensors
-  use fetools
-  use sparse_tools
-  use interpolation_module
-  use solvers
-  use adjacency_lists
   use vtk_interfaces
-  use unittest_tools
-  use spud
-  use intersection_finder_module
-  use linked_lists
+  use interpolation_module
   use sparse_matrices_fields
+  use solvers
   implicit none
 
   private

--- a/femtools/Detector_Move_Lagrangian.F90
+++ b/femtools/Detector_Move_Lagrangian.F90
@@ -28,13 +28,13 @@
 #include "fdebug.h"
 
 module detector_move_lagrangian
-  use state_module
   use spud
-  use fields
   use global_parameters, only: OPTION_PATH_LEN
   use integer_hash_table_module
   use halo_data_types
   use halos_base
+  use fields
+  use state_module
   use detector_data_types
   use detector_tools
   use detector_parallel

--- a/femtools/Detector_Parallel.F90
+++ b/femtools/Detector_Parallel.F90
@@ -28,15 +28,15 @@
 #include "fdebug.h"
 
 module detector_parallel
-  use state_module
-  use fields
   use spud
   use integer_hash_table_module
-  use detector_data_types
-  use detector_tools
+  use mpi_interfaces
   use halo_data_types
   use halos_numbering
-  use mpi_interfaces
+  use fields
+  use state_module
+  use detector_data_types
+  use detector_tools
   use pickers
 
   implicit none

--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -31,8 +31,8 @@ module detector_tools
   use spud
   use fldebug
   use detector_data_types
-  use fields
   use integer_hash_table_module
+  use fields
   
   implicit none
   

--- a/femtools/Dgtools.F90
+++ b/femtools/Dgtools.F90
@@ -2,16 +2,16 @@
 
 module dgtools
 
-use elements
-use sparse_tools
-use sparsity_patterns
 use vector_tools
-use fields
-use fields_data_types
-use FETools
-use transform_elements
-use boundary_conditions, only: get_boundary_condition_nodes
+use elements
 use halos_base
+use sparse_tools
+use fields_data_types
+use sparsity_patterns
+use transform_elements
+use FETools
+use fields
+use boundary_conditions, only: get_boundary_condition_nodes
 
 implicit none
 

--- a/femtools/Diagnostic_Fields.F90
+++ b/femtools/Diagnostic_Fields.F90
@@ -31,34 +31,33 @@ module diagnostic_fields
   !!< A module to calculate diagnostic fields.
 
   use global_parameters, only:FIELD_NAME_LEN, current_time, OPTION_PATH_LEN
+  use futils
+  use spud
+  use Vector_Tools
+  use CV_Faces
+  use parallel_tools
+  use quicksort
+  use fetools
+  use unittest_tools
   use fields
+  use state_module
   use halos
+  use boundary_conditions
   use field_derivatives
   use field_options
-  use state_module
-  use futils
-  use fetools
+  use sparse_matrices_fields
   use fefields, only: compute_lumped_mass, compute_cv_mass
   use MeshDiagnostics
-  use spud
   use CV_Shape_Functions, only: make_cv_element_shape, make_cvbdy_element_shape
-  use CV_Faces
   use CVTools
+  use cv_options
   use CV_Upwind_Values
   use CV_Face_Values, only: evaluate_face_val, theta_val
-  use cv_options
-  use parallel_tools
   use sparsity_patterns
   use sparsity_patterns_meshes
   use solvers
-  use sparse_matrices_fields
-  use boundary_conditions, only: get_entire_boundary_condition, get_dg_surface_mesh
-  use quicksort
-  use unittest_tools
-  use boundary_conditions
   use state_fields_module
   use interpolation_module
-  use Vector_Tools
   use streamfunction
 
   implicit none

--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -29,56 +29,53 @@
 
 module diagnostic_variables
   !!< A module to calculate and output diagnostics. This replaces the .s file.
-  use quadrature
-  use elements
   use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN, &
     & PYTHON_FUNC_LEN, int_16, integer_size, real_size
-  use fields
+  use quadrature
+  use futils
+  use elements
+  use spud
+  use mpi_interfaces
+  use parallel_tools
+  use memory_diagnostics
+  use integer_hash_table_module
+  use data_structures
+  use halo_data_types
+  use halos_base
+  use halos_debug
+  use halos_allocates
+  use ieee_arithmetic
+  use sparse_tools
   use fields_base
+  use eventcounter
+  use fetools
+  use unittest_tools
+  use halos_communications
+  use halos_numbering
+  use halos_ownership
+  use fields_manipulation
+  use fields
+  use profiler
+  use state_module
+  use vtk_interfaces
+  use halos_derivation
+  use halos_registration
   use field_derivatives
   use field_options
-  use state_module
-  use futils
-  use fetools
+  use c_interfaces
   use fefields
-  use MeshDiagnostics
-  use spud
-  use parallel_tools
-  use Profiler
+  use meshdiagnostics
   use sparsity_patterns
   use solvers
   use write_state_module, only: vtk_write_state_new_options
   use surface_integrals
-  use vtk_interfaces
-  use embed_python
-  use eventcounter
-  use pickers
-  use sparse_tools
-  use mixing_statistics
-  use c_interfaces
-!  use checkpoint
-  use memory_diagnostics
-  use data_structures
-  use unittest_tools
-  use integer_hash_table_module
-  use halo_data_types
-  use halos_allocates
-  use halos_base
-  use halos_debug
-  use halos_numbering
-  use halos_ownership
-  use halos_derivation
-  use halos_communications
-  use halos_registration
-  use mpi_interfaces
-  use parallel_tools
-  use fields_manipulation
   use detector_data_types
+  use pickers
+  use mixing_statistics
   use detector_tools
   use detector_parallel
   use detector_move_lagrangian
-  use ieee_arithmetic, only: cget_nan
-  use state_fields_module, only: get_cv_mass
+  use state_fields_module
   
   implicit none
 

--- a/femtools/Element_Numbering.F90
+++ b/femtools/Element_Numbering.F90
@@ -44,8 +44,8 @@ module element_numbering
   !!<
   !!< Nodes are subdivided into four disjoint sets: vertex nodes, those lying
   !!< on edges, those lying on faces and those interior to elements. 
-  use futils
   use FLDebug
+  use futils
   implicit none
 
   integer, parameter :: ELEMENT_LAGRANGIAN=1, ELEMENT_NONCONFORMING=2, ELEMENT_BUBBLE=3, &

--- a/femtools/Elements.F90
+++ b/femtools/Elements.F90
@@ -28,11 +28,11 @@
 #include "fdebug.h"
 module elements
   !!< This module provides derived types for finite elements and associated functions.
-  use element_numbering
-  use quadrature
   use FLDebug
-  use polynomials
+  use element_numbering
   use reference_counting
+  use quadrature
+  use polynomials
   implicit none
 
   type element_type

--- a/femtools/Embed_Python_Fortran.F90
+++ b/femtools/Embed_Python_Fortran.F90
@@ -30,8 +30,8 @@
 module embed_python
 
   use fldebug
-  use global_parameters, only : real_4, real_8
   use iso_c_binding
+  use global_parameters, only : real_4, real_8
 
   implicit none
   

--- a/femtools/FEFields.F90
+++ b/femtools/FEFields.F90
@@ -3,16 +3,16 @@ module fefields
   !!< Module containing general tools for discretising Finite Element problems.
 
   use data_structures
+  use element_numbering
+  use elements, only: element_type
+  use sparse_tools
+  use transform_elements, only: transform_to_physical, element_volume
+  use fetools, only: shape_shape
   use fields
+  use state_module
   use field_options, only: get_coordinate_field
   use halos
-  use elements, only: element_type
-  use element_numbering
-  use fetools, only: shape_shape
-  use transform_elements, only: transform_to_physical, element_volume
-  use sparse_tools
   use sparse_matrices_fields
-  use state_module
   implicit none
 
   interface add_source_to_rhs

--- a/femtools/FETools.F90
+++ b/femtools/FETools.F90
@@ -4,8 +4,8 @@ module fetools
   !!< Module containing general tools for discretising Finite Element problems.
 
   use elements
-  use transform_elements
   use fields_base
+  use transform_elements
   implicit none
 
   !! X, Y and Z indices.

--- a/femtools/Field_Options.F90
+++ b/femtools/Field_Options.F90
@@ -30,20 +30,19 @@ module field_options
    !!< This module contains code that uses scalar/vector/tensor_fields
    !!< in combination with floptions. Anything schema specific.
 
+   use FLDebug
+   use Global_Parameters, only: OPTION_PATH_LEN, adaptivity_mesh_name
    use quadrature
+   use futils
    use elements
    use spud
-   use FLDebug
+   use data_structures
    use Fields_Data_Types
    use fields_base
    use fields_allocates
    use fields_manipulation
-   use fields_calculations
-   use Global_Parameters, only: OPTION_PATH_LEN, adaptivity_mesh_name
-   use state_module
-   use futils
    use metric_tools
-   use data_structures
+   use fields_calculations
    use state_module
 
    implicit none
@@ -112,9 +111,6 @@ module field_options
 contains
 
   recursive subroutine print_children(path)
-
-    use spud
-    use global_parameters, only: OPTION_PATH_LEN
 
     implicit none
 

--- a/femtools/Field_derivatives.F90
+++ b/femtools/Field_derivatives.F90
@@ -8,19 +8,19 @@ module field_derivatives
     !!< (Since the k-th derivative of a scalar field is a rank-k tensor,
     !!< anything with k > 2 rapidly becomes far too big to store in memory.)
 
+    use vector_tools
     use elements
+    use eventcounter
+    use superconvergence
+    use transform_elements
     use fetools, only: shape_shape, shape_dshape, dshape_outer_dshape
     use fields
-    use halos
-    use eventcounter
-    use transform_elements
-    use vector_tools
-    use vector_set
-    use node_boundary
-    use surfacelabels
-    use vtk_interfaces
-    use superconvergence
     use state_module
+    use vtk_interfaces
+    use halos
+    use vector_set
+    use surfacelabels
+    use node_boundary
     use boundary_conditions, only: get_entire_boundary_condition
     implicit none
 

--- a/femtools/Fields_Allocates.F90
+++ b/femtools/Fields_Allocates.F90
@@ -26,23 +26,23 @@
 !    USA
 #include "fdebug.h"
 module fields_allocates
-use elements
-use fields_data_types
-use fields_base
-use shape_functions, only: make_element_shape
 use global_parameters, only: PYTHON_FUNC_LEN, empty_path, empty_name, &
      topology_mesh_name, NUM_COLOURINGS
+use elements
+use ieee_arithmetic
+use shape_functions, only: make_element_shape
 use halo_data_types
+use parallel_tools
 use halos_allocates
+use memory_diagnostics
+use data_structures
+use fields_data_types
+use fields_base
 use halos_repair
 use pickers_deallocates
 use adjacency_lists
 use global_numbering, only: make_global_numbering, make_global_numbering_dg,&
      &make_global_numbering_trace
-use memory_diagnostics
-use ieee_arithmetic
-use data_structures
-use parallel_tools
 
 implicit none
 

--- a/femtools/Fields_Base.F90
+++ b/femtools/Fields_Base.F90
@@ -29,16 +29,16 @@
 module fields_base
   !!< This module contains abstracted field types which carry shape and
   !!< connectivity with them.
+  use global_parameters, only: FIELD_NAME_LEN, current_debug_level, current_time
+  use reference_counting
+  use element_numbering
+  use vector_tools, only: solve, invert, norm2, cross_product
+  use elements
   use shape_functions, only: element_type
   use tensors
-  use fields_data_types
-  use reference_counting
-  use global_parameters, only: FIELD_NAME_LEN, current_debug_level, current_time
-  use elements
-  use element_numbering
-  use embed_python
   use sparse_tools
-  use vector_tools, only: solve, invert, norm2, cross_product
+  use fields_data_types
+  use embed_python
   implicit none
 
   interface ele_nodes

--- a/femtools/Fields_Calculations.F90
+++ b/femtools/Fields_Calculations.F90
@@ -27,18 +27,18 @@
 #include "fdebug.h"
 module fields_calculations
 
+use vector_tools
 use elements
-use fields_allocates
+use parallel_tools
 use fields_data_types
 use fields_base
+use linked_lists
+use fields_allocates
 use fields_manipulation
 use fetools
 use parallel_fields
-use parallel_tools
-use vector_tools
 use supermesh_construction
 use intersection_finder_module
-use linked_lists
 
 implicit none
     

--- a/femtools/Fields_Data_Types.F90
+++ b/femtools/Fields_Data_Types.F90
@@ -28,13 +28,13 @@
 module fields_data_types
 
   use global_parameters, only:FIELD_NAME_LEN, current_debug_level, OPTION_PATH_LEN, PYTHON_FUNC_LEN
+  use reference_counting
   use picker_data_types
   use shape_functions
-  use sparse_tools
   use spud
-  use reference_counting
   use halo_data_types
   use data_structures, only : integer_set_vector
+  use sparse_tools
   implicit none
 
   private

--- a/femtools/Fields_Halos.F90
+++ b/femtools/Fields_Halos.F90
@@ -27,9 +27,9 @@
 #include "fdebug.h"
 module fields_halos
 !!< This module contains code that depends on both fields and halos
+use data_structures
 use fields
 use halos
-use data_structures
 implicit none
 
 private

--- a/femtools/Fields_Manipulation.F90
+++ b/femtools/Fields_Manipulation.F90
@@ -26,25 +26,25 @@
 !    USA
 #include "fdebug.h"
 module fields_manipulation
-use elements
-use element_set
-use embed_python
-use data_structures
-use fields_data_types
-use fields_base
-use fields_allocates
-use halo_data_types
-use halos_allocates
-use halos_base
-use halos_debug
-use halos_numbering
-use halos_ownership
-use halos_repair
-use quicksort
-use parallel_tools
-use vector_tools
-use memory_diagnostics
-implicit none
+  use vector_tools
+  use elements
+  use element_set
+  use embed_python
+  use data_structures
+  use halo_data_types
+  use quicksort
+  use parallel_tools
+  use halos_base
+  use halos_debug
+  use memory_diagnostics
+  use halos_allocates
+  use fields_data_types
+  use fields_base
+  use halos_numbering
+  use halos_ownership
+  use halos_repair
+  use fields_allocates
+  implicit none
 
   private
 

--- a/femtools/Global_Numbering.F90
+++ b/femtools/Global_Numbering.F90
@@ -30,20 +30,20 @@ module global_numbering
   ! **********************************************************************
   ! Module to construct the global node numbering map for elements of a
   ! given degree.
-  use adjacency_lists
-  use elements
-  use sparse_tools
   use fldebug
+  use elements
+  use mpi_interfaces
   use halo_data_types
-  use halos_allocates
+  use parallel_tools
   use halos_base
   use halos_debug
-  use halos_numbering
-  use halos_ownership
-  use parallel_tools
-  use linked_lists
-  use mpi_interfaces
+  use halos_allocates
+  use sparse_tools
   use fields_base
+  use adjacency_lists
+  use linked_lists
+  use halos_numbering
+  use halos_ownership 
   
   implicit none
 

--- a/femtools/Halo_Data_Types.F90
+++ b/femtools/Halo_Data_Types.F90
@@ -29,8 +29,8 @@
 
 module halo_data_types
 
-  use futils
   use global_parameters, only : FIELD_NAME_LEN
+  use futils
   use mpi_interfaces
   use reference_counting
 

--- a/femtools/Halos.F90
+++ b/femtools/Halos.F90
@@ -30,16 +30,16 @@
 module halos
 
   use halo_data_types
-  use halos_allocates
   use halos_base
   use halos_debug
-  use halos_diagnostics
-  use halos_derivation
+  use halos_allocates
   use halos_communications
   use halos_numbering
   use halos_ownership
-  use halos_registration
   use halos_repair
+  use halos_diagnostics
+  use halos_derivation
+  use halos_registration
 
   implicit none
   

--- a/femtools/Halos_Allocates.F90
+++ b/femtools/Halos_Allocates.F90
@@ -31,12 +31,12 @@ module halos_allocates
 
   use fldebug
   use global_parameters, only : empty_name
+  use mpi_interfaces
+  use reference_counting
   use halo_data_types
+  use parallel_tools
   use halos_base
   use halos_debug
-  use mpi_interfaces
-  use parallel_tools
-  use reference_counting
 
   implicit none
   

--- a/femtools/Halos_Base.F90
+++ b/femtools/Halos_Base.F90
@@ -30,8 +30,8 @@
 module halos_base
 
   use fldebug
-  use halo_data_types
   use mpi_interfaces
+  use halo_data_types
   use quicksort
   use parallel_tools
 

--- a/femtools/Halos_Communications.F90
+++ b/femtools/Halos_Communications.F90
@@ -29,18 +29,18 @@
 
 module halos_communications
 
-  use fields_data_types
-  use fields_base
   use fldebug
   use futils
+  use mpi_interfaces
   use halo_data_types
-  use halos_allocates
+  use parallel_tools
+  use quicksort
   use halos_base
   use halos_debug
-  use mpi_interfaces
-  use parallel_tools
+  use halos_allocates
+  use fields_data_types
+  use fields_base
   use linked_lists
-  use quicksort
 
   implicit none
   

--- a/femtools/Halos_Debug.F90
+++ b/femtools/Halos_Debug.F90
@@ -30,10 +30,10 @@
 module halos_debug
 
   use fldebug
-  use halo_data_types
-  use halos_base
   use mpi_interfaces
+  use halo_data_types
   use parallel_tools
+  use halos_base
 
   implicit none
   

--- a/femtools/Halos_Derivation.F90
+++ b/femtools/Halos_Derivation.F90
@@ -27,25 +27,28 @@
 
 module halos_derivation
 
-  use data_structures
-  use fields_data_types
-  use fields_allocates
-  use fields_manipulation
-  use fields_base
-  use fldebug
-  use halo_data_types
-  use halos_allocates
-  use halos_base
-  use halos_debug
-  use halos_numbering
-  use halos_ownership
-  use halos_repair
-  use halos_communications
-  use mpi_interfaces
-  use parallel_tools
-  use sparse_tools
-  use linked_lists
-  use parallel_tools
+   use fldebug
+   use data_structures
+   use mpi_interfaces
+   use halo_data_types
+   use parallel_tools
+   use parallel_tools
+   use halos_base
+   use halos_debug
+   use halos_allocates
+   use sparse_tools
+   use fields_data_types
+   use fields_base
+   use linked_lists
+   use halos_communications
+   use halos_numbering
+   use halos_ownership
+   use halos_repair
+   use fields_allocates
+   use fields_manipulation
+#ifdef HAVE_ZOLTAN
+    use zoltan
+#endif
 
   implicit none
 
@@ -916,9 +919,6 @@ contains
   end function invert_comms_global
 
   function invert_comms(knowns, communicator) result(unknowns)
-#ifdef HAVE_ZOLTAN
-    use zoltan
-#endif
 
     type(integer_set), dimension(:), intent(in) :: knowns
     type(integer_set), dimension(size(knowns)) :: unknowns ! we'll actually know them by the end, but however

--- a/femtools/Halos_Diagnostics.F90
+++ b/femtools/Halos_Diagnostics.F90
@@ -28,14 +28,14 @@
 #include "fdebug.h"
 module halos_diagnostics
   !!< this module contains routines for diagnosing halo problems.
-  use vtk_interfaces
-  use fields_data_types
-  use fields_allocates
-  use fields_base
   use shape_functions
-  use halos_numbering
   use halo_data_types
+  use fields_data_types
+  use fields_base
+  use halos_numbering
+  use fields_allocates
   use fields_manipulation
+  use vtk_interfaces
   implicit none
 
   private

--- a/femtools/Halos_Numbering.F90
+++ b/femtools/Halos_Numbering.F90
@@ -29,17 +29,17 @@
 
 module halos_numbering
 
-  use data_structures
   use fldebug
+  use data_structures
   use futils
-  use halo_data_types
-  use halos_allocates
-  use halos_base
-  use halos_communications
-  use halos_debug
   use mpi_interfaces
+  use halo_data_types
   use parallel_tools
   use quicksort
+  use halos_base
+  use halos_debug
+  use halos_allocates
+  use halos_communications
 
   implicit none
   

--- a/femtools/Halos_Ownership.F90
+++ b/femtools/Halos_Ownership.F90
@@ -5,12 +5,12 @@ module halos_ownership
   use fldebug
   use futils
   use halo_data_types
-  use halos_allocates
-  use halos_base
-  use halos_debug
-  use halos_numbering
   use parallel_tools
   use quicksort
+  use halos_base
+  use halos_debug
+  use halos_allocates
+  use halos_numbering
   
   implicit none
   

--- a/femtools/Halos_Registration.F90
+++ b/femtools/Halos_Registration.F90
@@ -28,25 +28,25 @@
 #include "fdebug.h"
 
 module halos_registration
-
-  use fields_allocates
-  use fields_base
-  use fields_data_types
-  use fields_manipulation
+  
   use fldebug
   use futils
+  use mpi_interfaces
   use halo_data_types
-  use halos_allocates
+  use parallel_tools
   use halos_base
   use halos_debug
-  use halos_communications
-  use halos_derivation
-  use halos_ownership
-  use halos_numbering
-  use mpi_interfaces
-  use parallel_tools
+  use halos_allocates
   use data_structures
-
+  use fields_data_types
+  use fields_base
+  use halos_communications
+  use halos_numbering
+  use halos_ownership
+  use fields_allocates
+  use fields_manipulation
+  use halos_derivation
+   
   implicit none
   
   private

--- a/femtools/Halos_Repair.F90
+++ b/femtools/Halos_Repair.F90
@@ -29,17 +29,17 @@
 
 module halos_repair
 
-  use fields_data_types
-  use fields_base
-  use parallel_tools
   use fldebug
+  use mpi_interfaces
+  use parallel_tools
   use halo_data_types
+  use quicksort
   use halos_base
   use halos_debug
+  use fields_data_types
+  use fields_base
   use halos_numbering
   use halos_ownership
-  use mpi_interfaces
-  use quicksort
 
   implicit none
 

--- a/femtools/Interpolation.F90
+++ b/femtools/Interpolation.F90
@@ -1,18 +1,18 @@
 #include "fdebug.h"
 
 module interpolation_module
-  use fields
-  use superconvergence
-  use field_derivatives
-  use state_module
-  use sparse_tools
-  use supermesh_construction
   use futils
+  use superconvergence
+  use sparse_tools
   use transform_elements
+  use supermesh_construction
+  use parallel_fields
+  use fields
+  use state_module
+  use field_derivatives
   use meshdiagnostics
   use field_options
   use node_ownership
-  use parallel_fields
   implicit none
 
   interface linear_interpolation

--- a/femtools/Intersection_finder.F90
+++ b/femtools/Intersection_finder.F90
@@ -5,16 +5,16 @@ module intersection_finder_module
 
 use quadrature
 use elements
-use fields_base
+use parallel_tools
+use data_structures
 use fields_data_types
-use fields_allocates
+use fields_base
 use adjacency_lists
 use linked_lists
+use fields_allocates
 use parallel_fields
-use parallel_tools
-use supermesh_construction
 use transform_elements
-use data_structures
+use supermesh_construction
 
 implicit none
 

--- a/femtools/Lagrangian_Remap.F90
+++ b/femtools/Lagrangian_Remap.F90
@@ -1,14 +1,14 @@
 
 
 module lagrangian_remap
-  use conservative_interpolation_module
+  use sparse_tools
   use fields
   use vtk_interfaces
   use interpolation_module
+  use sparse_matrices_fields
   use solvers
   use sparsity_patterns
-  use sparse_tools
-  use sparse_matrices_fields
+  use conservative_interpolation_module
 
   implicit none
 

--- a/femtools/Matrix_Norms.F90
+++ b/femtools/Matrix_Norms.F90
@@ -2,8 +2,8 @@
 
 module matrix_norms
 
-  use fields
   use vector_tools
+  use fields
   use node_boundary
   implicit none
 

--- a/femtools/Merge_tensors.F90
+++ b/femtools/Merge_tensors.F90
@@ -6,10 +6,10 @@ module merge_tensors
     !!< satisfying both constraints.
     !!< See Gerard Gorman's thesis, section 2.4.
 
-    use fields
     use vector_tools
-    use metric_tools, only: aspect_ratio
     use unittest_tools
+    use metric_tools, only: aspect_ratio
+    use fields
     implicit none
 
     private

--- a/femtools/MeshDiagnostics.F90
+++ b/femtools/MeshDiagnostics.F90
@@ -28,13 +28,13 @@
 #include "fdebug.h"
 module MeshDiagnostics
 
-  use transform_elements
+  use fldebug
   use elements
   use spud
-  use fldebug
-  use parallel_fields
   use parallel_tools
   use fields_base
+  use transform_elements
+  use parallel_fields
 
   implicit none
 

--- a/femtools/Mesh_Files.F90
+++ b/femtools/Mesh_Files.F90
@@ -43,21 +43,18 @@
 
 
 module mesh_files
+  use global_parameters, only : OPTION_PATH_LEN
   use futils
   use elements
+  use spud
   use fields
   use state_module
-
-  use global_parameters, only : OPTION_PATH_LEN
-
   use gmsh_common
   use read_gmsh
   use read_triangle
   use read_exodusii
   use write_gmsh
   use write_triangle
-
-  use spud
 
   implicit none
 

--- a/femtools/Metric_tools.F90
+++ b/femtools/Metric_tools.F90
@@ -2,14 +2,14 @@
 
 module metric_tools
 
+  use fldebug
+  use vector_tools
+  use spud
   use unittest_tools
   use fields_data_types
   use fields_base
   use fields_allocates
   use fields_manipulation
-  use vector_tools
-  use spud
-  use fldebug
   implicit none
 
   interface edge_length_from_eigenvalue

--- a/femtools/Mixing_Statistics.F90
+++ b/femtools/Mixing_Statistics.F90
@@ -29,20 +29,20 @@
 
 module mixing_statistics
 
+  use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN
+  use futils
   use elements
   use embed_python
-  use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN
+  use spud
+  use fetools
+  use unittest_tools
   use fields
+  use state_module
+  use halos
   use field_derivatives
   use field_options
-  use state_module
-  use futils
-  use fetools
   use fefields
-  use halos
   use MeshDiagnostics
-  use spud
-  use unittest_tools
 
   implicit none
   

--- a/femtools/Multigrid.F90
+++ b/femtools/Multigrid.F90
@@ -2,9 +2,6 @@
 !! This module contains multigrid related subroutines, such as the smoothed
 !! aggregation preconditioner.
 module multigrid
-use Petsc_Tools
-use Sparse_tools
-use sparse_tools_petsc
 use FLDebug
 use spud
 use futils
@@ -12,6 +9,9 @@ use parallel_tools
 #ifdef HAVE_PETSC_MODULES
   use petsc
 #endif
+use Sparse_tools
+use Petsc_Tools
+use sparse_tools_petsc
 implicit none
 #include "petsc_legacy.h"
 

--- a/femtools/Node_Owner_Finder_Fortran.F90
+++ b/femtools/Node_Owner_Finder_Fortran.F90
@@ -29,11 +29,11 @@
 
 module node_owner_finder
 
-  use data_structures
-  use fields
   use fldebug
+  use data_structures
   use global_parameters, only : real_4, real_8
   use mpi_interfaces
+  use fields
 
   implicit none
   

--- a/femtools/Node_Ownership.F90
+++ b/femtools/Node_Ownership.F90
@@ -29,14 +29,14 @@
 
 module node_ownership
 
-  use adjacency_lists
-  use data_structures
-  use fields
   use fldebug
+  use data_structures
+  use sparse_tools
+  use adjacency_lists
   use linked_lists
+  use fields
   use node_owner_finder
   use pickers
-  use sparse_tools
 
   implicit none
   

--- a/femtools/Node_boundary.F90
+++ b/femtools/Node_boundary.F90
@@ -4,10 +4,11 @@ module node_boundary
 !!< Does a node lie on a boundary? Surprisingly
 !!< difficult question to answer.
 
-  use surfacelabels
-  use fields
   use linked_lists
   use eventcounter
+  use fields
+  use surfacelabels
+
   implicit none
 
   integer, dimension(:), pointer, save :: boundcount

--- a/femtools/Parallel_Tools.F90
+++ b/femtools/Parallel_Tools.F90
@@ -31,8 +31,8 @@ module parallel_tools
 
   use fldebug
   use mpi_interfaces
-  use global_parameters, only: is_active_process, no_active_processes
   use iso_c_binding
+  use global_parameters, only: is_active_process, no_active_processes
 #ifdef _OPENMP
   use omp_lib
 #endif

--- a/femtools/Parallel_fields.F90
+++ b/femtools/Parallel_fields.F90
@@ -30,17 +30,17 @@
 module parallel_fields
   !!< This module exists to separate out parallel operations on fields
   
-  use fields_allocates
-  use fields_base
-  use fields_data_types
+  use mpi_interfaces
   use parallel_tools
-  use halos_communications
-  use halos_ownership
-  use halos_numbering
   use halo_data_types
   use halos_base
+  use fields_data_types
+  use fields_base
+  use halos_communications
+  use halos_numbering
+  use halos_ownership
+  use fields_allocates
   use fields_manipulation
-  use mpi_interfaces
   
   implicit none
 

--- a/femtools/Petsc_Tools.F90
+++ b/femtools/Petsc_Tools.F90
@@ -27,19 +27,19 @@
 #include "fdebug.h"
 module Petsc_Tools
   use FLDebug
-  use Sparse_Tools
   use parallel_tools
-  use fields_base
-  use fields_manipulation
+  use Reference_Counting
   use halo_data_types
   use halos_base
-  use halos_communications
-  use halos_numbering
-  use Reference_Counting
-  use profiler
 #ifdef HAVE_PETSC_MODULES
   use petsc 
 #endif
+  use Sparse_Tools
+  use fields_base
+  use halos_communications
+  use halos_numbering
+  use fields_manipulation
+  use profiler
   implicit none
 
 #include "petsc_legacy.h"

--- a/femtools/Pickers.F90
+++ b/femtools/Pickers.F90
@@ -30,9 +30,9 @@
 module pickers
 
   use picker_data_types
-  use pickers_allocates
   use pickers_base
   use pickers_deallocates
+  use pickers_allocates
   use pickers_inquire
   
   implicit none

--- a/femtools/Pickers_Allocates.F90
+++ b/femtools/Pickers_Allocates.F90
@@ -29,16 +29,16 @@
 
 module pickers_allocates
 
-  use elements
-  use eventcounter
-  use fields_base
-  use fields_data_types
   use fldebug
   use global_parameters, only : empty_name
-  use node_owner_finder
+  use elements
+  use eventcounter
   use picker_data_types
+  use fields_data_types
+  use fields_base
   use pickers_base
   use pickers_deallocates
+  use node_owner_finder
 
   implicit none
 

--- a/femtools/Pickers_Deallocates.F90
+++ b/femtools/Pickers_Deallocates.F90
@@ -30,11 +30,11 @@
 module pickers_deallocates
 
   use fldebug
-  use fields_data_types
   use global_parameters, only : empty_name
-  use picker_data_types
-  use pickers_base
   use reference_counting
+  use picker_data_types
+  use fields_data_types
+  use pickers_base
 
   implicit none
 

--- a/femtools/Pickers_Inquire.F90
+++ b/femtools/Pickers_Inquire.F90
@@ -29,14 +29,14 @@
 
 module pickers_inquire
 
+  use fldebug
   use data_structures
   use detector_data_types
-  use fields
-  use fldebug
-  use node_owner_finder
   use picker_data_types
-  use pickers_allocates
   use pickers_base
+  use fields
+  use node_owner_finder
+  use pickers_allocates
   
   implicit none
   

--- a/femtools/Polynomials.F90
+++ b/femtools/Polynomials.F90
@@ -50,8 +50,8 @@ module polynomials
   !!< operand of each operation must be a polynomial and not a vector acting
   !!< as a polynomial or the module won't know to do polynomial operations.
   !!<
-  use futils
   use FLDebug
+  use futils
   
   implicit none
 

--- a/femtools/Profiler_Fortran.F90
+++ b/femtools/Profiler_Fortran.F90
@@ -26,6 +26,7 @@
 !    USA
 
 module Profiler
+  use iso_c_binding, only : c_ptr
   use global_parameters, only : real_8
   use fields
 
@@ -225,7 +226,6 @@ contains
   end subroutine profiler_majorpagefaults
 
   subroutine profiler_getresidence(ptr, residence)
-    use iso_c_binding, only : c_ptr
     type(c_ptr), intent(in) :: ptr
     integer, intent(out) :: residence
     call cprofiler_getresidence(ptr, residence)

--- a/femtools/Pseudo_Consistent_Interpolation.F90
+++ b/femtools/Pseudo_Consistent_Interpolation.F90
@@ -29,12 +29,12 @@
   
 module pseudo_consistent_interpolation
 
-  use data_structures
-  use field_options
-  use fields
   use fldebug
-  use node_ownership
+  use data_structures
+  use fields
   use state_module
+  use field_options
+  use node_ownership
 
   implicit none
   

--- a/femtools/Read_Exodusii.F90
+++ b/femtools/Read_Exodusii.F90
@@ -33,15 +33,15 @@ module read_exodusii
   ! given an ID, e.g. for setting physical boundaries)
 
   use iso_c_binding, only: C_INT, C_FLOAT, C_CHAR, C_NULL_CHAR
+  use global_parameters, only : OPTION_PATH_LEN, real_4
   use futils
   use elements
+  use spud
   use fields
   use state_module
-  use spud
   use vtk_interfaces
   use exodusii_common
   use exodusii_f_interface
-  use global_parameters, only : OPTION_PATH_LEN, real_4
 
   implicit none
 

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -31,13 +31,13 @@ module read_gmsh
   ! This module reads GMSH files and results in a vector field of
   ! positions.
 
+  use global_parameters, only : OPTION_PATH_LEN
   use futils
   use elements
+  use spud
   use fields
   use state_module
-  use spud
   use gmsh_common
-  use global_parameters, only : OPTION_PATH_LEN
 
   implicit none
 

--- a/femtools/Read_Triangle.F90
+++ b/femtools/Read_Triangle.F90
@@ -33,9 +33,9 @@ module read_triangle
    
   use futils
   use elements
+  use spud
   use fields
   use state_module
-  use spud
 
   implicit none
 

--- a/femtools/Rotated_Boundary_Conditions.F90
+++ b/femtools/Rotated_Boundary_Conditions.F90
@@ -29,14 +29,13 @@
 
 module rotated_boundary_conditions
 
-use fields
-use halos
-use boundary_conditions
 use spud
 use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
-use halos_base
+use fields
 use sparse_tools_petsc
 use state_module
+use halos
+use boundary_conditions
 
 implicit none
 

--- a/femtools/Shape_Functions.F90
+++ b/femtools/Shape_Functions.F90
@@ -27,11 +27,11 @@
 #include "fdebug.h"
 module shape_functions
   !!< Generate shape functions for elements of arbitrary polynomial degree.
-  use futils
   use FLDebug
+  use futils
   use polynomials
-  use elements
   use element_numbering
+  use elements
   use Superconvergence
   use ieee_arithmetic, only: ieee_quiet_nan, ieee_value
   

--- a/femtools/Smoothing_module.F90
+++ b/femtools/Smoothing_module.F90
@@ -1,14 +1,14 @@
 #include "fdebug.h"
 
 module smoothing_module
-  use state_module
-  use fields
+  use global_parameters, only : OPTION_PATH_LEN
   use sparse_tools
+  use metric_tools
+  use fields
+  use state_module
   use sparsity_patterns
   use solvers
-  use metric_tools
   use boundary_conditions, only: apply_dirichlet_conditions
-  use global_parameters, only : OPTION_PATH_LEN
   implicit none
 
   private

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -27,24 +27,24 @@
 #include "fdebug.h"
 module solvers
   use FLDebug
-  use elements
-  use Petsc_tools
-  use Signal_Vars
-  use Multigrid
-  use Sparse_Tools
-  use sparse_tools_petsc
-  use sparse_matrices_fields
-  use Fields
   use Global_Parameters
+  use elements
   use spud
-  use halos
-  use profiler
-  use vtk_interfaces
   use parallel_tools
-  use MeshDiagnostics
 #ifdef HAVE_PETSC_MODULES
   use petsc 
 #endif
+  use Sparse_Tools
+  use Fields
+  use profiler
+  use Petsc_tools
+  use Signal_Vars
+  use Multigrid
+  use sparse_tools_petsc
+  use sparse_matrices_fields
+  use vtk_interfaces
+  use halos
+  use MeshDiagnostics
   implicit none
   ! Module to provide explicit interfaces to matrix solvers.
 

--- a/femtools/Sparse_Matrices_Fields.F90
+++ b/femtools/Sparse_Matrices_Fields.F90
@@ -26,11 +26,11 @@
 !    USA
 #include "fdebug.h"
 module sparse_matrices_fields
-use fields
+use iso_c_binding
 use sparse_tools
+use fields
 use sparse_tools_petsc
 use c_interfaces
-use iso_c_binding
 implicit none
 
   interface mult

--- a/femtools/Sparse_Tools.F90
+++ b/femtools/Sparse_Tools.F90
@@ -29,9 +29,9 @@ module sparse_tools
   !!< This module implements abstract data types for sparse matrices and
   !!< operations on them.
   use FLDebug
+  use Global_Parameters, only: FIELD_NAME_LEN
   use Futils
   use Reference_Counting
-  use Global_Parameters, only: FIELD_NAME_LEN
   use Halo_data_types
   use halos_allocates
   use memory_diagnostics

--- a/femtools/Sparse_Tools_Petsc.F90
+++ b/femtools/Sparse_Tools_Petsc.F90
@@ -30,17 +30,17 @@ module sparse_tools_petsc
   !!< implements a csr matrix type 'petsc_csr_matrix' that directly
   !!< stores the matrix in petsc format.
   use FLDebug
-  use Sparse_Tools
   use Reference_Counting
   use parallel_tools
   use halo_data_types
   use halos_allocates
-  use fields_base
-  use fields_manipulation
-  use petsc_tools
 #ifdef HAVE_PETSC_MODULES
   use petsc
 #endif
+  use Sparse_Tools
+  use fields_base
+  use fields_manipulation
+  use petsc_tools
   implicit none
 #include "petsc_legacy.h"
   private

--- a/femtools/Sparsity_Patterns_Meshes.F90
+++ b/femtools/Sparsity_Patterns_Meshes.F90
@@ -27,13 +27,13 @@
 #include "fdebug.h"
 module sparsity_patterns_meshes
   !! Calculate shape functions and sparsity patterns.
-  use sparse_tools
-  use sparsity_patterns
-  use shape_functions
-  use fields
-  use state_module
   use fldebug
   use global_parameters, only : FIELD_NAME_LEN
+  use sparse_tools
+  use shape_functions
+  use sparsity_patterns
+  use fields
+  use state_module
   
   implicit none
 

--- a/femtools/State.F90
+++ b/femtools/State.F90
@@ -30,16 +30,16 @@ module state_module
   !!< This module provides a wrapper object which allows related groups of
   !!< fields to be passed around together.
   use global_parameters, only:OPTION_PATH_LEN, empty_path
-  use fields_data_types
-  use fields_allocates
-  use fields_base
-  use fields_manipulation
+  use futils, only: int2str
   use halo_data_types
   use halos_allocates
-  use halos_communications
   use sparse_tools
-  use futils, only: int2str
+  use fields_data_types
+  use fields_base
   use linked_lists
+  use halos_communications
+  use fields_allocates
+  use fields_manipulation
   use sparse_tools_petsc
   implicit none
 

--- a/femtools/State_Fields.F90
+++ b/femtools/State_Fields.F90
@@ -28,13 +28,13 @@
 module state_fields_module
   !!< Module containing general tools for discretising Finite Element problems.
 
+  use global_parameters, only: FIELD_NAME_LEN
+  use eventcounter
   use fields
   use state_module
   use fefields
-  use global_parameters, only: FIELD_NAME_LEN
   use sparsity_patterns_meshes
   use dgtools, only: get_dg_inverse_mass_matrix
-  use eventcounter
   implicit none
   
   interface get_cv_mass

--- a/femtools/Streamfunction.F90
+++ b/femtools/Streamfunction.F90
@@ -28,20 +28,20 @@
 #include "fdebug.h"
 
 module streamfunction
-  use state_module
-  use fields
-  use sparse_tools
   use spud
   use global_parameters, only: OPTION_PATH_LEN
+  use parallel_tools
+  use sparse_tools
+  use vector_tools
+  use eventcounter
+  use transform_elements
+  use parallel_fields
+  use fields
+  use state_module
   use sparsity_patterns
   use solvers
   use boundary_conditions
-  use vector_tools
-  use transform_elements
-  use eventcounter
   use sparsity_patterns_meshes
-  USE parallel_fields
-  USE Parallel_Tools
   
   implicit none
 

--- a/femtools/Superconvergence.F90
+++ b/femtools/Superconvergence.F90
@@ -7,8 +7,8 @@ module superconvergence
 !!< Zienkiewicz & Zhu, Int. J. Numer. Methods Eng, 33, 1331-1364 (1992)
 !! This is primarily used by field_derivatives.
 
-use elements
 use vector_tools
+use elements
 
 implicit none
 

--- a/femtools/Supermesh.F90
+++ b/femtools/Supermesh.F90
@@ -1,16 +1,16 @@
 #include "fdebug.h"
 
 module supermesh_construction
-  use fields_data_types
-  use fields_allocates
-  use fields_base
-  use sparse_tools
+  use global_parameters, only : real_4, real_8
   use futils
-  use metric_tools
+  use sparse_tools
+  use fields_data_types
+  use fields_base
   use linked_lists
+  use fields_allocates
+  use metric_tools
   use unify_meshes_module
   use transform_elements
-  use global_parameters, only : real_4, real_8
   use tetrahedron_intersection_module
   implicit none
 

--- a/femtools/Supermesh_Assembly.F90
+++ b/femtools/Supermesh_Assembly.F90
@@ -29,23 +29,21 @@
 
 module supermesh_assembly
 
-! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler 
+  use fldebug
   use quadrature
   use elements
   use sparse_tools
+  use linked_lists
+  use transform_elements
+  use supermesh_construction
+  use intersection_finder_module
   use fields
   use state_module
-!
+  use solvers
   use adaptive_interpolation_module
-  use fldebug
   use field_options
   use interpolation_module
-  use intersection_finder_module
-  use linked_lists
   use state_fields_module
-  use solvers
-  use supermesh_construction
-  use transform_elements
   
   implicit none
   

--- a/femtools/Surface_Integrals.F90
+++ b/femtools/Surface_Integrals.F90
@@ -29,16 +29,15 @@
 
 module surface_integrals
 
-  use quadrature
-  use elements
-  use field_options
-  use fields
   use fldebug
   use global_parameters, only : OPTION_PATH_LEN
-  use parallel_fields
   use spud
+  use quadrature
+  use elements
+  use parallel_fields
+  use fields
   use state_module
-  !use smoothing_module
+  use field_options
 
   implicit none
   

--- a/femtools/Surface_Labels.F90
+++ b/femtools/Surface_Labels.F90
@@ -31,20 +31,20 @@ module SurfaceLabels
   !!< These IDs are used to indicate how surface
   !!< elements can be coarsened or refined.
 
-  use vector_tools
   use fldebug
+  use vector_tools
   use linked_lists
-  use merge_tensors
+  use mpi_interfaces
   use parallel_tools
+  use data_structures
   use sparse_tools
+  use elements
+  use adjacency_lists
   use adjacency_lists
   use fields
-  use elements
+  use merge_tensors
   use vtk_interfaces
-  use adjacency_lists
-  use data_structures
   use halos
-  use mpi_interfaces
   
   implicit none
   

--- a/femtools/Tetrahedron_intersection.F90
+++ b/femtools/Tetrahedron_intersection.F90
@@ -3,8 +3,8 @@
 
 module tetrahedron_intersection_module
 
-  use elements
   use vector_tools
+  use elements
   use fields_data_types
   use fields_base
   use fields_allocates

--- a/femtools/Transform_elements.F90
+++ b/femtools/Transform_elements.F90
@@ -29,14 +29,14 @@
 module transform_elements
   ! Module to calculate element transformations from local to physical
   ! coordinates.
+  use vector_tools
   use quadrature
   use elements
-  use vector_tools
   use parallel_tools, only: abort_if_in_parallel_region
+  use memory_diagnostics
   use fields_base
   use cv_faces, only: cv_faces_type
   use eventcounter
-  use memory_diagnostics
   
   implicit none
   

--- a/femtools/Unify_meshes.F90
+++ b/femtools/Unify_meshes.F90
@@ -28,11 +28,11 @@
 
 module unify_meshes_module
 
-  use fields_data_types
-  use fields_manipulation, only: set, remap_field, set_ele_nodes
-  use fields_allocates
-  use fields_base
   use fldebug
+  use fields_data_types
+  use fields_base
+  use fields_allocates
+  use fields_manipulation, only: set, remap_field, set_ele_nodes
   implicit none
 
   interface unify_meshes

--- a/femtools/Unittest_tools.F90
+++ b/femtools/Unittest_tools.F90
@@ -2,11 +2,11 @@
 
 module unittest_tools
 !!< This module contains utility functions for the unit testing framework.
-  use vector_tools
-  use sparse_tools
   use fldebug
+  use vector_tools
   use reference_counting
   use ieee_arithmetic
+  use sparse_tools
   implicit none
 
   private

--- a/femtools/VTK_interfaces.F90
+++ b/femtools/VTK_interfaces.F90
@@ -31,18 +31,18 @@ module vtk_interfaces
   ! libvtkfortran. It provides generic interfaces which ensure that the
   ! calls work in both single and double precision.
 
+  use global_parameters, only : FIELD_NAME_LEN
   use elements
-  use fields
-  use state_module
+  use mpi_interfaces
+  use parallel_tools
+  use spud
+  use data_structures
   use sparse_tools
   use global_numbering
   use fetools, only: X_,Y_,Z_
-  use global_parameters, only : FIELD_NAME_LEN
-  use mpi_interfaces
-  use parallel_tools
   use parallel_fields
-  use spud
-  use data_structures
+  use fields
+  use state_module
   use vtkfortran
   
   implicit none

--- a/femtools/Vertical_Extrapolation.F90
+++ b/femtools/Vertical_Extrapolation.F90
@@ -34,18 +34,18 @@ module vertical_extrapolation_module
 !!< fully unstructured 3D meshes. Also contains routines for updating
 !!< distance to top and bottom fields.
 use fldebug
+use global_parameters, only: real_4, real_8
 use elements
+use parallel_tools
+use spud
+use integer_set_module
 use sparse_tools
+use transform_elements
 use fields
 use state_module
-use transform_elements
 use boundary_conditions
-use parallel_tools
-use global_parameters, only: real_4, real_8
-use spud
 use dynamic_bin_sort_module
 use pickers
-use integer_set_module
 use vtk_interfaces
 implicit none
 

--- a/femtools/Write_GMSH.F90
+++ b/femtools/Write_GMSH.F90
@@ -29,13 +29,13 @@
 
 module write_gmsh
 
+  use global_parameters, only : OPTION_PATH_LEN
+  use futils
   use elements
+  use parallel_tools
   use fields
   use state_module
-  use futils
-  use parallel_tools
   use field_options
-  use global_parameters, only : OPTION_PATH_LEN
   use gmsh_common
 
   implicit none

--- a/femtools/Write_State.F90
+++ b/femtools/Write_State.F90
@@ -5,17 +5,17 @@
 module write_state_module
   !!< Data output routines
   
-  use embed_python
-  use fields
   use FLDebug
+  use global_parameters, only: OPTION_PATH_LEN
+  use embed_python
   use spud
+  use futils
+  use fields
+  use Profiler
   use state_module
   use timers
-  use Profiler
   use vtk_interfaces
   use field_options
-  use futils
-  use global_parameters, only: OPTION_PATH_LEN
   use halos
   
   implicit none

--- a/femtools/Write_Triangle.F90
+++ b/femtools/Write_Triangle.F90
@@ -29,11 +29,11 @@
 
 module write_triangle
 
+  use futils
   use elements
+  use parallel_tools
   use fields
   use state_module
-  use futils
-  use parallel_tools
   use field_options
 
   implicit none

--- a/femtools/python_state.F90
+++ b/femtools/python_state.F90
@@ -23,10 +23,10 @@
 
 module python_state
   use fldebug
+  use global_parameters, only:FIELD_NAME_LEN, current_debug_level, OPTION_PATH_LEN, PYTHON_FUNC_LEN
   use quadrature
   use elements
   use fields
-  use global_parameters, only:FIELD_NAME_LEN, current_debug_level, OPTION_PATH_LEN, PYTHON_FUNC_LEN
   use state_module 
    
   implicit none

--- a/forward_interfaces/Diagnostic_Fields_Wrapper_New.F90
+++ b/forward_interfaces/Diagnostic_Fields_Wrapper_New.F90
@@ -29,8 +29,8 @@
 
 module diagnostic_fields_wrapper_new
 
-  use fields
   use global_parameters, only : empty_path, OPTION_PATH_LEN
+  use fields
   use state_module
 
   implicit none

--- a/horizontal_adaptivity/Advancing_front.F90
+++ b/horizontal_adaptivity/Advancing_front.F90
@@ -1,16 +1,18 @@
 #include "fdebug.h"
 
 module hadapt_advancing_front
-  use fields
-  use sparse_tools
+
   use quicksort
-  use linked_lists
-  use adjacency_lists
-  use meshdiagnostics
   use data_structures
   use spud
-  use halos
+  use sparse_tools
+  use linked_lists
+  use adjacency_lists
+  use fields
+  use meshdiagnostics
   use halos_derivation
+  use halos
+
   implicit none
   
   private

--- a/horizontal_adaptivity/Combine_Meshes.F90
+++ b/horizontal_adaptivity/Combine_Meshes.F90
@@ -4,15 +4,17 @@ module hadapt_combine_meshes
   !!< Extrude a given 2D mesh to a full 3D mesh.
   !!< The layer depths are specified by a sizing function
   !!< which can be arbitrary python.
-  use elements
-  use fields
-  use spud
-  use quadrature
+
   use global_parameters
+  use quadrature
+  use elements
+  use spud
   use sparse_tools
-  use hadapt_advancing_front
   use linked_lists
+  use fields
   use halos
+  use hadapt_advancing_front
+
   implicit none
 
   private

--- a/horizontal_adaptivity/Extrude.F90
+++ b/horizontal_adaptivity/Extrude.F90
@@ -4,16 +4,18 @@ module hadapt_extrude
   !!< Extrude a given 2D mesh to a full 3D mesh.
   !!< The layer depths are specified by a sizing function
   !!< which can be arbitrary python.
-  use elements
-  use fields
-  use spud
-  use quadrature
+
   use global_parameters
+  use quadrature
+  use elements
+  use spud
   use sparse_tools
-  use vtk_interfaces
   use linked_lists
-  use hadapt_combine_meshes
+  use fields
+  use vtk_interfaces
   use halos
+  use hadapt_combine_meshes
+
   implicit none
 
   private

--- a/horizontal_adaptivity/Metric_based_extrude.F90
+++ b/horizontal_adaptivity/Metric_based_extrude.F90
@@ -2,21 +2,22 @@
 
 module hadapt_metric_based_extrude
 
-  use elements
-  use fields
-  use sparse_tools
-  use spud
-  use metric_tools
   use vector_tools
-  use meshdiagnostics
-  use halos
-  use vtk_interfaces
-  use hadapt_combine_meshes
   use global_parameters
+  use elements
+  use spud
   use quicksort
   use data_structures
-  use interpolation_module
+  use sparse_tools
+  use metric_tools
+  use fields
+  use meshdiagnostics
+  use vtk_interfaces
+  use halos
   use hadapt_advancing_front
+  use hadapt_combine_meshes
+  use interpolation_module
+
   implicit none
 
   public :: metric_based_extrude, recombine_metric, get_1d_mesh, get_1d_tensor

--- a/hyperlight/Hyperlight_interface.F90
+++ b/hyperlight/Hyperlight_interface.F90
@@ -28,9 +28,9 @@
 
 module hyperlight
   use spud
-  use state_module
-  use fields
   use global_parameters, only:   OPTION_PATH_LEN
+  use fields
+  use state_module
   use fluxes
 
   implicit none

--- a/main/Fluids.F90
+++ b/main/Fluids.F90
@@ -29,81 +29,80 @@
 
 module fluids_module
 
-  use AuxilaryOptions
-  use MeshDiagnostics
-  use signal_vars
+  use fldebug
+  use auxilaryoptions
   use spud
-  use equation_of_state
-  use timers
-  use adapt_state_module
-  use adapt_state_prescribed_module
-  use FLDebug
+  use global_parameters, only: current_time, dt, timestep, OPTION_PATH_LEN, &
+simulation_start_time, &
+simulation_start_cpu_time, &
+simulation_start_wall_time, &
+topology_mesh_name
+  use parallel_tools
+  use memory_diagnostics
   use sparse_tools
   use elements
+  use adjacency_lists
+  use eventcounter
+  use meshdiagnostics
+  use signal_vars
   use fields
-  use boundary_conditions_from_options
-  use populate_state_module
-  use populate_sub_state_module
-  use reserve_state_module
   use vtk_interfaces
-  use Diagnostic_variables
-  use diagnostic_fields_new, only : &
-    & calculate_diagnostic_variables_new => calculate_diagnostic_variables, &
-    & check_diagnostic_dependencies
-  use diagnostic_fields_wrapper
-  use diagnostic_children
-  use advection_diffusion_cg
-  use advection_diffusion_DG
-  use advection_diffusion_FV
-  use field_equations_cv, only: solve_field_eqn_cv, initialise_advection_convergence, coupled_cv_field_eqn
-  use vertical_extrapolation_module
-  use qmesh_module
-  use checkpoint
-  use write_state_module
+  use boundary_conditions
+  use halos
+  use sediment
+  use equation_of_state
+  use timers
   use synthetic_bc
+  use k_epsilon
+  use tictoc
+  use boundary_conditions_from_options
+  use reserve_state_module
+  use write_state_module
+  use detector_parallel, only: sync_detector_coordinates, deallocate_detector_list_array
+  use diagnostic_variables
+  use populate_state_module
+  use vertical_extrapolation_module
+  use field_priority_lists
+  use multiphase_module
+  use multimaterial_module
+  use spontaneous_potentials, only: calculate_electrical_potential
+  use free_surface_module
+  use momentum_diagnostic_fields, only: calculate_densities
+  use sediment_diagnostics, only: calculate_sediment_flux
+  use diagnostic_fields_wrapper
+  use checkpoint
   use goals
   use adaptive_timestepping
   use conformity_measurement
-  ! Use Solid-fluid coupling and ALE - Julian- 18-09-06
-  use ale_module
-  use adjacency_lists
-  use multimaterial_module
-  use parallel_tools
-  use SolidConfiguration
-  use MeshMovement
+  use timeloop_utilities
+  use discrete_properties_module
+  use adapt_state_module
+  use adapt_state_prescribed_module
+  use populate_sub_state_module
+  use diagnostic_fields_new, only : &
+& calculate_diagnostic_variables_new => calculate_diagnostic_variables, &
+& check_diagnostic_dependencies
+  use diagnostic_children
+  use advection_diffusion_cg
+  use advection_diffusion_dg
+  use advection_diffusion_fv
+  use field_equations_cv, only: solve_field_eqn_cv, initialise_advection_convergence, coupled_cv_field_eqn
+  use qmesh_module
   use write_triangle
+  use solidconfiguration
+  use ale_module
+  use meshmovement
   use biology
   use foam_flow_module, only: calculate_potential_flow, calculate_foam_velocity
-  use momentum_equation
-  use timeloop_utilities
-  use field_priority_lists
-  use boundary_conditions
-  use spontaneous_potentials, only: calculate_electrical_potential
-  use saturation_distribution_search_hookejeeves
-  use discrete_properties_module
-  use gls
-  use k_epsilon
-  use iceshelf_meltrate_surf_normal
-  use halos
-  use memory_diagnostics
-  use free_surface_module
-  use global_parameters, only: current_time, dt, timestep, OPTION_PATH_LEN, &
-                               simulation_start_time, &
-                               simulation_start_cpu_time, &
-                               simulation_start_wall_time, &
-                               topology_mesh_name
-  use eventcounter
   use reduced_model_runtime
   use implicit_solids
-  use sediment
+  use momentum_equation
+  use saturation_distribution_search_hookejeeves
+  use gls
+  use iceshelf_meltrate_surf_normal
 #ifdef HAVE_HYPERLIGHT
   use hyperlight
 #endif
-  use multiphase_module
-  use detector_parallel, only: sync_detector_coordinates, deallocate_detector_list_array
-  use tictoc
-  use momentum_diagnostic_fields, only: calculate_densities
-  use sediment_diagnostics, only: calculate_sediment_flux
 
   implicit none
 

--- a/ocean_forcing/NEMO_load_fields.F90
+++ b/ocean_forcing/NEMO_load_fields.F90
@@ -1,15 +1,15 @@
 ! This module loads NEMO data into the states specified in the flml
 module nemo_states_module
 
-use NEMO_load_fields_vars
+use nemo_load_fields_vars
+use global_parameters, only: OPTION_PATH_LEN, pi, current_debug_level
 use nemo_v2
 use spud
 use fields
 use state_module
 use boundary_conditions
-use global_parameters, only: OPTION_PATH_LEN, pi, current_debug_level
 use coordinates
-use Field_Options
+use field_options
 
 implicit none
 

--- a/ocean_forcing/NEMO_load_fields_vars.F90
+++ b/ocean_forcing/NEMO_load_fields_vars.F90
@@ -2,10 +2,10 @@
 module NEMO_load_fields_vars
 
   use fldebug
-  use fields
-  use state_module
   use global_parameters, only: OPTION_PATH_LEN, pi, current_debug_level
   use spud
+  use fields
+  use state_module
  
   type(scalar_field), save :: salinity_t, temperature_t, pressure_t
   type(vector_field), save :: velocity_t

--- a/ocean_forcing/bulk_parameterisations.F90
+++ b/ocean_forcing/bulk_parameterisations.F90
@@ -34,15 +34,15 @@
 
 module bulk_parameterisations
 
-    use boundary_conditions
     use fldebug
+    use global_parameters, only: OPTION_PATH_LEN
     use quadrature
     use elements
-    use fields
-    use field_options
-    use state_module
     use spud
-    use global_parameters, only: OPTION_PATH_LEN
+    use fields
+    use state_module
+    use boundary_conditions
+    use field_options
 
     implicit none
  

--- a/parameterisation/Equation_of_State.F90
+++ b/parameterisation/Equation_of_State.F90
@@ -28,12 +28,14 @@
 
 module equation_of_state
   !!< This module contains functions used to evaluate the equation of state.
+
   use fldebug
+  use global_parameters, only: OPTION_PATH_LEN
+  use spud
   use fields
   use state_module
-  use global_parameters, only: OPTION_PATH_LEN
   use sediment, only: get_n_sediment_fields, get_sediment_item
-  use spud
+
   implicit none
   
   private

--- a/parameterisation/Gls_vertical_turbulence_model.F90
+++ b/parameterisation/Gls_vertical_turbulence_model.F90
@@ -28,20 +28,21 @@
 #include "fdebug.h"
 
 module gls
+
+  use global_parameters, only:   OPTION_PATH_LEN
+  use fldebug
   use quadrature
   use elements
-  use field_derivatives
-  use fields
-  use sparse_matrices_fields
-  use state_module
   use spud
-  use global_parameters, only:   OPTION_PATH_LEN
-  use equation_of_state
-  use state_fields_module
+  use fields
+  use state_module
   use boundary_conditions
-  use Coordinates
-  use FLDebug
+  use field_derivatives
+  use sparse_matrices_fields
   use fefields
+  use state_fields_module
+  use equation_of_state
+  use coordinates
   use vertical_extrapolation_module
 
   implicit none

--- a/parameterisation/iceshelf_meltrate_surf_normal.F90
+++ b/parameterisation/iceshelf_meltrate_surf_normal.F90
@@ -28,26 +28,28 @@
 #include "fdebug.h"
 
 module iceshelf_meltrate_surf_normal
+
+  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
+  use fldebug
+  use vector_tools
   use quadrature
   use elements
-  use field_derivatives
-  use fields
-  use field_options
-  use fields_allocates
-  use state_module
   use spud
-  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
-  use state_fields_module
-  use boundary_conditions
-  use fields_manipulation
-  use surface_integrals
-  use fetools
-  use vector_tools
-  use FLDebug
   use integer_set_module
-  use pickers_inquire
+  use fields_allocates
+  use fields_manipulation
   use transform_elements
+  use fetools
+  use fields
+  use state_module
+  use boundary_conditions
+  use field_derivatives
+  use field_options
   use state_fields_module
+  use surface_integrals
+  use pickers_inquire
+  use state_fields_module
+
 implicit none
 
   private

--- a/parameterisation/k_epsilon.F90
+++ b/parameterisation/k_epsilon.F90
@@ -28,27 +28,28 @@
 #include "fdebug.h"
 
 module k_epsilon
+
+  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN, timestep, current_time
+  use fldebug
+  use vector_tools
   use quadrature
   use elements
-  use field_derivatives
-  use fields
-  use field_options
-  use state_module
   use spud
-  use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN, timestep, current_time
-  use state_fields_module
-  use boundary_conditions
   use fields_manipulation
-  use surface_integrals
-  use smoothing_module
   use fetools
-  use vector_tools
-  use sparsity_patterns_meshes
-  use FLDebug
+  use fields
+  use state_module
+  use boundary_conditions
   use vtk_interfaces
+  use field_derivatives
+  use field_options
+  use sparsity_patterns_meshes
+  use state_fields_module
+  use surface_integrals
   use solvers
+  use smoothing_module
 
-implicit none
+  implicit none
 
   private
 

--- a/preprocessor/Boundary_Conditions_From_Options.F90
+++ b/preprocessor/Boundary_Conditions_From_Options.F90
@@ -27,31 +27,32 @@
 
 #include "fdebug.h"
 module boundary_conditions_from_options
+
 use fldebug
+use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN, pi, current_debug_level
+use vector_tools
 use quadrature
 use elements
-use fields
-use fefields
-use field_options
-use state_module
-use sparse_tools_petsc
-use boundary_conditions
-use initialise_fields_module
-use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN, pi, current_debug_level
-use tidal_module
-use SampleNetCDF
-use coordinates
-use synthetic_bc
 use spud
-use vector_tools
+use integer_set_module
+use halos_base
+use halos_numbering
+use fields
+use sparse_tools_petsc
+use state_module
+use field_options
 use vtk_interfaces
+use fefields
+use boundary_conditions
+use coordinates
+use initialise_fields_module
+use tidal_module
+use samplenetcdf
+use synthetic_bc
 use pickers_inquire
 use bulk_parameterisations
 use k_epsilon
-use integer_set_module !for iceshelf
 use sediment, only: set_sediment_reentrainment
-use halos_numbering
-use halos_base
 
 implicit none
 

--- a/preprocessor/Field_Priority_Lists.F90
+++ b/preprocessor/Field_Priority_Lists.F90
@@ -28,10 +28,11 @@
 #include "fdebug.h"
 
 module field_priority_lists
+
   use global_parameters, only: FIELD_NAME_LEN, OPTION_PATH_LEN
+  use spud
   use fields
   use state_module
-  use spud
   use sediment, only: get_n_sediment_fields, get_sediment_item
 
   implicit none

--- a/preprocessor/Initialise_Fields.F90
+++ b/preprocessor/Initialise_Fields.F90
@@ -27,12 +27,12 @@
 
 #include "fdebug.h"
 module initialise_fields_module
-use fields
 use spud
-use coordinates
-use futils
-use tictoc
 use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN, is_active_process
+use futils
+use fields
+use coordinates
+use tictoc
 use vtk_cache_module
 use climatology
 use fluxes

--- a/preprocessor/Physics_From_Options.F90
+++ b/preprocessor/Physics_From_Options.F90
@@ -27,9 +27,11 @@
 #include "fdebug.h"
 
 module physics_from_options
+
+use spud
 use fields
 use state_module
-use spud
+
 implicit none
 
 private

--- a/preprocessor/Populate_State.F90
+++ b/preprocessor/Populate_State.F90
@@ -27,33 +27,35 @@
 
 #include "fdebug.h"
 module populate_state_module
+
+  use fldebug
+  use global_parameters, only: OPTION_PATH_LEN, is_active_process, pi, &
+no_active_processes, topology_mesh_name, adaptivity_mesh_name, &
+periodic_boundary_option_path, domain_bbox, domain_volume, surface_radius
   use elements
-  use state_module
-  use FLDebug
   use spud
+  use parallel_tools
+  use data_structures
+  use fields_manipulation
+  use metric_tools
+  use transform_elements
+  use profiler
+  use state_module
   use mesh_files
   use vtk_cache_module
-  use global_parameters, only: OPTION_PATH_LEN, is_active_process, pi, &
-    no_active_processes, topology_mesh_name, adaptivity_mesh_name, &
-    periodic_boundary_option_path, domain_bbox, domain_volume, surface_radius
   use field_options
   use reserve_state_module
-  use fields_manipulation
-  use diagnostic_variables, only: convergence_field, steady_state_field
   use field_options
-  use surfacelabels
-  use climatology
-  use metric_tools
-  use coordinates
   use halos
+  use surfacelabels
+  use diagnostic_variables, only: convergence_field, steady_state_field
+  use climatology
+  use coordinates
   use tictoc
   use hadapt_extrude
-  use initialise_fields_module
-  use transform_elements
-  use parallel_tools
-  use boundary_conditions_from_options
   use nemo_states_module
-  use data_structures
+  use initialise_fields_module
+  use boundary_conditions_from_options
   use fields_halos
   use read_triangle
   use initialise_ocean_forcing_module
@@ -126,7 +128,6 @@ contains
 
 
   subroutine populate_state(states)
-    use Profiler
     type(state_type), pointer, dimension(:) :: states
 
     integer :: nstates ! number of states
@@ -2959,7 +2960,6 @@ contains
 
   function mesh_name(field_path)
     !!< given a field path, establish the mesh that the field is on.
-    use global_parameters, only: FIELD_NAME_LEN
     character(len=FIELD_NAME_LEN) :: mesh_name
     character(len=*), intent(in) :: field_path
 

--- a/preprocessor/Populate_Sub_State.F90
+++ b/preprocessor/Populate_Sub_State.F90
@@ -27,39 +27,41 @@
 
 #include "fdebug.h"
 module populate_sub_state_module
+
+  use fldebug
+  use global_parameters, only: OPTION_PATH_LEN, is_active_process, pi, &
+no_active_processes, topology_mesh_name, adaptivity_mesh_name, &
+periodic_boundary_option_path, domain_bbox, domain_volume
   use elements
-  use state_module
-  use FLDebug
   use spud
+  use parallel_tools
+  use data_structures
+  use fields_manipulation
+  use metric_tools
+  use transform_elements
+  use profiler
+  use state_module
   use mesh_files
   use vtk_cache_module
-  use vtk_interfaces       
-  use global_parameters, only: OPTION_PATH_LEN, is_active_process, pi, &
-    no_active_processes, topology_mesh_name, adaptivity_mesh_name, &
-    periodic_boundary_option_path, domain_bbox, domain_volume
+  use vtk_interfaces
   use field_options
   use reserve_state_module
-  use fields_manipulation
   use field_options
+  use halos_registration
+  use halos
   use surfacelabels
   use climatology
-  use metric_tools
   use coordinates
-  use halos
-  use halos_registration
   use tictoc
   use hadapt_extrude
-  use initialise_fields_module
-  use transform_elements
-  use parallel_tools
-  use boundary_conditions_from_options
   use nemo_states_module
-  use data_structures
-  use fields_halos
+  use initialise_fields_module
   use fefields
+  use boundary_conditions_from_options
+  use fields_halos
   use read_triangle
+  use diagnostic_variables
   use populate_state_module
-  use diagnostic_variables , only: convergence_field, steady_state_field
 
   implicit none
 
@@ -75,8 +77,6 @@ contains
     ! This routine initialises all meshes, fields and boundary conditions
     ! that will be used in partially prognostic solves - i.e. where certain
     ! variables are only solved for in part of the computational domain.
-
-    use Profiler
 
     type(state_type), intent(in), dimension(:) :: states
     type(state_type), pointer, dimension(:) :: sub_states

--- a/preprocessor/Reserve_State.F90
+++ b/preprocessor/Reserve_State.F90
@@ -33,9 +33,9 @@ module reserve_state_module
   !!< them are also saved. After an adapt, all this information is reinserted
   !!< into state
   
-  use fields
   use global_parameters, only: OPTION_PATH_LEN
   use spud
+  use fields
   use state_module
   
   implicit none

--- a/preprocessor/Tidal_Modelling.F90
+++ b/preprocessor/Tidal_Modelling.F90
@@ -28,13 +28,13 @@
 
 module Tidal_module
 
-   use FLDebug
+   use fldebug
+   use spud
    use fields
    use state_module
-   use spud
+   use state_module
    use coordinates
    use sparse_matrices_fields
-   use state_module
    
    implicit none
    

--- a/preprocessor/synthetic_bc.F90
+++ b/preprocessor/synthetic_bc.F90
@@ -29,13 +29,14 @@
 
 module synthetic_bc
 
-use FLDebug
+use fldebug
 use spud
-use state_module
 use global_parameters, only: dt, option_path_len
-use fields
 use elements
 use parallel_tools
+use fields
+use state_module
+
 implicit none
 
 private

--- a/python/organise_use_statements.py
+++ b/python/organise_use_statements.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+import re
+import glob
+import sys
+import os
+import io
+import subprocess
+
+# These files are ignored in the scanning, due to being too weird.
+SKIP_LIST=['Diagnostic_Fields_Interfaces.F90','Diagnostic_Fields_New.F90']
+
+def read_fortran_file(filename):
+    """ Parse a Fortran 90 file and extract the use statements."""
+    
+    data=""
+
+    file_handle=open(filename)
+    flag = True
+    for line in file_handle.readlines():
+        clean_line=" ".join(line.strip().rstrip().split(" "))+'\n'
+        if clean_line.lower().startswith("interface"):
+            flag = False
+        if flag:
+            data += clean_line
+        if clean_line.lower().startswith("end interface"):
+            flag = True
+    file_handle.close()
+
+    module_name=re.search('(?<=module )\w+',data,re.I)
+    if module_name:
+        module_name = module_name.group(0).lower()
+        modflag = True
+    else:
+        modflag = False
+
+    modules_used = re.findall('(?<=^use )\w+',data,re.MULTILINE+re.I)
+    modules_used = [module.lower() for module in modules_used]
+    module_text = {}
+
+    for module in modules_used:
+        text='&' 
+        test =',.+'
+        while text[-1]=='&':
+            text = re.search("(?<=^use %s)%s"%(module,test),data,re.MULTILINE)
+            if text:
+                text = text.group(0)
+            else:
+                text=""
+                break
+            test+=r"\n.+"
+        module_text[module] = text
+        
+
+    return module_name, modules_used, module_text, modflag
+
+def build_trees(filenames):
+    """Build the hierarchy of use statements for an input list of filenames"""
+    
+    data = dict()
+    namelist = dict()
+
+    for filename in filenames:
+        filename = os.path.relpath(filename)
+        
+        name, children, module_text, test = read_fortran_file(filename)
+        
+        if test:
+            namelist[filename]=children, name
+        if name:
+            data[name]=dict(filename=filename,
+                            directly_used_modules=set(children),
+                            indirectly_used_modules=set(children),
+                            module_text=module_text,
+                            scan=True)
+
+    for name in data.keys():
+        add_children(data,name)
+    
+    return data, namelist
+
+def print_misplaced(data, namelist, silent, args):
+    """Find and list any modules which have use statements out of order."""
+
+    def child_cmp(nm1,nm2):
+        """ module comparision for precidence."""
+        if nm1 in data.setdefault(nm2,{'indirectly_used_modules':[]})['indirectly_used_modules']:
+            return -1
+        elif nm2 in data.setdefault(nm1,{'indirectly_used_modules':[]})['indirectly_used_modules']:
+            return 1
+        else:
+            return 0
+
+
+    def insert_sort(modules, comp):
+        """Perform an insertion sort to check that modules are always inserted before any others which use them."""
+        out = []
+
+        if modules:
+            out.insert(0,modules[0])
+        for module in modules[1:]:
+            k=len(out)
+            for j, val in enumerate(out):
+                if comp(module, val) == -1:
+                    k=j
+                    break
+            out.insert(k,module)
+            if k!=len(out)-1:
+                insert_sort(out,comp)
+
+        return out
+            
+                    
+    order = data.keys()
+
+    out = ""
+
+    high_filenames=[]
+    if args:
+        high_filenames.extend(args)
+    else:
+        for nm in order:
+            if data[nm]['filename']:
+                high_filenames.append(data[nm]['filename'])
+
+    clean_high_filenames = set([os.path.relpath(filename)
+                      for filename in high_filenames])
+
+    
+
+    for filename in clean_high_filenames:
+        if (os.path.basename(filename) in SKIP_LIST
+            or not namelist.has_key(filename)):
+            continue
+        new_order = insert_sort(namelist[filename][0],child_cmp)
+
+        if data.has_key(namelist[filename][1]):
+            module_text = data[namelist[filename][1]]['module_text']
+        else:
+            module_text={}
+
+        if new_order != namelist[filename][0]:
+            out+=filename+':\n'
+        
+            for module in new_order:
+                out+= '  use '+module+module_text.setdefault(module,"")+'\n'
+
+    if not silent:
+        print(out)
+    return out
+
+def add_children(data,name):
+    """Add the use statements inherited from the previous generation."""
+    for child in data[name]['directly_used_modules']:
+        if data.has_key(child):
+            if data[child]['scan']:
+                add_children(data,child)
+            data[name]['indirectly_used_modules']=data[name]['indirectly_used_modules'].union(data[child]['indirectly_used_modules'])
+        else:
+            data[child]=dict(filename=None,
+                            directly_used_modules=set(),
+                            indirectly_used_modules=set(),
+                            module_text="",
+                            scan=False)
+    data[name]['scan']=False
+
+def make_graphs(tree, namelist):
+    """ Output the inheritance tree for named files."""
+
+    from PIL import Image
+
+    high_filenames=[]
+
+    if len(sys.argv)>2:
+        high_filenames.extend(sys.argv[2:])
+
+    for filename in high_filenames:
+        filename = os.path.relpath(filename)
+
+        outstring = "digraph %s{\n"%namelist[filename][1]
+        visited = set()
+
+        def add_used(name, out, visited):
+
+            if name in visited:
+                return out
+            
+            for module in tree[name]['directly_used_modules']:
+                if module not in visited or (name == namelist[filename][1]
+                                             and module in namelist[filename][0]):
+                    out += "%s->%s\n"%(name,module)
+                    out = add_used(module, out, visited)
+
+            visited.add(name)
+            return out
+
+        outstring = add_used(namelist[filename][1], outstring, visited)
+        outstring += "}\n"
+
+    dot = subprocess.Popen(['dot','-Ttiff'],
+                           stdin = subprocess.PIPE,
+                           stdout = subprocess.PIPE)
+    raw = dot.communicate(input=outstring)[0]
+    Image.open(io.BytesIO(raw)).show()
+
+    return outstring
+                
+            
+
+if __name__ == "__main__":
+    import optparse
+
+    parser = optparse.OptionParser()
+    parser.add_option("-s", "--silent", action="store_true", dest="silent", help="silence output", default=False)
+    parser.add_option("-g", "--graph", action="store_true", dest="graph", help="generate graph of use statement inheritance.", default=False)
+    parser.add_option("-p", "--path", dest="path", help="set path", default=os.path.dirname(os.path.realpath(__file__))+"/../*/*.F90")
+
+    (options, args) = parser.parse_args()
+
+    tree, namelist = build_trees(glob.glob(options.path))
+    out = print_misplaced(tree, namelist, options.silent or options.graph, args)
+
+    if options.graph:
+
+        make_graphs(tree, namelist)
+
+    if out:
+        sys.exit(10)
+    else:
+        sys.exit(0)

--- a/reduced_modelling/snapsvd.F90
+++ b/reduced_modelling/snapsvd.F90
@@ -38,6 +38,7 @@
 #include "fdebug.h"
 
 module snapsvd_module
+  use FLDebug
   use vector_tools 
   implicit none
 
@@ -157,8 +158,6 @@ contains
     !     | MAXNCV: Maximum NCV allowed                          |
     !     %------------------------------------------------------%
     !
-
-    use FLDebug
 
     !include 'paramnew.h'
 
@@ -763,8 +762,6 @@ contains
     !     | MAXNCV: Maximum NCV allowed                          |
     !     %------------------------------------------------------%
     !
-
-    use FLDebug
 
     !IMPLICIT NONE
     !include 'paramnew.h'

--- a/sediments/Sediment.F90
+++ b/sediments/Sediment.F90
@@ -29,17 +29,17 @@
   
 module sediment
 
+  use global_parameters, only:   OPTION_PATH_LEN, dt, timestep
+  use fldebug
   use quadrature
   use elements
-  use field_derivatives
-  use fields
-  use sparse_matrices_fields
-  use state_module
   use spud
-  use global_parameters, only:   OPTION_PATH_LEN, dt, timestep
-  use state_fields_module
+  use fields
+  use state_module
   use boundary_conditions
-  use FLDebug
+  use field_derivatives
+  use sparse_matrices_fields
+  use state_fields_module
 
   implicit none
 

--- a/sediments/Sediment_Diagnostics.F90
+++ b/sediments/Sediment_Diagnostics.F90
@@ -29,18 +29,16 @@
 
 module sediment_diagnostics 
 
-  ! these 5 need to be on top and in this order, so as not to confuse silly old intel compiler
+  use global_parameters, only:FIELD_NAME_LEN, OPTION_PATH_LEN, dt, timestep
   use quadrature
   use elements
+  use spud
   use sparse_tools
   use fields
   use state_module
-
   use fefields
-  use global_parameters, only:FIELD_NAME_LEN, OPTION_PATH_LEN, dt, timestep
-  use spud
-  use sediment
   use boundary_conditions
+  use sediment
 
   implicit none
   

--- a/tests/check_use_statements/check_use_statements.xml
+++ b/tests/check_use_statements/check_use_statements.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testproblem>
+  <name>check_use_statements</name>
+  <owner userid="jrper"/>
+  <problem_definition length="short" nprocs="1">
+    <command_line>:</command_line>
+  </problem_definition>
+  <variables>
+    <variable name="out" language="python">import organise_use_statements as ous
+import os
+import glob
+
+tree, namelist = ous.build_trees(glob.glob(os.path.dirname(os.path.realpath(ous.__file__))+"/../*/*.F90"))
+out = ous.print_misplaced(tree, namelist, True, [])</variable>
+  </variables>
+  <pass_tests/>
+  <warn_tests>
+    <test name="Check_use_statements" language="python">if out=="":
+  assert(True)
+else:
+  print out
+  assert(False)</test>
+  </warn_tests>
+</testproblem>


### PR DESCRIPTION
As described in #87, this changeset reorders use statements in all modules to be in the Intel fortran compiler preferred order. This in turn gives slightly more overhead before running into internal compiler errors when additional code is added. A warn test has also been added to scan the ordering of the files as additional work is added. 