### PR TITLE
Fix bugs related to intersect_elements() short-cut.

### DIFF
--- a/femtools/Conservative_interpolation.F90
+++ b/femtools/Conservative_interpolation.F90
@@ -102,6 +102,7 @@ module conservative_interpolation_module
     type(plane_type), dimension(4) :: planes_B
     type(tet_type) :: tet_A, tet_B
     integer :: lstat
+    logical :: empty_intersection
 
     real, dimension(size(local_rhs, 3)) :: tmp_local_rhs, tmp_ele_val
 
@@ -150,8 +151,8 @@ module conservative_interpolation_module
           cycle
         end if
       else
-        intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape)
-        if (.not. has_references(intersection)) then
+        intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape, empty_intersection=empty_intersection)
+        if (empty_intersection) then
            llnode => llnode%next
            cycle
         end if
@@ -1017,6 +1018,7 @@ module conservative_interpolation_module
     character(len=OPTION_PATH_LEN) :: old_path
     integer :: stat
     real, dimension(new_position%dim, ele_loc(new_position, 1)) :: pos_B
+    logical :: empty_intersection
 
     field_cnt = size(old_fields)
     dim = mesh_dim(new_position)
@@ -1059,8 +1061,8 @@ module conservative_interpolation_module
           integral_A(field) = dot_product(ele_val_at_quad(old_fields(field), ele_A), detwei_A)
         end do
 
-        intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape)
-        if (.not. has_references(intersection)) then
+        intersection = intersect_elements(old_position, ele_A, pos_B, supermesh_shape, empty_intersection=empty_intersection)
+        if (empty_intersection) then
            llnode => llnode%next
            cycle
         end if

--- a/femtools/Intersection_finder.F90
+++ b/femtools/Intersection_finder.F90
@@ -669,6 +669,7 @@ contains
     type(quadrature_type) :: quad
     type(inode), pointer :: node
     type(vector_field) :: intersection
+    logical :: empty_intersection
     
     ewrite(1, *) "Entering verify_map"
         
@@ -700,8 +701,8 @@ contains
       intersection_volume = 0.0
       node => map_ab(i)%firstnode
       do while(associated(node))
-        intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape)
-        if (.not. has_references(intersection)) then
+        intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape, empty_intersection)
+        if (empty_intersection) then
            node => node%next
            cycle
         end if
@@ -719,8 +720,8 @@ contains
       reference_intersection_volume = 0.0
       node => map_ab_reference(i)%firstnode
       do while(associated(node))
-        intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape)
-        if (.not. has_references(intersection)) then
+        intersection = intersect_elements(mesh_field_a, i, ele_val(mesh_field_b, node%value), shape, empty_intersection)
+        if (empty_intersection) then
            node => node%next
            cycle
         end if

--- a/femtools/tests/test_intersection_finder_completeness.F90
+++ b/femtools/tests/test_intersection_finder_completeness.F90
@@ -16,7 +16,7 @@ subroutine test_intersection_finder_completeness
   real, dimension(:), allocatable :: detwei
   integer :: ele_A, ele_B, ele_C
   real :: vol_B, vols_C
-  logical :: fail
+  logical :: fail, empty_intersection
   type(inode), pointer :: llnode
   type(vector_field) :: intersection
 
@@ -37,8 +37,8 @@ subroutine test_intersection_finder_completeness
     vols_C = 0.0
     do while(associated(llnode))
       ele_A = llnode%value
-      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B))
-      if (.not. has_references(intersection)) then
+      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B), empty_intersection=empty_intersection)
+      if (empty_intersection) then
          llnode => llnode%next
          cycle
       end if

--- a/femtools/tests/test_intersection_finder_completeness_3d.F90
+++ b/femtools/tests/test_intersection_finder_completeness_3d.F90
@@ -16,7 +16,7 @@ subroutine test_intersection_finder_completeness_3d
   real, dimension(:), allocatable :: detwei
   integer :: ele_A, ele_B, ele_C
   real :: vol_B, vols_C
-  logical :: fail
+  logical :: fail, empty_intersection
   type(inode), pointer :: llnode
   type(vector_field) :: intersection
 
@@ -40,8 +40,8 @@ subroutine test_intersection_finder_completeness_3d
     vols_C = 0.0
     do while(associated(llnode))
       ele_A = llnode%value
-      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B))
-      if (.not. has_references(intersection)) then
+      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), ele_shape(positionsB, ele_B), empty_intersection=empty_intersection)
+      if (empty_intersection) then
          llnode => llnode%next
          cycle
       end if

--- a/femtools/tests/test_quad_supermesh.F90
+++ b/femtools/tests/test_quad_supermesh.F90
@@ -20,7 +20,7 @@ subroutine test_quad_supermesh
   real, dimension(:), allocatable :: quad_detwei, tri_detwei
   integer :: ele_A, ele_B, ele_C
   real :: vol_B, vols_C, total_B, total_C
-  logical :: fail
+  logical :: fail, empty_intersection
   type(element_type), pointer :: shape
   type(inode), pointer :: llnode
   type(vector_field) :: intersection
