### PR TITLE
Update manual text on interactive shell.

### DIFF
--- a/manual/python.tex
+++ b/manual/python.tex
@@ -200,17 +200,16 @@ within \fluidity. This depends on iPython being installed on the system and
 is achieved by placing the following code in the flml file at the point
 within Python at which you wish to stop:
 \begin{lstlisting}[language=Python]
-import fluidity_tools
-fluidity_tools.shell()()
+import IPython
+IPython.embed()
 \end{lstlisting}
-Note the double brackets \lstinline[language=Python]+()()+ after
-\lstinline[language=Python]+fluidity_tools.shell+! From within this Python
+From within this Python
 session, you can examine or set any variables which are currently
 visible. As well as using this to debug straightforward syntax errors, you
 can trap much more complex errors by placing the commands inside an
 \lstinline[language=Python]+if+ statement or a
 \lstinline[language=Python]+try+\ldots\lstinline[language=Python]+except+ clause.
-As soon as you leave the Python shell, \fluidity\ execution will continue.
+As soon as you leave the Python shell, by typing \lstinline[language=Python]+exit+ or pressing \lstinline[language=Python].CTRL+d., \fluidity\ execution will continue.
 
 It is also possible to launch an interactive Python session from within the
 simple Python interface for prescribed fields, however resuming execution

--- a/python/fluidity_tools.py
+++ b/python/fluidity_tools.py
@@ -464,41 +464,4 @@ if __name__ == "__main__":
     import sys
     var = parse_s(sys.argv[1])
     print `var`
-
-def shell():
-  '''
-  shell()
-
-  Return ipython shell. To actually start the shell, invoke the function
-  returned by this function.
-
-  This is particularly useful for debugging embedded
-  python or for crawling over the data when something has gone wrong.
-  '''
-  import sys
-  
-  if not hasattr(sys,"argv"):
-    sys.argv=[]
-
-  try:
-    from IPython.Shell import IPShellEmbed
-  except ImportError:
-    sys.stderr.write(
-      """
-      *****************************************************
-      *** Failed to import IPython. This probably means ***
-      *** you don't have it installed. Please install   ***
-      *** IPython and try again.                        ***
-      *****************************************************
-      """)
-    raise
-
-  banner = """
-  This is an IPython shell embedded in Fluidity. You can use it to examine
-  or even set variables. Press CTRL+d to exit and return to Fluidity.
-  """
-
-  ipshell = IPShellEmbed(banner=banner)
-
-  return ipshell
   


### PR DESCRIPTION
The existing fluidity_tools method to get an interactive python shell no longer works with a modern version of IPython (i.e. in the last 4 years or so). Based on an offline discussion with @stephankramer this pulls the failing code out and updates the manual to give a generic version which should work.