### PR TITLE
Use iso_c_binding kind names.

### DIFF
--- a/assemble/Mba3d_Integration.F90
+++ b/assemble/Mba3d_Integration.F90
@@ -29,8 +29,8 @@
 
 module mba3d_integration 
 
+  use iso_c_binding, only: c_double
   use fldebug
-  use global_parameters, only : real_8
   use futils, only: present_and_true
   use quadrature
   use elements
@@ -80,7 +80,7 @@ contains
     ! mbanodal arguments
     ! Group (M)
     integer :: np, maxp, nf, maxf, ne, maxe
-    real(kind = real_8), dimension(:, :), allocatable :: xyp
+    real(kind = c_double), dimension(:, :), allocatable :: xyp
     integer, dimension(:, :), allocatable :: ipf, ipe
     integer, dimension(:), allocatable :: lbf, lbe
     integer :: nestar
@@ -91,11 +91,11 @@ contains
     integer :: status
     ! Group (Q)
     integer :: maxskipe, maxqitr
-    real(kind = real_8), dimension(:, :), allocatable :: metric_handle
-    real(kind = real_8) :: quality, rquality
+    real(kind = c_double), dimension(:, :), allocatable :: metric_handle
+    real(kind = c_double) :: quality, rquality
     ! Group (W)
     integer :: maxwr, maxwi
-    real(kind = real_8), dimension(:), allocatable :: rw
+    real(kind = c_double), dimension(:), allocatable :: rw
     integer, dimension(:), allocatable :: iw
     integer :: iprint, ierr
 
@@ -206,7 +206,7 @@ contains
       metric_handle(6, i) = node_val(metric, 1, 3, i)
     end do
 