@@ -58,8 +58,8 @@ subroutine test_quad_supermesh
     vols_C = 0.0
     do while(associated(llnode))
       ele_A = llnode%value
-      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape)
-      if (.not. has_references(intersection)) then
+      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape, empty_intersection=empty_intersection)
+      if (empty_intersection) then
          llnode => llnode%next
          cycle
       end if

--- a/femtools/tests/test_unify_meshes.F90
+++ b/femtools/tests/test_unify_meshes.F90
@@ -22,7 +22,7 @@ subroutine test_unify_meshes
   real, dimension(:), allocatable :: quad_detwei, tri_detwei
   integer :: ele_A, ele_B, ele_C
   real :: vol_B, vols_C, total_B, total_C
-  logical :: fail
+  logical :: fail, empty_intersection
   type(element_type), pointer :: shape
   type(inode), pointer :: llnode
   type(vector_field) :: intersection
@@ -63,8 +63,8 @@ subroutine test_unify_meshes
     vols_C = 0.0
     do while(associated(llnode))
       ele_A = llnode%value
-      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape)
-      if (.not. has_references(intersection)) then
+      intersection = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape, empty_intersection=empty_intersection)
+      if (empty_intersection) then
           llnode => llnode%next
           cycle
       end if

--- a/tools/Vertical_Integration.F90
+++ b/tools/Vertical_Integration.F90
@@ -62,6 +62,7 @@ subroutine vertical_integration(target_basename_, target_basename_len, &
   type(vector_field) :: positions_b_ext, positions_b_surf, vfield_b
   type(vector_field), pointer :: positions_a, vfield_a
   type(vector_field), target :: positions_c
+  logical :: empty_intersection
 
   ewrite(-1, *) "In vertical_integration"
 
@@ -223,12 +224,11 @@ subroutine vertical_integration(target_basename_, target_basename_len, &
           cycle
         end if
       else
-        positions_c = intersect_elements(positions_b_ext, ele_b, ele_val(positions_a, ele_a), ele_shape(positions_a, ele_a))
+        positions_c = intersect_elements(positions_b_ext, ele_b, ele_val(positions_a, ele_a), ele_shape(positions_a, ele_a), empty_intersection=empty_intersection)
       end if
 
-      if(ele_count(positions_c) == 0) then
+      if(empty_intersection) then
         ! No intersection to integrate
-        call deallocate(positions_c)
         cycle
       end if
       if(dim /= 3 .or. (intersector_exactness .eqv. .true.)) then  ! The stat argument to intersect_tets checks this

--- a/tools/unifiedmesh.F90
+++ b/tools/unifiedmesh.F90
@@ -113,6 +113,7 @@ subroutine unifiedmesh(filename1_, filename1_len, &
 
     integer :: ele_A, ele_B
     integer :: new_start, new_end, step
+    logical :: empty_intersection
 
     call allocate(supermesh_mesh, 0, 0, supermesh_shape, "AccumulatedMesh")
     call allocate(supermesh, positionsA%dim, supermesh_mesh, "AccumulatedPositions")
@@ -123,11 +124,13 @@ subroutine unifiedmesh(filename1_, filename1_len, &
         llnode => map_BA(ele_B)%firstnode
         do while(associated(llnode))
           ele_A = llnode%value
-          supermesh_tmp = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape)
-          call unify_meshes_quadratic(supermesh, supermesh_tmp, supermesh_accum)
-          call deallocate(supermesh)
-          call deallocate(supermesh_tmp)
-          supermesh = supermesh_accum
+          supermesh_tmp = intersect_elements(positionsA, ele_A, ele_val(positionsB, ele_B), supermesh_shape, empty_intersection=empty_intersection)
+          if (.not. empty_intersection) then
+            call unify_meshes_quadratic(supermesh, supermesh_tmp, supermesh_accum)
+            call deallocate(supermesh)
+            call deallocate(supermesh_tmp)
+            supermesh = supermesh_accum
+          end if
           llnode => llnode%next
         end do
       end do


### PR DESCRIPTION
The optimisation in commit c68550e5d8fb700ecf1c6acda28f66b00eb2d465
introduced a short-cut in intersect_elements() where if the intersection
was found to be empty it no longer bothered to allocate a valid
0-element mesh. This condition had to then be catched
by always checking with has_references() on the returned mesh. On second
thought this is a little flaky. If a function returns an
allocated femtools object it should always return a valid object - or
there should be some other mechanism to indicate the function result
should be discarded (e.g. extract_scalar_field with a stat argument).

In this spirit, intersect_elements() now has an optional
empty_intersection argument. The short-cut is only invoked if this
argument is provided  - thus restoring the semantics from before the
introduction of the short-cut if the argument is not present,
which fixes a few places where intersect_element() calls where not
checked with has_references(). If the argument is provided,
upon return empty_intersection can be checked whether the function
result is valid or not.

This fixes a.o. unifiedmesh and therefore the
explicit-hyperc-shear-adapt long test. The short-cut is now also extended to
the libsupermesh implementation (although I believe this is currently
entirely untested?).