### PR TITLE
configure level test for intel advance bug.

### DIFF
--- a/configure
+++ b/configure
@@ -637,6 +637,7 @@ FLLINKER
 LINKER
 FORTRAN_REAL_8
 PROFILING_FLAG
+IO_ADVANCE_BUG
 HAVE_ZOLTAN
 CXXCPP
 HAVE_PETSC33
@@ -13611,6 +13612,72 @@ fi
 if test -z "$FORTRAN_REAL_8" ; then
    as_fn_error $? "none found" "$LINENO" 5
 fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+c_ext=F90
+
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat > conftest.$ac_ext <<_ACEOF
+      program main
+
+	implicit none
+
+	integer :: unit = 10
+	integer :: i, data(3)
+
+	open(access='stream', action='write', form='formatted', file='conftest.data', unit=unit)
+	do i = 1, 3
+ 	   write(fmt='(i0)', unit=unit) i
+	end do
+	close(unit=unit)
+
+	open(access='stream', action='read', form='formatted', file='conftest.data', unit=unit)
+	read(fmt='(i1)', advance='no', unit=unit)
+	read(fmt=*, unit=unit) data(1)
+	read(fmt=*, unit=unit) data(2)
+	read(fmt=*, unit=unit) data(3)
+	close(unit=unit)
+
+	if (all(data == (/1,2,3/))) then
+ 	   call exit(0)
+	else
+	   call exit(-1)
+  	end if
+
+      end
+_ACEOF
+if ac_fn_fc_try_run "$LINENO"; then :
+    IO_ADVANCE_BUG="no"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: fortran compiler has bugged advance io" >&5
+$as_echo "$as_me: fortran compiler has bugged advance io" >&6;}
+  $as_echo "#define IO_ADVANCE_BUG 1" >>confdefs.h
+
+  IO_ADVANCE_BUG="yes"
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'

--- a/configure.in
+++ b/configure.in
@@ -974,6 +974,44 @@ fi
 
 AC_LANG_POP([Fortran])
 
+AC_LANG_SAVE
+AC_LANG(Fortran)
+c_ext=F90
+
+AC_RUN_IFELSE([AC_LANG_PROGRAM([], [
+	implicit none
+
+	integer :: unit = 10
+	integer :: i, data(3)
+
+	open(access='stream', action='write', form='formatted', file='conftest.data', unit=unit)
+	do i = 1, 3
+ 	   write(fmt='(i0)', unit=unit) i
+	end do
+	close(unit=unit)
+
+	open(access='stream', action='read', form='formatted', file='conftest.data', unit=unit)
+	read(fmt='(i1)', advance='no', unit=unit)
+	read(fmt=*, unit=unit) data(1)
+	read(fmt=*, unit=unit) data(2)
+	read(fmt=*, unit=unit) data(3)
+	close(unit=unit)
+
+	if (all(data == (/1,2,3/))) then
+ 	   call exit(0)
+	else
+	   call exit(-1)
+  	end if
+])],
+ [  IO_ADVANCE_BUG="no"],
+ [AC_MSG_NOTICE(fortran compiler has bugged advance io)
+  AC_DEFINE(IO_ADVANCE_BUG, [1])
+  IO_ADVANCE_BUG="yes"
+  ])
+AC_SUBST(IO_ADVANCE_BUG)
+
+AC_LANG_RESTORE
+
 AC_ARG_ENABLE(dp,
 [AC_HELP_STRING([--enable-dp[=flag]],
 [compile with 64 bit floating point numbers (default)])])

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -332,7 +332,7 @@ contains
     ! Done with error checking... set format (ie. ascii or binary)
     gmshFormat = gmshFileType
 
-#ifdef __INTEL_COMPILER
+#ifdef IO_ADVANCE_BUG
 !   for intel the call to ascii_formatting causes the first read after it to have advance='no'
 !   therefore forcing it to jump to a newline here
     if(gmshFormat == binaryFormat) read(fd, *) charBuf
@@ -393,7 +393,7 @@ contains
     if( trim(charBuf) .ne. "$EndNodes" ) then
        FLExit("Error: can't find '$EndNodes' in GMSH file '"//trim(filename)//"'")
     end if
-#ifdef __INTEL_COMPILER
+#ifdef IO_ADVANCE_BUG
 !   for intel the call to ascii_formatting causes the first read after it to have advance='no'
 !   therefore forcing it to jump to a newline here
     if(gmshFormat == binaryFormat) read(fd, *) charBuf
@@ -484,7 +484,7 @@ contains
        FLExit("Error: cannot find '$EndNodeData' in GMSH mesh file")
     end if
 
-#ifdef __INTEL_COMPILER
+#ifdef IO_ADVANCE_BUG
 !   for intel the call to ascii_formatting causes the first read after it to have advance='no'
 !   therefore forcing it to jump to a newline here
     if(gmshFormat == binaryFormat) read(fd, *) charBuf
@@ -599,7 +599,7 @@ contains
        FLExit("Error: cannot find '$EndElements' in GMSH mesh file")
     end if
 
-#ifdef __INTEL_COMPILER
+#ifdef IO_ADVANCE_BUG
 !   for intel the call to ascii_formatting causes the first read after it to have advance='no'
 !   therefore forcing it to jump to a newline here
     if(gmshFormat == binaryFormat) read(fd, *) charBuf


### PR DESCRIPTION
This commit adds an autoconf test to look for the intel advancing io bug. If found, it sets a preprocessor symbol such that the workaround code gets called, otherwise it is ignored. I _think_ this is the best way of dealing with the whole problem, given multiple compiler versions and Intel's habit of reintroducing old bugs into the latest versions of ifort.