### PR TITLE
Changing to scipy lower case namespace for NetCDF

### DIFF
--- a/python/fluidity/diagnostics/era.py
+++ b/python/fluidity/diagnostics/era.py
@@ -25,10 +25,21 @@ import unittest
 
 import fluidity.diagnostics.debug as debug
 
-try:
-  import scipy.io.netcdf as netcdf
-except:
-  debug.deprint("Warning: Failed to import scipy.io.netcdf module")
+from scipy.version import version as SciPyVersion
+
+if SciPyVersion < '0.9.0':
+  try:
+    import Scientific.IO.NetCDF as netcdf
+  except:
+    debug.deprint("Warning: Your SciPy version is too old (<0.9.0) and \nthe Scientific.IO.NetCDF module failed to import")
+else:
+  try:
+    import scipy.io.netcdf as netcdf
+  except:
+    debug.deprint("Warning: Failed to import scipy.io.netcdf module")
+
+
+
 
 import fluidity.diagnostics.calc as calc
 import fluidity.diagnostics.filehandling as filehandling
@@ -43,7 +54,7 @@ class Era15:
   _epoch = datetime.datetime(1900, 1, 1, 0, 0, 0)
 
   def __init__(self, filename, latitudeName = "latitude", longitudeName = "longitude", timeName = "time"):
-    self._file = netcdf.NetCDFFile(filename, "r")
+    self._file = netcdf.netcdf_file(filename, "r")
     self._latitudes = self.Values(latitudeName)
     self._longitudes = self.Values(longitudeName)
     self._times = self.Values(timeName)
@@ -254,8 +265,14 @@ class Era15:
 
 class eraUnittests(unittest.TestCase):
   def testNetcdfSupport(self):
-    import scipy.io.netcdf
-    
+
+    from scipy.version import version as SciPyVersion
+
+    if SciPyVersion < '0.9.0':
+        import Scientific.IO.NetCDF
+    else:
+        import scipy.io.netcdf
+
     return
 
 class eraDataUnittests(unittest.TestCase):

--- a/tests/netcdf_read_errors/createnetcdf.py
+++ b/tests/netcdf_read_errors/createnetcdf.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 
-from scipy.io.netcdf import NetCDFFile
+from scipy.version import version as SciPyVersion
+
+if SciPyVersion < '0.9.0':
+    from Scientific.IO.NetCDF import NetCDFFile as netcdf_file
+else:
+    from scipy.io.netcdf import netcdf_file
+
 from numpy import arange, zeros
 
 def create(missingdata = False, missingdimension = False, missingvariable = False, incorrectdimension = False, incorrectvariable = False):
@@ -26,7 +32,7 @@ def create(missingdata = False, missingdimension = False, missingvariable = Fals
 
   print "Creating " + filename + description
 
-  f = NetCDFFile(filename, 'w')
+  f = netcdf_file(filename, 'w')
   f.description = 'Example free surface height' + description
   
   if (missingdata):

--- a/tests/netcdf_read_free_surface/createnetcdf.py
+++ b/tests/netcdf_read_free_surface/createnetcdf.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
-from scipy.io.netcdf import NetCDFFile
+from scipy.version import version as SciPyVersion
+
+if SciPyVersion < '0.9.0':
+    from Scientific.IO.NetCDF import NetCDFFile as netcdf_file
+else:
+    from scipy.io.netcdf import netcdf_file
+
 from numpy import arange, zeros
 import height
 
-f = NetCDFFile('height.nc', 'w')
+f = netcdf_file('height.nc', 'w')
 f.description = 'Example free surface height.'
 
 x = arange(-1.2, 1.21, 0.2)


### PR DESCRIPTION
As James presciently pointed out, this one has come back to bite us: turns out that the scipy shipped with CentOS 6 doesn't support the upper case naming convention, hence changing to a lower case plus underscores version.