### PR TITLE
Change tests attempting to use the Euclid preconditioner

### DIFF
--- a/tests/channel-flow-dg/channel_viscous.flml
+++ b/tests/channel-flow-dg/channel_viscous.flml
@@ -140,7 +140,7 @@
         <solver>
           <iterative_method name="cg"/>
           <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
+            <hypre_type name="boomeramg"/>
           </preconditioner>
           <relative_error>
             <real_value rank="0">1.0e-10</real_value>
@@ -204,9 +204,7 @@
               <integer_value rank="0">40</integer_value>
             </restart>
           </iterative_method>
-          <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
-          </preconditioner>
+          <preconditioner name="sor"/>
           <relative_error>
             <real_value rank="0">1.0e-10</real_value>
           </relative_error>

--- a/tests/no_normal_flow_dg/no_normal_flow.flml
+++ b/tests/no_normal_flow_dg/no_normal_flow.flml
@@ -135,7 +135,7 @@
         <solver>
           <iterative_method name="cg"/>
           <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
+            <hypre_type name="boomeramg"/>
           </preconditioner>
           <relative_error>
             <real_value rank="0">1.0e-10</real_value>
@@ -199,9 +199,7 @@
               <integer_value rank="0">40</integer_value>
             </restart>
           </iterative_method>
-          <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
-          </preconditioner>
+          <preconditioner name="sor"/>
           <relative_error>
             <real_value rank="0">1.0e-10</real_value>
           </relative_error>

--- a/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
+++ b/tests/prescribed_normal_flow_dg/presc_normal_flow.flml
@@ -100,7 +100,7 @@
         <solver>
           <iterative_method name="cg"/>
           <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
+            <hypre_type name="boomeramg"/>
           </preconditioner>
           <relative_error>
             <real_value rank="0">1.0e-7</real_value>
@@ -164,9 +164,7 @@
               <integer_value rank="0">40</integer_value>
             </restart>
           </iterative_method>
-          <preconditioner name="hypre">
-            <hypre_type name="euclid"/>
-          </preconditioner>
+          <preconditioner name="sor"/>
           <relative_error>
             <real_value rank="0">1.0e-7</real_value>
           </relative_error>


### PR DESCRIPTION
As I reported in #101, It appears that hypre - euclid isn't a preconditioner option available in recent Petsc - at least as compiled by us. This change set switches the tests that use it to cg + boomerAMG / gmres+sor.

@tmbgreaves: Is there a way of just testing the test changes under the buildbot environment? It seems like overkill to build a whole branch for just this?