-    call get_option(base_path // "/adaptivity_library/libmba3d/quality", quality, default = real(0.6, kind = real_8))
+    call get_option(base_path // "/adaptivity_library/libmba3d/quality", quality, default = real(0.6, kind = c_double))
     ! Output variable - initialise just in case it's also used as input
     rquality = 0.0
 

--- a/femtools/Bound_field.F90
+++ b/femtools/Bound_field.F90
@@ -31,7 +31,7 @@ module bound_field_module
 
   use FLDebug
   use spud
-  use global_parameters, only : FIELD_NAME_LEN, real_8
+  use global_parameters, only : FIELD_NAME_LEN
   use quicksort
   use parallel_tools
   use sparse_tools

--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -31,7 +31,7 @@ module diagnostic_variables
   !!< A module to calculate and output diagnostics. This replaces the .s file.
   use fldebug 
   use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN, &
-& PYTHON_FUNC_LEN, int_16, integer_size, real_size
+& PYTHON_FUNC_LEN, integer_size, real_size
   use quadrature
   use futils
   use elements
@@ -174,7 +174,7 @@ module diagnostic_variables
     
     !! Recording wall time since the system start
     integer :: current_count, count_rate, count_max
-    integer(kind = int_16) :: elapsed_count
+    integer(kind = c_long) :: elapsed_count
   end type stat_type
 
   type(stat_type), save, target :: default_stat

--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -29,6 +29,7 @@
 
 module diagnostic_variables
   !!< A module to calculate and output diagnostics. This replaces the .s file.
+  use iso_c_binding, only: c_long
   use fldebug 
   use global_parameters, only:FIELD_NAME_LEN,OPTION_PATH_LEN, &
 & PYTHON_FUNC_LEN, integer_size, real_size

--- a/femtools/Embed_Python_Fortran.F90
+++ b/femtools/Embed_Python_Fortran.F90
@@ -31,7 +31,6 @@ module embed_python
 
   use fldebug
   use iso_c_binding
-  use global_parameters, only : real_4, real_8
 
   implicit none
   
@@ -41,15 +40,15 @@ module embed_python
     subroutine set_scalar_field_from_python(function, function_len, dim,&
          & nodes, x, y, z, t, result, stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: dim
       integer, intent(in) :: nodes
-      real(kind = real_8), dimension(nodes), intent(in) :: x, y, z
-      real(kind = real_8), intent(in) :: t
-      real(kind = real_8), dimension(nodes), intent(out) :: result
+      real(kind = c_double), dimension(nodes), intent(in) :: x, y, z
+      real(kind = c_double), intent(in) :: t
+      real(kind = c_double), dimension(nodes), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine set_scalar_field_from_python
   end interface set_scalar_field_from_python
@@ -58,16 +57,16 @@ module embed_python
     module procedure set_integer_array_from_python_sp
 
     subroutine set_integer_array_from_python(function, function_len, dim, nodes, x, y, z, t, result, stat)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len), intent(in) :: function
       integer, intent(in) :: dim
       integer, intent(in) :: nodes
-      real(kind = real_8), dimension(nodes), intent(in) :: x
-      real(kind = real_8), dimension(nodes), intent(in) :: y
-      real(kind = real_8), dimension(nodes), intent(in) :: z
-      real(kind = real_8), intent(in) :: t
+      real(kind = c_double), dimension(nodes), intent(in) :: x
+      real(kind = c_double), dimension(nodes), intent(in) :: y
+      real(kind = c_double), dimension(nodes), intent(in) :: z
+      real(kind = c_double), intent(in) :: t
       integer, dimension(nodes), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine set_integer_array_from_python
@@ -80,16 +79,16 @@ module embed_python
          & nodes, x, y, z, t, result_dim, result_x, result_y, result_z,&
          & stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: dim
       integer, intent(in) :: nodes
-      real(kind = real_8), dimension(nodes), intent(in) :: x, y, z
-      real(kind = real_8), intent(in) :: t
+      real(kind = c_double), dimension(nodes), intent(in) :: x, y, z
+      real(kind = c_double), intent(in) :: t
       integer, intent(in) :: result_dim
-      real(kind = real_8), dimension(nodes), intent(out) :: result_x, result_y, result_z
+      real(kind = c_double), dimension(nodes), intent(out) :: result_x, result_y, result_z
       integer, intent(out) :: stat
     end subroutine set_vector_field_from_python
   end interface set_vector_field_from_python
@@ -100,16 +99,16 @@ module embed_python
     subroutine set_tensor_field_from_python(function, function_len, dim,&
          & nodes, x, y, z, t, result_dim, result, stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: dim
       integer, intent(in) :: nodes
-      real(kind = real_8), dimension(nodes), intent(in) :: x, y, z
-      real(kind = real_8), intent(in) :: t
+      real(kind = c_double), dimension(nodes), intent(in) :: x, y, z
+      real(kind = c_double), intent(in) :: t
       integer,dimension(2), intent(in) :: result_dim
-      real(kind = real_8), dimension(result_dim(1), result_dim(2), nodes), intent(out) :: result
+      real(kind = c_double), dimension(result_dim(1), result_dim(2), nodes), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine set_tensor_field_from_python
   end interface set_tensor_field_from_python
@@ -120,13 +119,13 @@ module embed_python
     subroutine set_particle_sfield_from_python(function, function_len,&
          & nparticles,t, result, stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: nparticles
-      real(kind = real_8), intent(in) :: t
-      real(kind = real_8), dimension(nparticles), intent(out) :: result
+      real(kind = c_double), intent(in) :: t
+      real(kind = c_double), dimension(nparticles), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine set_particle_sfield_from_python
   end interface set_particle_sfield_from_python
@@ -138,13 +137,13 @@ module embed_python
          & nparticles, t, result_x, result_y, result_z,&
          & stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: nparticles
-      real(kind = real_8), intent(in) :: t
-      real(kind = real_8), dimension(nparticles), intent(out) :: result_x, result_y, result_z
+      real(kind = c_double), intent(in) :: t
+      real(kind = c_double), dimension(nparticles), intent(out) :: result_x, result_y, result_z
       integer, intent(out) :: stat
     end subroutine set_particle_vfield_from_python
   end interface set_particle_vfield_from_python
@@ -155,14 +154,14 @@ module embed_python
     subroutine set_detectors_from_python(function, function_len, dim,&
          ndete, t, rdim, result_x, result_y, result_z, stat)
       !! Interface to c wrapper function.
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len) :: function
       integer, intent(in) :: dim,rdim
       integer, intent(in) :: ndete
-      real(kind = real_8), intent(in) :: t
-      real(kind = real_8), dimension(ndete), intent(out) :: result_x, result_y, result_z
+      real(kind = c_double), intent(in) :: t
+      real(kind = c_double), dimension(ndete), intent(out) :: result_x, result_y, result_z
       integer, intent(out) :: stat
     end subroutine set_detectors_from_python
   end interface set_detectors_from_python
@@ -171,12 +170,12 @@ module embed_python
     module procedure real_from_python_sp, real_from_python_interface
 
     subroutine real_from_python(function, function_len, t, result, stat)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len), intent(in) :: function
-      real(kind = real_8), intent(in) :: t
-      real(kind = real_8), intent(out) :: result
+      real(kind = c_double), intent(in) :: t
+      real(kind = c_double), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine real_from_python
   end interface real_from_python
@@ -223,11 +222,11 @@ module embed_python
     module procedure integer_from_python_sp, integer_from_python_interface
 
     subroutine integer_from_python(function, function_len, t, result, stat)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len), intent(in) :: function
-      real(kind = real_8), intent(in) :: t
+      real(kind = c_double), intent(in) :: t
       integer, intent(out) :: result
       integer, intent(out) :: stat
     end subroutine integer_from_python
@@ -237,12 +236,12 @@ module embed_python
     module procedure string_from_python_sp, string_from_python_interface
 
     subroutine string_from_python(function, function_len, result_len, t, result, stat)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: function_len
       character(len = function_len), intent(in) :: function
       integer, intent(inout) :: result_len
-      real(kind = real_8), intent(in) :: t
+      real(kind = c_double), intent(in) :: t
       character(len = result_len), intent(out) :: result
       integer, intent(out) :: stat
     end subroutine string_from_python
@@ -265,17 +264,17 @@ contains
     character(len = function_len) :: function
     integer, intent(in) :: dim
     integer, intent(in) :: nodes
-    real(kind = real_4), dimension(nodes), intent(in) :: x
-    real(kind = real_4), dimension(:), intent(in) :: y
-    real(kind = real_4), dimension(:), intent(in) :: z
-    real(kind = real_4), intent(in) :: t
-    real(kind = real_4), dimension(nodes), intent(out) :: result
+    real(kind = c_float), dimension(nodes), intent(in) :: x
+    real(kind = c_float), dimension(:), intent(in) :: y
+    real(kind = c_float), dimension(:), intent(in) :: z
+    real(kind = c_float), intent(in) :: t
+    real(kind = c_float), dimension(nodes), intent(out) :: result
     integer, intent(out) :: stat
 
-    real(kind = real_8), dimension(nodes) :: lresult
+    real(kind = c_double), dimension(nodes) :: lresult
 
     call set_scalar_field_from_python(function, function_len, dim, &
-      & nodes, real(x, kind = real_8), real(y, kind = real_8), real(z, kind = real_8), real(t, kind = real_8), lresult, stat)
+      & nodes, real(x, kind = c_double), real(y, kind = c_double), real(z, kind = c_double), real(t, kind = c_double), lresult, stat)
     result = lresult
 
   end subroutine set_scalar_field_from_python_sp
