### PR TITLE
UPSTREAM BUGFIX for libspud

### DIFF
--- a/libspud/include/spud
+++ b/libspud/include/spud
@@ -406,7 +406,7 @@ namespace Spud{
           
       };
       
-      bool deallocated;
+      static bool deallocated;
       Option* options;
       
   };

--- a/libspud/src/spud.cpp
+++ b/libspud/src/spud.cpp
@@ -33,6 +33,10 @@ namespace Spud{
 
   // OptionManager CLASS METHODS
 
+  // PRIVATE VARIABLES
+
+  bool OptionManager::deallocated = false;
+
   // PUBLIC METHODS
 
   void OptionManager::clear_options() {
@@ -674,7 +678,7 @@ namespace Spud{
 
   OptionManager::Option::~Option(){
     for(deque< pair<string, Option*> >::iterator it=children.begin();it!=children.end();++it){
-      delete it->second;
+      if(it->second) delete it->second;
     }
 
     return;


### PR DESCRIPTION
To avoid a destructor being called twice (due to optimisation removing a
variable), deallocated is defined as static in libspud/include/spud and then
defined in libspud/src/spud.cpp.

Fix supplied by James Percival (jrper)