### PR TITLE
Updating VTK checks for vtk-6.2

### DIFF
--- a/configure
+++ b/configure
@@ -15059,6 +15059,61 @@ _ACEOF
 
 fi
 
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIOParallelXML" >&5
+$as_echo_n "checking for main in -lvtkIOParallelXML... " >&6; }
+if ${ac_cv_lib_vtkIOParallelXML_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkIOParallelXML  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef F77_DUMMY_MAIN
+
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int F77_DUMMY_MAIN() { return 1; }
+
+#endif
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_vtkIOParallelXML_main=yes
+else
+  ac_cv_lib_vtkIOParallelXML_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIOParallelXML_main" >&5
+$as_echo "$ac_cv_lib_vtkIOParallelXML_main" >&6; }
+if test "x$ac_cv_lib_vtkIOParallelXML_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKIOPARALLELXML 1
+_ACEOF
+
+  LIBS="-lvtkIOParallelXML $LIBS"
+
+fi
+
             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIOCore" >&5
 $as_echo_n "checking for main in -lvtkIOCore... " >&6; }
 if ${ac_cv_lib_vtkIOCore_main+:} false; then :
@@ -15665,7 +15720,7 @@ fi
 
 #*******************
 
-ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile schemas/flml reduced_modelling/Makefile"
+ac_config_files="$ac_config_files Makefile debug/Makefile bathymetry/Makefile ocean_forcing/Makefile ocean_forcing/tests/Makefile sediments/Makefile hyperlight/Makefile femtools/Makefile femtools/tests/Makefile forward_interfaces/Makefile horizontal_adaptivity/Makefile horizontal_adaptivity/tests/Makefile preprocessor/Makefile error_measures/Makefile error_measures/tests/Makefile parameterisation/Makefile parameterisation/tests/Makefile fldecomp/Makefile assemble/Makefile assemble/tests/Makefile diagnostics/Makefile main/Makefile tools/Makefile tools/version-info python/setup.py climatology/Makefile libmba2d/Makefile libmba3d/Makefile libjudy/Makefile libjudy/src/Makefile libjudy/src/JudyCommon/Makefile libjudy/src/Judy1/Makefile libjudy/src/JudyL/Makefile libjudy/src/JudySL/Makefile libjudy/src/JudyHS/Makefile libwm/Makefile libvtkfortran/Makefile reduced_modelling/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure

--- a/configure.in
+++ b/configure.in
@@ -1483,6 +1483,7 @@ if test "$enable_vtk" != "no" ; then
                 ])
             AC_CHECK_LIB(vtkIOXML, main)
             AC_CHECK_LIB(vtkIOParallel, main)
+            AC_CHECK_LIB(vtkIOParallelXML, main)
             AC_CHECK_LIB(vtkIOCore, main)
             AC_CHECK_LIB(vtkCommonDataModel, main)
             AC_CHECK_LIB(vtkCommonExecutionModel, main)


### PR DESCRIPTION
Change purely in configure system:

In VTK 6.2, vtkXMLPUnstructuredGridWriter::new() has been moved from libvtkIOXML to libvtkIOParallelXML; this is added to the list of VTK libraries checked at configure time.

Note that this is still assuming 'standard' VTK library naming; Ubuntu's packaging of VTK6 does significant renaming of libraries and will need a far more comprehensive fix. This change is particularly targetted at Fedora 23's VTK6.3 packaging.