@@ -285,14 +284,14 @@ contains
     character(len = function_len), intent(in) :: function
     integer, intent(in) :: dim
     integer, intent(in) :: nodes
-    real(kind = real_4), dimension(nodes), intent(in) :: x
-    real(kind = real_4), dimension(:), intent(in) :: y
-    real(kind = real_4), dimension(:), intent(in) :: z
-    real(kind = real_4), intent(in) :: t
+    real(kind = c_float), dimension(nodes), intent(in) :: x
+    real(kind = c_float), dimension(:), intent(in) :: y
+    real(kind = c_float), dimension(:), intent(in) :: z
+    real(kind = c_float), intent(in) :: t
     integer, dimension(nodes), intent(out) :: result
     integer, intent(out) :: stat
 
-    call set_integer_array_from_python(function, function_len, dim, nodes, real(x, kind = real_8), real(y, kind = real_8), real(z, kind = real_8), real(t, kind = real_8), result, stat)
+    call set_integer_array_from_python(function, function_len, dim, nodes, real(x, kind = c_double), real(y, kind = c_double), real(z, kind = c_double), real(t, kind = c_double), result, stat)
 
   end subroutine set_integer_array_from_python_sp
 
@@ -303,22 +302,22 @@ contains
     character(len = function_len) :: function
     integer, intent(in) :: dim
     integer, intent(in) :: nodes
-    real(kind = real_4), dimension(nodes), intent(in) :: x
-    real(kind = real_4), dimension(:), intent(in) :: y
-    real(kind = real_4), dimension(:), intent(in) :: z
-    real(kind = real_4), intent(in) :: t
+    real(kind = c_float), dimension(nodes), intent(in) :: x
+    real(kind = c_float), dimension(:), intent(in) :: y
+    real(kind = c_float), dimension(:), intent(in) :: z
+    real(kind = c_float), intent(in) :: t
     integer, intent(in) :: result_dim
-    real(kind = real_4), dimension(nodes), intent(out) :: result_x
-    real(kind = real_4), dimension(:), intent(out) :: result_y
-    real(kind = real_4), dimension(:), intent(out) :: result_z
+    real(kind = c_float), dimension(nodes), intent(out) :: result_x
+    real(kind = c_float), dimension(:), intent(out) :: result_y
+    real(kind = c_float), dimension(:), intent(out) :: result_z
     integer, intent(out) :: stat
    
-    real(kind = real_8), dimension(size(result_x)) :: lresult_x
-    real(kind = real_8), dimension(size(result_y)) :: lresult_y
-    real(kind = real_8), dimension(size(result_z)) :: lresult_z
+    real(kind = c_double), dimension(size(result_x)) :: lresult_x
+    real(kind = c_double), dimension(size(result_y)) :: lresult_y
+    real(kind = c_double), dimension(size(result_z)) :: lresult_z
 
     call set_vector_field_from_python(function, function_len, dim, &
-      & nodes, real(x, kind = real_8), real(y, kind = real_8), real(z, kind = real_8), real(t, kind = real_8), result_dim, lresult_x, lresult_y, lresult_z, &
+      & nodes, real(x, kind = c_double), real(y, kind = c_double), real(z, kind = c_double), real(t, kind = c_double), result_dim, lresult_x, lresult_y, lresult_z, &
       & stat)
     result_x = lresult_x
     result_y = lresult_y
@@ -332,18 +331,18 @@ contains
     character(len = function_len) :: function
     integer, intent(in) :: dim
     integer, intent(in) :: nodes
-    real(kind = real_4), dimension(nodes), intent(in) :: x
-    real(kind = real_4), dimension(:), intent(in) :: y
-    real(kind = real_4), dimension(:), intent(in) :: z
-    real(kind = real_4), intent(in) :: t
+    real(kind = c_float), dimension(nodes), intent(in) :: x
+    real(kind = c_float), dimension(:), intent(in) :: y
+    real(kind = c_float), dimension(:), intent(in) :: z
+    real(kind = c_float), intent(in) :: t
     integer, dimension(2), intent(in) :: result_dim
-    real(kind = real_4), dimension(:, :, :), intent(out) :: result
+    real(kind = c_float), dimension(:, :, :), intent(out) :: result
     integer, intent(out) :: stat
 
-    real(kind = real_8), dimension(size(result, 1), size(result, 2), size(result, 3)) :: lresult
+    real(kind = c_double), dimension(size(result, 1), size(result, 2), size(result, 3)) :: lresult
 
     call set_tensor_field_from_python(function, function_len, dim, &
-      & nodes, real(x, kind = real_8), real(y, kind = real_8), real(z, kind = real_8), real(t, kind = real_8), result_dim, lresult, stat)
+      & nodes, real(x, kind = c_double), real(y, kind = c_double), real(z, kind = c_double), real(t, kind = c_double), result_dim, lresult, stat)
     result = lresult
 
   end subroutine set_tensor_field_from_python_sp
@@ -354,18 +353,18 @@ contains
     character(len = function_len) :: function
     integer, intent(in) :: dim,rdim
     integer, intent(in) :: ndete
-    real(kind = real_4), intent(in) :: t
-    real(kind = real_4), dimension(ndete), intent(out) :: result_x
-    real(kind = real_4), dimension(:), intent(out) :: result_y
-    real(kind = real_4), dimension(:), intent(out) :: result_z
+    real(kind = c_float), intent(in) :: t
+    real(kind = c_float), dimension(ndete), intent(out) :: result_x
+    real(kind = c_float), dimension(:), intent(out) :: result_y
+    real(kind = c_float), dimension(:), intent(out) :: result_z
     integer, intent(out) :: stat
 
