### PR TITLE
Intersection optimisation

### DIFF
--- a/femtools/Conservative_interpolation.F90
+++ b/femtools/Conservative_interpolation.F90
@@ -151,6 +151,10 @@ module conservative_interpolation_module
         end if
       else
         intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape)
+        if (.not. has_references(intersection)) then
+           llnode => llnode%next
+           cycle
+        end if
       end if
 
 #ifdef DUMP_SUPERMESH_INTERSECTIONS
@@ -1055,6 +1059,11 @@ module conservative_interpolation_module
         end do
 
         intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape)
+        if (.not. has_references(intersection)) then
+           llnode => llnode%next
+           cycle
+        end if
+
         do ele_C=1,ele_count(intersection)
           vol_C = simplex_volume(intersection, ele_C)
           do field=1,field_cnt

--- a/femtools/Intersection_finder.F90
+++ b/femtools/Intersection_finder.F90
@@ -701,6 +701,11 @@ contains
       node => map_ab(i)%firstnode
       do while(associated(node))
         intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape)
+        if (.not. has_references(intersection)) then
+           node => node%next
+           cycle
+        end if
+
         do j = 1, ele_count(intersection)
           allocate(detwei(shape%ngi))
           call transform_to_physical(intersection, j, detwei = detwei)
@@ -715,6 +720,11 @@ contains
       node => map_ab_reference(i)%firstnode
       do while(associated(node))
         intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape)
+        if (.not. has_references(intersection)) then
+           node => node%next
+           cycle
+        end if
+
         do j = 1, ele_count(intersection)
           allocate(detwei(shape%ngi))
           call transform_to_physical(intersection, j, detwei = detwei)

--- a/femtools/Supermesh.F90
+++ b/femtools/Supermesh.F90
@@ -290,6 +290,10 @@ module supermesh_construction
         assert(continuity(intersection(j)) < 0)
       else
         intersection(j) = intersect_elements(old_positions, ele_A, pos_B, supermesh_shape)
+        if (.not. has_references(intersection(j))) then
+          llnode => llnode%next
+          cycle
+        end if
         assert(continuity(intersection(j)) < 0)
       end if
 

--- a/femtools/Supermesh.F90
+++ b/femtools/Supermesh.F90
@@ -205,6 +205,11 @@ module supermesh_construction
     call cintersector_set_input(ele_val(positions_A, ele_A), posB, dim, loc)
     call cintersector_drive
     call cintersector_query(nonods, totele)
+
+    if (totele==0) then
+       return
+    end if
+    
     call allocate(intersection_mesh, nonods, totele, shape, "IntersectionMesh")
     intersection_mesh%continuity = -1
     call allocate(intersection, dim, intersection_mesh, "IntersectionCoordinates")

--- a/femtools/tests/test_intersection_finder_completeness.F90
+++ b/femtools/tests/test_intersection_finder_completeness.F90
@@ -38,6 +38,10 @@ subroutine test_intersection_finder_completeness
     do while(associated(llnode))
       ele_A = llnode%value
       intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B))
+      if (.not. has_references(intersection)) then
+         llnode => llnode%next
+         cycle
+      end if
       do ele_C=1,ele_count(intersection)
         call transform_to_physical(intersection, ele_C, detwei=detwei)
         vols_C = vols_C + sum(detwei)

--- a/femtools/tests/test_intersection_finder_completeness_3d.F90
+++ b/femtools/tests/test_intersection_finder_completeness_3d.F90
@@ -41,6 +41,10 @@ subroutine test_intersection_finder_completeness_3d
     do while(associated(llnode))
       ele_A = llnode%value
       intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B))
+      if (.not. has_references(intersection)) then
+         llnode => llnode%next
+         cycle
+      end if
       do ele_C=1,ele_count(intersection)
         call transform_to_physical(intersection, ele_C, detwei=detwei)
         vols_C = vols_C + sum(detwei)

--- a/femtools/tests/test_quad_supermesh.F90
+++ b/femtools/tests/test_quad_supermesh.F90
@@ -59,6 +59,10 @@ subroutine test_quad_supermesh
     do while(associated(llnode))
       ele_A = llnode%value
       intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape)
+      if (.not. has_references(intersection)) then
+         llnode => llnode%next
+         cycle
+      end if
 #define DUMP_SUPERMESH_INTERSECTIONS
 #ifdef DUMP_SUPERMESH_INTERSECTIONS
       if (ele_count(intersection) /= 0) then

--- a/femtools/tests/test_tet_intersector.F90
+++ b/femtools/tests/test_tet_intersector.F90
@@ -47,7 +47,9 @@ subroutine test_tet_intersector
       fail = (vol_libwm .fne. vol_fort)
       call report_test("[tet_intersector volumes]", fail, .false., "Should give the same volumes of intersection")
 
-      call deallocate(libwm)
+      if (has_references(libwm)) then
+         call deallocate(libwm)
+      end if
       if (stat == 0) then
         call deallocate(fort)
       end if

--- a/femtools/tests/test_unify_meshes.F90
+++ b/femtools/tests/test_unify_meshes.F90
@@ -64,6 +64,11 @@ subroutine test_unify_meshes
     do while(associated(llnode))
       ele_A = llnode%value
       intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape)
+      if (.not. has_references(intersection)) then
+          llnode => llnode%next
+          cycle
+      end if
+
       call unify_meshes_quadratic(accum_positions, intersection, accum_positions_tmp)
       call deallocate(accum_positions)
       accum_positions = accum_positions_tmp


### PR DESCRIPTION
This changeset short circuits the vanilla 2d intersection code so that it doesn't pointlessly allocate a vector field when run with "false alarm" elements which touch at a point or edge rather than overlapping. The original version has a significant penalty when running Galerkin projection to interpolate between meshes which are almost identical, and it seems we do something similar by default in 3d anyway.