### PR TITLE
Fix to make clean in libspud for CX1

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -372,7 +372,7 @@ clean: clean-light clean-test python_clean clean-debian
 	@cd libvtkfortran; $(MAKE) clean
 	@echo "    CLEAN libjudy"
 	@cd libjudy; $(MAKE) clean >> make.log 2>&1
-ifeq (@SPUDLIB@,$(abspath lib/libspud.a))
+ifeq (abspath @SPUDLIB@,$(abspath lib/libspud.a))
 	@echo "    CLEAN libspud"
 	@cd libspud; $(MAKE) clean
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -372,7 +372,7 @@ clean: clean-light clean-test python_clean clean-debian
 	@cd libvtkfortran; $(MAKE) clean
 	@echo "    CLEAN libjudy"
 	@cd libjudy; $(MAKE) clean >> make.log 2>&1
-ifeq (abspath @SPUDLIB@,$(abspath lib/libspud.a))
+ifeq ($(abspath @SPUDLIB@),$(abspath lib/libspud.a))
 	@echo "    CLEAN libspud"
 	@cd libspud; $(MAKE) clean
 endif


### PR DESCRIPTION
Hi Tim,

James and I spotted a problem when cleaning the libspud library in CX1.

We added the abspath to the SPUDLIB so it returns an absolute name of the library without getting confuse with the CX1 path names. 