### PR TITLE
Fix race condition in writing pvtus.

### DIFF
--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -743,9 +743,13 @@ extern "C" {
     dataSet->Delete();
     dataSet = NULL;
   
-    if(is_pvtu && (*rank)==0){
-      rename(filename.c_str(), fl_vtkFileName.c_str());
-      pvtu_fix_path(fl_vtkFileName.c_str(), basename.c_str());
+    if(is_pvtu){
+      // Ensure all processes are finished writing before we fiddle with the .ptvu
+      MPI::COMM_WORLD.Barrier();
+      if((*rank)==0){
+        rename(filename.c_str(), fl_vtkFileName.c_str());
+        pvtu_fix_path(fl_vtkFileName.c_str(), basename.c_str());
+      }
     }
 
     return;


### PR DESCRIPTION
This is a bug-fix really - but I'd appreciate if @jrper could have a quick look to check it.

The hack that allows us to write the vtus of a pvtu into a
sub-directory, involves the following step:
1) create the subdirectory, and tell vtk to write the pvtu and vtus into
  that subdirectory
2) move the pvtu to the directory above
3) fix the paths in the pvtus to relative paths into the subdirectory

Steps 2) and 3) are done by process 0. But currently no steps are taken
to ensure the other processes are actually finished with 1).

This change puts a barrier between 2) and 3) to avoid a race condition
that causes the pvtu to get mangled (observed on Debian unstable with
vtk 6.3).