-    real(kind = real_8), dimension(size(result_x)) :: lresult_x
-    real(kind = real_8), dimension(size(result_y)) :: lresult_y
-    real(kind = real_8), dimension(size(result_z)) :: lresult_z
+    real(kind = c_double), dimension(size(result_x)) :: lresult_x
+    real(kind = c_double), dimension(size(result_y)) :: lresult_y
+    real(kind = c_double), dimension(size(result_z)) :: lresult_z
 
     call set_detectors_from_python(function, function_len, dim, &
-      & ndete, real(t, kind = real_8), rdim, lresult_x, lresult_y, lresult_z, stat)
+      & ndete, real(t, kind = c_double), rdim, lresult_x, lresult_y, lresult_z, stat)
     result_x = lresult_x
     result_y = lresult_y
     result_z = lresult_z
@@ -377,14 +376,14 @@ contains
     integer, intent(in) :: function_len
     character(len = function_len) :: function
     integer, intent(in) :: nparticles
-    real(kind = real_4), intent(in) :: t
-    real(kind = real_4), dimension(nparticles), intent(out) :: result
+    real(kind = c_float), intent(in) :: t
+    real(kind = c_float), dimension(nparticles), intent(out) :: result
     integer, intent(out) :: stat
 
-    real(kind = real_8), dimension(nparticles) :: lresult
+    real(kind = c_double), dimension(nparticles) :: lresult
 
     call set_particle_sfield_from_python(function, function_len,&
-      & nparticles, real(t, kind = real_8), lresult, stat)
+      & nparticles, real(t, kind = c_double), lresult, stat)
     result = lresult
 
   end subroutine set_particle_sfield_from_python_sp
@@ -395,18 +394,18 @@ contains
     integer, intent(in) :: function_len
     character(len = function_len) :: function
     integer, intent(in) :: nparticles
-    real(kind = real_4), intent(in) :: t
-    real(kind = real_4), dimension(nparticles), intent(out) :: result_x
-    real(kind = real_4), dimension(:), intent(out) :: result_y
-    real(kind = real_4), dimension(:), intent(out) :: result_z
+    real(kind = c_float), intent(in) :: t
+    real(kind = c_float), dimension(nparticles), intent(out) :: result_x
+    real(kind = c_float), dimension(:), intent(out) :: result_y
+    real(kind = c_float), dimension(:), intent(out) :: result_z
     integer, intent(out) :: stat
 
-    real(kind = real_8), dimension(size(result_x)) :: lresult_x
-    real(kind = real_8), dimension(size(result_y)) :: lresult_y
-    real(kind = real_8), dimension(size(result_z)) :: lresult_z
+    real(kind = c_double), dimension(size(result_x)) :: lresult_x
+    real(kind = c_double), dimension(size(result_y)) :: lresult_y
+    real(kind = c_double), dimension(size(result_z)) :: lresult_z
 
     call set_particle_vfield_from_python(function, function_len, &
-      & nparticles, real(t, kind = real_8), lresult_x, lresult_y, lresult_z,&
+      & nparticles, real(t, kind = c_double), lresult_x, lresult_y, lresult_z,&
       & stat)
     result_x = lresult_x
     result_y = lresult_y
@@ -417,13 +416,13 @@ contains
   subroutine real_from_python_sp(function, function_len, t, result, stat)
     integer, intent(in) :: function_len
     character(len = function_len), intent(in) :: function
-    real(kind = real_4), intent(in) :: t
-    real(kind = real_4), intent(out) :: result
+    real(kind = c_float), intent(in) :: t
+    real(kind = c_float), intent(out) :: result
     integer, intent(out) :: stat
 
-    real(kind = real_8) :: lresult
+    real(kind = c_double) :: lresult
 
-    call real_from_python(function, function_len, real(t, kind = real_8), lresult, stat)
+    call real_from_python(function, function_len, real(t, kind = c_double), lresult, stat)
     result = lresult
 
   end subroutine real_from_python_sp
@@ -455,13 +454,13 @@ contains
  
   subroutine real_vector_from_python_sp(function, current_time,  result, stat)
     character(len = *), intent(in) :: function
-    real(kind=real_4), intent(in) :: current_time
-    real(kind=real_4), dimension(:), pointer, intent(out) :: result
+    real(kind=c_float), intent(in) :: current_time
+    real(kind=c_float), dimension(:), pointer, intent(out) :: result
     integer, optional, intent(out) :: stat
 
-    real(kind=real_8), dimension(:), pointer :: lresult
+    real(kind=c_double), dimension(:), pointer :: lresult
     
