### PR TITLE
Hook up the GMRES restart option (and make setting it optional).

### DIFF
--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -1578,7 +1578,7 @@ subroutine SetupKSP(ksp, mat, pmat, solver_option_path, parallel, &
     KSPType ksptype
     PC pc
     PetscReal rtol, atol, dtol
-    PetscInt max_its
+    PetscInt max_its, lrestart
     PetscErrorCode ierr
     PetscObject vf
     
@@ -1610,6 +1610,15 @@ subroutine SetupKSP(ksp, mat, pmat, solver_option_path, parallel, &
     ! set ksptype again to force the flml choice
     call KSPSetType(ksp, ksptype, ierr)
     ewrite(2, *) 'ksp_type:', trim(ksptype)
+
+    if(trim(ksptype) == 'gmres') then
+       call get_option(trim(solver_option_path)//&
+            '/iterative_method::gmres/restart', lrestart, default=-1)
+       if (lrestart >= 0) then
+          call KSPGMRESSetRestart(ksp, lrestart, ierr)
+          ewrite(2, *) 'restart:', lrestart
+       end if
+    end if
 
     ! set max. iterations and tolerances:
     ! =======================================

--- a/schemas/solvers.rnc
+++ b/schemas/solvers.rnc
@@ -113,10 +113,10 @@ kspgmres_options =
          attribute name { "gmres" },
          ## Restart value for gmres iteration
          ## Higher values give better convergence but require more memory.
-         ## Suggested value: 30
+         ## Default value: 30
          element restart {
             integer
-         }
+         }?
       }
    )
    

--- a/schemas/solvers.rng
+++ b/schemas/solvers.rng
@@ -110,12 +110,14 @@ Your safest bet for non-symmetric systems.</a:documentation>
       <attribute name="name">
         <value>gmres</value>
       </attribute>
-      <element name="restart">
-        <a:documentation>Restart value for gmres iteration
+      <optional>
+        <element name="restart">
+          <a:documentation>Restart value for gmres iteration
 Higher values give better convergence but require more memory.
-Suggested value: 30</a:documentation>
-        <ref name="integer"/>
-      </element>
+Default value: 30</a:documentation>
+          <ref name="integer"/>
+        </element>
+      </optional>
     </element>
   </define>
   <define name="kspcg_options">


### PR DESCRIPTION
This changeset means that the GMRES restart option in diamond is used in the code if set. If the option isn't present in the options file then the default value of 30 is used (as always occurs currently).