### PR TITLE
Replace Scientific.IO.NetCDF with scipy.io.netcdf

### DIFF
--- a/python/fluidity/diagnostics/era.py
+++ b/python/fluidity/diagnostics/era.py
@@ -26,9 +26,9 @@ import unittest
 import fluidity.diagnostics.debug as debug
 
 try:
-  import Scientific.IO.NetCDF as netcdf
+  import scipy.io.netcdf as netcdf
 except:
-  debug.deprint("Warning: Failed to import Scientific.IO.NetCDF module")
+  debug.deprint("Warning: Failed to import scipy.io.netcdf module")
 
 import fluidity.diagnostics.calc as calc
 import fluidity.diagnostics.filehandling as filehandling
@@ -254,7 +254,7 @@ class Era15:
 
 class eraUnittests(unittest.TestCase):
   def testNetcdfSupport(self):
-    import Scientific.IO.NetCDF
+    import scipy.io.netcdf
     
     return
 

--- a/tests/netcdf_read_errors/createnetcdf.py
+++ b/tests/netcdf_read_errors/createnetcdf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from Scientific.IO.NetCDF import NetCDFFile
+from scipy.io.netcdf import NetCDFFile
 from numpy import arange, zeros
 
 def create(missingdata = False, missingdimension = False, missingvariable = False, incorrectdimension = False, incorrectvariable = False):

--- a/tests/netcdf_read_free_surface/createnetcdf.py
+++ b/tests/netcdf_read_free_surface/createnetcdf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from Scientific.IO.NetCDF import NetCDFFile
+from scipy.io.netcdf import NetCDFFile
 from numpy import arange, zeros
 import height
 


### PR DESCRIPTION
python-scientific is now unsupported; it doesn't work with numpy >= 1.9 and there are no plans to fix this, hence it's being dropped from most distros as numpy upgrades to 1.9 and beyond. We only use this for Scientific.IO.NetCDF which appears to be able to be replaced like-for-like with scipy.io.netcdf.

This commit makes that change.