-    call real_vector_from_python(function, real(current_time, kind=real_8),&
+    call real_vector_from_python(function, real(current_time, kind=c_double),&
          & lresult, stat)
 
     allocate(result(size(lresult)))
@@ -474,8 +473,8 @@ contains
 
   subroutine real_vector_from_python_interface(function, current_time,  result, stat)
     character(len = *), intent(in) :: function
-    real(kind=real_8), intent(in) :: current_time
-    real(kind=real_8), dimension(:), pointer, intent(out) :: result
+    real(kind=c_double), intent(in) :: current_time
+    real(kind=c_double), dimension(:), pointer, intent(out) :: result
     integer, optional, intent(out) :: stat
 
     
@@ -553,11 +552,11 @@ contains
   subroutine integer_from_python_sp(function, function_len, t, result, stat)
     integer, intent(in) :: function_len
     character(len = function_len), intent(in) :: function
-    real(kind = real_4), intent(in) :: t
+    real(kind = c_float), intent(in) :: t
     integer, intent(out) :: result
     integer, intent(out) :: stat
 
-    call integer_from_python(function, function_len, real(t, kind = real_8), result, stat)
+    call integer_from_python(function, function_len, real(t, kind = c_double), result, stat)
 
   end subroutine integer_from_python_sp
  
@@ -590,11 +589,11 @@ contains
     integer, intent(in) :: function_len
     character(len = function_len), intent(in) :: function
     integer, intent(inout) :: result_len
-    real(kind = real_4), intent(in) :: t
+    real(kind = c_float), intent(in) :: t
     character(len = result_len), intent(out) :: result
     integer, intent(out) :: stat
 
-    call string_from_python(function, function_len, result_len, real(t, kind = real_8), result, stat)
+    call string_from_python(function, function_len, result_len, real(t, kind = c_double), result, stat)
 
   end subroutine string_from_python_sp
 

--- a/femtools/Global_Parameters.F90
+++ b/femtools/Global_Parameters.F90
@@ -63,17 +63,6 @@ module global_parameters
   integer, parameter :: real_size=4
 #endif
 
-  integer, parameter :: int_4 = selected_int_kind(4), &
-                      & int_8 = selected_int_kind(8), &
-                     & int_16 = selected_int_kind(16)
-  ! real variable declarations of the form:
-  !   real*4 :: real_var
-  ! are not portable. Use these instead:
-  !   real(real_4) :: real_val
-  integer, parameter :: real_4 = selected_real_kind(4), &
-                      & real_8 = selected_real_kind(8), &
-                     & real_16 = selected_real_kind(16)
-
   !------------------------------------------------------------------------
   ! Parameters controlling the scheme used in the flow core.
   !------------------------------------------------------------------------

--- a/femtools/Grundmann_Moeller_Quadrature.F90
+++ b/femtools/Grundmann_Moeller_Quadrature.F90
@@ -1,6 +1,6 @@
 module grundmann_moeller_quadrature
 
-  use global_parameters, only : real_4, real_8
+  use iso_c_binding, only: c_float, c_double
 
   implicit none
 
@@ -192,11 +192,11 @@ module grundmann_moeller_quadrature
     integer, intent(in) :: rule
     integer, intent(in) :: dim_num
     integer, intent(in) :: point_num
-    real(kind = real_4), dimension(point_num), intent(out) :: w
-    real(kind = real_4), dimension(dim_num, point_num), intent(out) :: x
+    real(kind = c_float), dimension(point_num), intent(out) :: w
+    real(kind = c_float), dimension(dim_num, point_num), intent(out) :: x
     
-    real(kind = real_8), dimension(point_num) :: lw
-    real(kind = real_8), dimension(dim_num, point_num) :: lx
+    real(kind = c_double), dimension(point_num) :: lw
+    real(kind = c_double), dimension(dim_num, point_num) :: lx
     
     call gm_rule_set(rule, dim_num, point_num, lw, lx)
     w = lw

--- a/femtools/MPI_Interfaces.F90
+++ b/femtools/MPI_Interfaces.F90
@@ -91,9 +91,9 @@ module mpi_interfaces
     end subroutine mpi_iprobe
     
     function mpi_tick()
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
-      real(kind = real_8) :: mpi_tick
+      real(kind = c_double) :: mpi_tick
     end function mpi_tick
 
     subroutine mpi_type_commit(type, ierr)

--- a/femtools/Node_Owner_Finder_Fortran.F90
+++ b/femtools/Node_Owner_Finder_Fortran.F90
@@ -29,8 +29,8 @@
 
 module node_owner_finder
 
+  use iso_c_binding, only: c_float, c_double
   use fldebug
-  use global_parameters, only : real_4, real_8
   use futils, only: present_and_false
   use data_structures
   use element_numbering, only: FAMILY_SIMPLEX
@@ -68,14 +68,14 @@ module node_owner_finder
     module procedure node_owner_finder_set_input_sp
   
     subroutine cnode_owner_finder_set_input(id, positions, enlist, dim, loc, nnodes, nelements)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(out) :: id
       integer, intent(in) :: dim
       integer, intent(in) :: loc
       integer, intent(in) :: nnodes
       integer, intent(in) :: nelements
-      real(kind = real_8), dimension(nnodes * dim), intent(in) :: positions
+      real(kind = c_double), dimension(nnodes * dim), intent(in) :: positions
       integer, dimension(nelements * loc), intent(in) :: enlist
     end subroutine cnode_owner_finder_set_input
   end interface cnode_owner_finder_set_input
@@ -88,11 +88,11 @@ module node_owner_finder
     module procedure node_owner_finder_find_sp
   
     subroutine cnode_owner_finder_find(id, position, dim) 
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: id
       integer, intent(in) :: dim
-      real(kind = real_8), dimension(dim), intent(in) :: position
+      real(kind = c_double), dimension(dim), intent(in) :: position
     end subroutine cnode_owner_finder_find
   end interface cnode_owner_finder_find
   
@@ -135,10 +135,10 @@ contains
     integer, intent(in) :: loc
     integer, intent(in) :: nnodes
     integer, intent(in) :: nelements
-    real(kind = real_4), dimension(nnodes * dim), intent(in) :: positions
+    real(kind = c_float), dimension(nnodes * dim), intent(in) :: positions
     integer, dimension(nelements * loc), intent(in) :: enlist
     
-    call cnode_owner_finder_set_input(id, real(positions, kind = real_8), enlist, dim, loc, nnodes, nelements)
+    call cnode_owner_finder_set_input(id, real(positions, kind = c_double), enlist, dim, loc, nnodes, nelements)
     
   end subroutine node_owner_finder_set_input_sp
   
@@ -166,9 +166,9 @@ contains
   subroutine node_owner_finder_find_sp(id, position, dim)
     integer, intent(in) :: id
     integer, intent(in) :: dim
-    real(kind = real_4), dimension(dim), intent(in) :: position
+    real(kind = c_float), dimension(dim), intent(in) :: position
     
-    call cnode_owner_finder_find(id, real(position, kind = real_8), dim)
+    call cnode_owner_finder_find(id, real(position, kind = c_double), dim)
     
   end subroutine node_owner_finder_find_sp
  

--- a/femtools/Profiler_Fortran.F90
+++ b/femtools/Profiler_Fortran.F90
@@ -26,8 +26,7 @@
 !    USA
 
 module Profiler
-  use iso_c_binding, only : c_ptr
-  use global_parameters, only : real_8
+  use iso_c_binding, only : c_ptr, c_double
   use fields
 
   implicit none
@@ -70,11 +69,11 @@ module Profiler
     end subroutine cprofiler_toc
     
     subroutine cprofiler_get(key, key_len, time)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: key_len
       character(len = key_len), intent(in) :: key
-      real(kind = real_8), intent(out) :: time
+      real(kind = c_double), intent(out) :: time
     end subroutine cprofiler_get
 
     subroutine cprofiler_minorpagefaults(faults)
@@ -98,7 +97,7 @@ module Profiler
 
 contains
   
-  real(kind = real_8) function profiler_get_scalar(field, action)
+  real(kind = c_double) function profiler_get_scalar(field, action)
     !!< Starts profiling a certain 'action', .e.g.: assembly, solve, interpolation
     !!< for field and stores this under a unique key
     type(scalar_field), intent(in):: field
@@ -108,7 +107,7 @@ contains
     
   end function profiler_get_scalar
   
-  real(kind = real_8) function profiler_get_vector(field, action)
+  real(kind = c_double) function profiler_get_vector(field, action)
     !!< Starts profiling a certain 'action', .e.g.: assembly, solve, interpolation
     !!< for field and stores this under a unique key
     type(vector_field), intent(in):: field
@@ -118,7 +117,7 @@ contains
     
   end function profiler_get_vector
 
-  real(kind = real_8) function profiler_get_tensor(field, action)
+  real(kind = c_double) function profiler_get_tensor(field, action)
     !!< Starts profiling a certain 'action', .e.g.: assembly, solve, interpolation
     !!< for field and stores this under a unique key
     type(tensor_field), intent(in):: field
@@ -128,7 +127,7 @@ contains
     
   end function profiler_get_tensor
   
-  real(kind = real_8) function profiler_get_key(key)
+  real(kind = c_double) function profiler_get_key(key)
     character(len=*), intent(in)::key
     call cprofiler_get(key, len_trim(key), profiler_get_key)
   end function profiler_get_key

--- a/femtools/Read_Exodusii.F90
+++ b/femtools/Read_Exodusii.F90
@@ -34,7 +34,7 @@ module read_exodusii
 
   use iso_c_binding, only: C_INT, C_FLOAT, C_CHAR, C_NULL_CHAR
   use fldebug
-  use global_parameters, only : OPTION_PATH_LEN, real_4
+  use global_parameters, only : OPTION_PATH_LEN
   use futils
   use quadrature
   use elements
@@ -222,7 +222,7 @@ contains
     integer :: num_node_sets, num_side_sets
 
     ! exodusii lib variables:
-    real(real_4), allocatable, dimension(:) :: coord_x, coord_y, coord_z
+    real(kind=c_float), allocatable, dimension(:) :: coord_x, coord_y, coord_z
     integer, allocatable, dimension(:) :: node_map, elem_num_map, elem_order_map
     integer, allocatable, dimension(:) :: block_ids, num_elem_in_block, num_nodes_per_elem
     integer, allocatable, dimension(:) :: elem_type, elem_connectivity
@@ -231,7 +231,7 @@ contains
     integer, allocatable, dimension(:) :: total_side_sets_node_cnt_list
 
     ! variables for conversion to fluidity structure:
-    real(real_4), allocatable, dimension(:,:) :: node_coord
+    real(c_float), allocatable, dimension(:,:) :: node_coord
     integer, allocatable, dimension(:) :: total_elem_node_list
     integer, allocatable, dimension(:) :: sndglno, boundaryIDs
     
@@ -1082,7 +1082,7 @@ contains
     integer, intent(in) :: eff_dim
     integer, intent(in) :: num_nodes
     integer, allocatable, dimension(:), intent(in) :: node_map
-    real(real_4), dimension(:,:), intent(in) :: node_coord
+    real(kind=c_float), dimension(:,:), intent(in) :: node_coord
     type(vector_field), intent(inout) :: field
 
     type(EXOnode), pointer, dimension(:) :: exo_nodes

--- a/femtools/Supermesh.F90
+++ b/femtools/Supermesh.F90
@@ -1,8 +1,8 @@
 #include "fdebug.h"
 
 module supermesh_construction
+  use iso_c_binding, only: c_float, c_double
   use fldebug
-  use global_parameters, only : real_4, real_8
   use futils
   use sparse_tools
   use elements
@@ -21,9 +21,9 @@ module supermesh_construction
     module procedure intersector_set_input_sp
   
     subroutine cintersector_set_input(nodes_A, nodes_B, ndim, loc)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
-      real(kind = real_8), dimension(ndim, loc), intent(in) :: nodes_A, nodes_B
+      real(kind = c_double), dimension(ndim, loc), intent(in) :: nodes_A, nodes_B
       integer, intent(in) :: ndim, loc
     end subroutine cintersector_set_input
   end interface cintersector_set_input
@@ -44,10 +44,10 @@ module supermesh_construction
     module procedure intersector_get_output_sp
   
     subroutine cintersector_get_output(nonods, totele, ndim, loc, nodes, enlist)
-      use global_parameters, only : real_8
+      use iso_c_binding, only: c_double
       implicit none
       integer, intent(in) :: nonods, totele, ndim, loc
-      real(kind = real_8), dimension(nonods * ndim), intent(out) :: nodes
+      real(kind = c_double), dimension(nonods * ndim), intent(out) :: nodes
       integer, dimension(totele * loc), intent(out) :: enlist
     end subroutine cintersector_get_output
   end interface cintersector_get_output
@@ -78,12 +78,12 @@ module supermesh_construction
   contains
   
   subroutine intersector_set_input_sp(nodes_A, nodes_B, ndim, loc)
-    real(kind = real_4), dimension(ndim, loc), intent(in) :: nodes_A
-    real(kind = real_4), dimension(ndim, loc), intent(in) :: nodes_B
+    real(kind = c_float), dimension(ndim, loc), intent(in) :: nodes_A
+    real(kind = c_float), dimension(ndim, loc), intent(in) :: nodes_B
     integer, intent(in) :: ndim
     integer, intent(in) :: loc
     
-    call cintersector_set_input(real(nodes_A, kind = real_8), real(nodes_B, kind = real_8), ndim, loc)
+    call cintersector_set_input(real(nodes_A, kind = c_double), real(nodes_B, kind = c_double), ndim, loc)
   
   end subroutine intersector_set_input_sp
   
@@ -92,10 +92,10 @@ module supermesh_construction
     integer, intent(in) :: totele
     integer, intent(in) :: ndim
     integer, intent(in) :: loc
-    real(kind = real_4), dimension(nonods * ndim), intent(out) :: nodes
+    real(kind = c_float), dimension(nonods * ndim), intent(out) :: nodes
     integer, dimension(totele * loc), intent(out) :: enlist
     
-    real(kind = real_8), dimension(size(nodes)) :: lnodes
+    real(kind = c_double), dimension(size(nodes)) :: lnodes
     
     call cintersector_get_output(nonods, totele, ndim, loc, lnodes, enlist)
     nodes = lnodes

--- a/femtools/Timers.F90
+++ b/femtools/Timers.F90
@@ -30,8 +30,8 @@
 module timers
 !  !!< This module contains routines which time the fluidity run
 
+  use iso_c_binding, only: c_double
   use fldebug
-  use global_parameters, only : real_8
   use mpi_interfaces
 
   implicit none
@@ -48,10 +48,10 @@ contains
     !
     ! It must be called at the start of the simulation to get the clock
     ! running.
-    real(kind = real_8):: wall_time
+    real(kind = c_double):: wall_time
     logical, save :: started=.false.
 #ifdef HAVE_MPI
-    real(kind = real_8), save :: wall_time0
+    real(kind = c_double), save :: wall_time0
     
     wall_time = MPI_Wtime()
     if(.not.started) then

--- a/femtools/Vertical_Extrapolation.F90
+++ b/femtools/Vertical_Extrapolation.F90
@@ -34,7 +34,7 @@ module vertical_extrapolation_module
 !!< fully unstructured 3D meshes. Also contains routines for updating
 !!< distance to top and bottom fields.
 use fldebug
-use global_parameters, only: real_4, real_8, FIELD_NAME_LEN
+use global_parameters, only: FIELD_NAME_LEN
 use elements
 use parallel_tools
 use spud

--- a/femtools/Wandzura_Quadrature.F90
+++ b/femtools/Wandzura_Quadrature.F90
@@ -1,6 +1,6 @@
 module wandzura_quadrature
 
-  use global_parameters, only : real_4, real_8
+  use iso_c_binding, only: c_float, c_double
 
   implicit none
 
@@ -1133,11 +1133,11 @@ module wandzura_quadrature
   subroutine wandzura_rule_sp(rule, order_num, xy, w)
     integer, intent(in) :: rule
     integer, intent(in) :: order_num
-    real(kind = real_4), dimension(2, order_num), intent(out) :: xy
-    real(kind = real_4), dimension(order_num), intent(out) :: w
+    real(kind = c_float), dimension(2, order_num), intent(out) :: xy
+    real(kind = c_float), dimension(order_num), intent(out) :: w
     
-    real(kind = real_8), dimension(2, order_num) :: lxy
-    real(kind = real_8), dimension(order_num) :: lw
+    real(kind = c_double), dimension(2, order_num) :: lxy
+    real(kind = c_double), dimension(order_num) :: lw
     
     call wandzura_rule(rule, order_num, lxy, lw)
     xy = lxy

--- a/femtools/qsortd.F90
+++ b/femtools/qsortd.F90
@@ -2,8 +2,8 @@
 
 module quicksort
 
+  use iso_c_binding, only: c_float
   use fldebug
-  use global_parameters, only : real_4
 
   implicit none
 
@@ -250,7 +250,7 @@ SUBROUTINE qsortsp(x, ind)
 
 IMPLICIT NONE
 
-REAL (kind = real_4), INTENT(IN)  :: x(:)
+REAL (kind = c_float), INTENT(IN)  :: x(:)
 INTEGER, INTENT(OUT)   :: ind(:)
 INTEGER :: n
 
@@ -294,7 +294,7 @@ INTEGER :: n
 INTEGER   :: iu(21), il(21)
 INTEGER   :: m, i, j, k, l, ij, it, itt, indx
 REAL      :: r
-REAL (kind = real_4) :: t
+REAL (kind = c_float) :: t
 
 n = size(x)
 

--- a/femtools/tests/test_vtk_precision.F90
+++ b/femtools/tests/test_vtk_precision.F90
@@ -30,11 +30,11 @@
 subroutine test_vtk_precision
   !!< Test the precision of VTK I/O
 
+  use iso_c_binding, only: c_float, c_double
   use quadrature
   use elements  
   use fields
   use fields_data_types
-  use global_parameters, only : real_4, real_8
   use state_module
   use unittest_tools
   use vtk_interfaces
@@ -43,7 +43,7 @@ subroutine test_vtk_precision
   
   character(len = 255) :: filename
   integer :: i, stat
-  integer, parameter :: D = real_8, S = real_4
+  integer, parameter :: D = c_double, S = c_float
   type(element_type) :: shape
   type(mesh_type) :: mesh
   type(quadrature_type) :: quad
@@ -108,11 +108,11 @@ subroutine test_vtk_precision
     
   call vtk_read_state(filename, state = read_state)
   read_v_field => extract_vector_field(read_state, "Coordinate")
-  call report_test("[Coordinate field, tiny, real_4 precision]", read_v_field%val(1,1) < tiny(0.0_S), .false., "[Insufficient precision]")
+  call report_test("[Coordinate field, tiny, c_float precision]", read_v_field%val(1,1) < tiny(0.0_S), .false., "[Insufficient precision]")
   read_s_field => extract_scalar_field(read_state, "TestScalarField")
   read_v_field => extract_vector_field(read_state, "TestVectorField")
-  call report_test("[Scalar field, tiny, real_4 precision]", any(read_s_field%val < tiny(0.0_S)), .false., "[Insufficient precision]")
-  call report_test("[Vector field, tiny, real_4 precision]", any(read_v_field%val(1,:) < tiny(0.0_S)), .false., "[Insufficient precision]")
+  call report_test("[Scalar field, tiny, c_float precision]", any(read_s_field%val < tiny(0.0_S)), .false., "[Insufficient precision]")
+  call report_test("[Vector field, tiny, c_float precision]", any(read_v_field%val(1,:) < tiny(0.0_S)), .false., "[Insufficient precision]")
   call deallocate(read_state)
   nullify(read_s_field)
   nullify(read_v_field)
@@ -126,11 +126,11 @@ subroutine test_vtk_precision
     
   call vtk_read_state(filename, state = read_state)
   read_v_field => extract_vector_field(read_state, "Coordinate")
-  call report_test("[Coordinate field, tiny, real_8 precision]", read_v_field%val(1,1) < tiny(0.0_D), .false., "[Insufficient precision]")
+  call report_test("[Coordinate field, tiny, c_double precision]", read_v_field%val(1,1) < tiny(0.0_D), .false., "[Insufficient precision]")
   read_s_field => extract_scalar_field(read_state, "TestScalarField")
   read_v_field => extract_vector_field(read_state, "TestVectorField")
-  call report_test("[Scalar field, tiny, real_8 precision]", any(read_s_field%val < tiny(0.0_D)), .false., "[Insufficient precision]")
-  call report_test("[Vector field, tiny, real_8 precision]", any(read_v_field%val(1,:) < tiny(0.0_D)), .false., "[Insufficient precision]")
+  call report_test("[Scalar field, tiny, c_double precision]", any(read_s_field%val < tiny(0.0_D)), .false., "[Insufficient precision]")
+  call report_test("[Vector field, tiny, c_double precision]", any(read_v_field%val(1,:) < tiny(0.0_D)), .false., "[Insufficient precision]")
   call deallocate(read_state)
   nullify(read_s_field)
   nullify(read_v_field)

--- a/ocean_forcing/ClimateReader_interface.F90
+++ b/ocean_forcing/ClimateReader_interface.F90
@@ -76,7 +76,7 @@ contains
   end subroutine climatology_SetClimatology
 
   subroutine climatology_SetTimeSeconds(time)
-    real(real_8), intent(in) :: time
+    real(c_double), intent(in) :: time
     call climatology_SetTimeSeconds_c(time)
   end subroutine climatology_SetTimeSeconds
 

--- a/ocean_forcing/FluxesReader_interface.F90
+++ b/ocean_forcing/FluxesReader_interface.F90
@@ -108,7 +108,7 @@ contains
   end subroutine fluxes_SetSimulationTimeunits
   
   subroutine fluxes_SetTimeSeconds(time)
-    real(real_8), intent(in) :: time
+    real(c_double), intent(in) :: time
     call fluxes_SetTimeSeconds_c(time)
   end subroutine fluxes_SetTimeSeconds
   

--- a/ocean_forcing/NemoReader_interface.F90
+++ b/ocean_forcing/NemoReader_interface.F90
@@ -100,13 +100,13 @@ contains
   end subroutine nemo_v2_SetSimulationTimeunits
   
   subroutine nemo_v2_SetTimeSeconds(time)
-    real(real_8), intent(in) :: time
+    real(c_double), intent(in) :: time
     call nemo_v2_SetTimeSeconds_c(time)
   end subroutine nemo_v2_SetTimeSeconds
   
   subroutine get_nemo_variables(time, X, Y, Z, DEPTH, Te, Sa, U, V, W, SSH, NNodes)
     use, intrinsic :: iso_c_binding
-    real(real_8), intent(in) :: time
+    real(c_double), intent(in) :: time
     real, dimension(:), intent(in) :: X, Y, Z, DEPTH
     real, dimension(:), intent(out) :: Te, Sa, U, V, W, SSH
     integer, intent(in) :: NNodes


### PR DESCRIPTION
This changeset attempts to deal with the issue raised in #109 by explicitly replacing the kind parameters with those from iso_c_binding in all cases.