### PR TITLE
Remove spurious sends

### DIFF
--- a/assemble/Makefile.dependencies
+++ b/assemble/Makefile.dependencies
@@ -23,9 +23,10 @@ Adapt_State.o ../include/adapt_state_module.mod: Adapt_State.F90 \
    ../include/detector_parallel.mod ../include/diagnostic_fields_wrapper.mod \
    ../include/diagnostic_fields_wrapper_new.mod \
    ../include/diagnostic_variables.mod \
-   ../include/discrete_properties_module.mod ../include/edge_length_module.mod \
-   ../include/elements.mod ../include/eventcounter.mod ../include/fdebug.h \
-   ../include/fefields.mod ../include/field_options.mod ../include/fields.mod \
+   ../include/discrete_properties_module.mod ../include/dqmom.mod \
+   ../include/edge_length_module.mod ../include/elements.mod \
+   ../include/eventcounter.mod ../include/fdebug.h ../include/fefields.mod \
+   ../include/field_options.mod ../include/fields.mod \
    ../include/fields_halos.mod ../include/fldebug.mod ../include/futils.mod \
    ../include/global_parameters.mod ../include/hadapt_extrude.mod \
    ../include/hadapt_metric_based_extrude.mod ../include/halos.mod \
@@ -141,12 +142,13 @@ Advection_Diffusion_FV.o ../include/advection_diffusion_fv.mod: \
 	@true
 
 Assemble_CMC.o ../include/assemble_cmc.mod: Assemble_CMC.F90 \
-   ../include/elements.mod ../include/fdebug.h ../include/fefields.mod \
-   ../include/fetools.mod ../include/field_options.mod ../include/fields.mod \
-   ../include/fldebug.mod ../include/global_parameters.mod \
-   ../include/linked_lists.mod ../include/sparse_matrices_fields.mod \
-   ../include/sparse_tools.mod ../include/sparse_tools_petsc.mod \
-   ../include/state_module.mod ../include/transform_elements.mod
+   ../include/boundary_conditions.mod ../include/elements.mod \
+   ../include/fdebug.h ../include/fefields.mod ../include/fetools.mod \
+   ../include/field_options.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/global_parameters.mod ../include/linked_lists.mod \
+   ../include/sparse_matrices_fields.mod ../include/sparse_tools.mod \
+   ../include/sparse_tools_petsc.mod ../include/state_module.mod \
+   ../include/transform_elements.mod
 
 ../include/biology.mod: Biology.o
 	@true
@@ -214,9 +216,10 @@ Diagnostic_Fields_Matrices.o ../include/diagnostic_fields_matrices.mod: \
 
 Diagnostic_fields_wrapper.o ../include/diagnostic_fields_wrapper.mod: \
    Diagnostic_fields_wrapper.F90 ../include/diagnostic_fields.mod \
-   ../include/diagnostic_fields_matrices.mod ../include/equation_of_state.mod \
-   ../include/fdebug.h ../include/fetools.mod ../include/field_derivatives.mod \
-   ../include/field_options.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/diagnostic_fields_matrices.mod ../include/dqmom.mod \
+   ../include/equation_of_state.mod ../include/fdebug.h ../include/fetools.mod \
+   ../include/field_derivatives.mod ../include/field_options.mod \
+   ../include/fields.mod ../include/fldebug.mod \
    ../include/free_surface_module.mod ../include/futils.mod \
    ../include/geostrophic_pressure.mod ../include/global_parameters.mod \
    ../include/momentum_diagnostic_fields.mod \
@@ -356,8 +359,10 @@ Free_Surface.o ../include/free_surface_module.mod: Free_Surface.F90 \
 	@true
 
 Full_Projection.o ../include/full_projection.mod: Full_Projection.F90 \
-   ../include/boundary_conditions_from_options.mod ../include/elements.mod \
-   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
+   ../include/boundary_conditions.mod \
+   ../include/boundary_conditions_from_options.mod \
+   ../include/data_structures.mod ../include/elements.mod ../include/fdebug.h \
+   ../include/fields.mod ../include/fldebug.mod \
    ../include/global_parameters.mod ../include/halos.mod \
    ../include/multigrid.mod ../include/parallel_tools.mod \
    ../include/petsc_legacy.h ../include/petsc_solve_state_module.mod \

--- a/femtools/Detector_Parallel.F90
+++ b/femtools/Detector_Parallel.F90
@@ -36,9 +36,9 @@ module detector_parallel
   use elements
   use parallel_tools
   use parallel_fields
-  use halos
   use fields
   use state_module
+  use halos
   use detector_data_types
   use detector_tools
   use pickers

--- a/femtools/Detector_Parallel.F90
+++ b/femtools/Detector_Parallel.F90
@@ -359,7 +359,7 @@ contains
        ndet_to_send=send_list_array(target_proc)%length
        ! if we don't know any elements owned by target_proc - we shouldn't have anything to send
        if (halo_receive_count(ele_halo, target_proc)==0) then
-         ! check that this is te case
+         ! check that this is the case
          if (ndet_to_send>0) then
            FLAbort('send_list_array should only send detectors to known elements.')
          end if

--- a/femtools/Detector_Parallel.F90
+++ b/femtools/Detector_Parallel.F90
@@ -34,10 +34,9 @@ module detector_parallel
   use integer_hash_table_module
   use mpi_interfaces
   use elements
-  use halo_data_types
   use parallel_tools
-  use halos_numbering
   use parallel_fields
+  use halos
   use fields
   use state_module
   use detector_data_types
@@ -309,6 +308,8 @@ contains
     ! receives serialised detectors from all procs and unpacks them.
     type(state_type), intent(in) :: state
     type(detector_linked_list), intent(inout) :: detector_list
+    ! the assumption is here that we only send detectors located in element that we know about
+    ! in the largest element halo
     type(detector_linked_list), dimension(:), intent(inout) :: send_list_array
 
     type(detector_buffer), dimension(:), allocatable :: send_buffer, recv_buffer
@@ -332,6 +333,7 @@ contains
     xfield => extract_vector_field(state,"Coordinate")
     dim=xfield%dim
     allocate( sendRequest(nprocs) )
+    sendRequest = MPI_REQUEST_NULL
 
     ! Get the element halo 
     halo_level = element_halo_count(xfield%mesh)
@@ -355,6 +357,14 @@ contains
     allocate(send_buffer(nprocs))
     do target_proc=1, nprocs
        ndet_to_send=send_list_array(target_proc)%length
+       ! if we don't know any elements owned by target_proc - we shouldn't have anything to send
+       if (halo_receive_count(ele_halo, target_proc)==0) then
+         ! check that this is te case
+         if (ndet_to_send>0) then
+           FLAbort('send_list_array should only send detectors to known elements.')
+         end if
+         cycle
+       end if
        allocate(send_buffer(target_proc)%ptr(ndet_to_send,det_size))
 
        if (ndet_to_send>0) then
@@ -395,6 +405,9 @@ contains
     ! Receive from all procs
     allocate(recv_buffer(nprocs))
     do receive_proc=1, nprocs
+       ! this should predict whether to expect a message:
+       if (halo_send_count(ele_halo, receive_proc)==0) cycle
+
        call MPI_PROBE(receive_proc-1, TAG, MPI_COMM_FEMTOOLS, status(:), IERROR) 
        assert(ierror == MPI_SUCCESS)
 
@@ -440,8 +453,12 @@ contains
 
     ! Deallocate buffers after exchange
     do target_proc=1, nprocs
-       deallocate(send_buffer(target_proc)%ptr)
-       deallocate(recv_buffer(target_proc)%ptr)
+       if (halo_receive_count(ele_halo, target_proc)>0) then
+         deallocate(send_buffer(target_proc)%ptr)
+       end if
+       if (halo_send_count(ele_halo, target_proc)>0) then
+         deallocate(recv_buffer(target_proc)%ptr)
+       end if
     end do
     deallocate(send_buffer)
     deallocate(recv_buffer)

--- a/femtools/Halos_Derivation.F90
+++ b/femtools/Halos_Derivation.F90
@@ -1558,10 +1558,12 @@ contains
     tag = next_mpi_tag()
     allocate(send_buffer(nprocs), send_request(nprocs))
     allocate(recv_buffer(nprocs))
+    send_request = MPI_REQUEST_NULL
 
     ! loop over all new send nodes and send its adjacent elements
     nelist => extract_nelist(mesh)
     do proc=1, nprocs
+      if (halo_send_count(new_halo, proc)==0) cycle
       call allocate(elements_to_send)
       ! loop over all send nodes 
       do i=1, halo_send_count(new_halo, proc)
@@ -1605,6 +1607,8 @@ contains
     ! loop over the recv buffers to work out the numbering
     ! for new elements and surface elements
     do proc=1, nprocs
+      assert( (halo_send_count(new_halo, proc)==0) .eqv. (halo_receive_count(new_halo, proc)==0) )
+      if (halo_receive_count(new_halo, proc)==0) cycle
       call mpi_probe(proc-1, tag, comm, status, ierr)
       assert(ierr == MPI_SUCCESS)
       
@@ -1628,7 +1632,7 @@ contains
           ! Additionaly, we also skip elements that consist of new nodes only - this is because
           ! such elements can potentially become isolated (i.e. if all adjacent elements have a non-shared
           ! node that is in an even higher level halo)
-          ! Elements consisting of the highest level halo nodes only, are not typically not needed because
+          ! Elements consisting of the highest level halo nodes only, are typically not needed because
           ! even elements adjacent to elements adjacent to such elements will still consist of nodes that are either
           ! in the highest or in the one-but-highest level halo. Thus e.g. if we're regrowing an l2-halo, 
           ! elements adjacent to elements adjacent to an element consisting of l2-halo nodes only, still consists
@@ -1702,6 +1706,7 @@ contains
 
     ! now peel out the new elements from the recv buffers
     do proc=1, nprocs
+      if (halo_receive_count(new_halo, proc)==0) cycle
       recv_size = size(recv_buffer(proc)%ptr)
       do i=1, recv_size/ele_info_size
         ele_uid = recv_buffer(proc)%ptr((i-1)*ele_info_size+1)
@@ -1809,10 +1814,13 @@ contains
     my_rank = getrank(comm)
     allocate(send_buffer(nprocs), recv_buffer(nprocs))
     allocate(send_request(nprocs), recv_request(nprocs))
+    send_request = MPI_REQUEST_NULL
+    recv_request = MPI_REQUEST_NULL
 
     ! record the adjacency count for halo1 send nodes
     ! and allocate send buffers
     do proc=1, nprocs
+      if (halo_send_count(halo, proc)==0) cycle
       send_count = 0
       do i=1, halo_send_count(halo, proc)
         node = halo_send(halo, proc, i)
@@ -1829,6 +1837,7 @@ contains
     ! so we can allocate the recv buffers
     ! and setup the mpi recv call
     do proc=1, nprocs
+      if (halo_receive_count(halo, proc)==0) cycle
       recv_count = 0
       do i=1, halo_receive_count(halo, proc)
         node = halo_receive(halo, proc, i)
@@ -1845,6 +1854,7 @@ contains
     ! now pack the send buffers with uid and owner for each entry 
     ! in the nnlist around all halo1 send nodes, and send them off
     do proc=1, nprocs
+      if (halo_send_count(halo, proc)==0) cycle
       send_count = 0
       do i=1, halo_send_count(halo, proc) 
         node = halo_send(halo, proc, i)
@@ -1860,13 +1870,14 @@ contains
       assert(ierr == MPI_SUCCESS)
     end do
 
-    ! from the bits of nnlist that we've got sent, collect the new halo recv nodes we encounter
+    ! from the bits of nnlist that we've been sent, collect the new halo recv nodes we encounter
     allocate(new_halo_recvs(nprocs))
     do proc=1, nprocs
       call allocate(new_halo_recvs(proc))
     end do
 
     do proc=1, nprocs
+      if (halo_receive_count(halo, proc)==0) cycle
       call MPI_Wait(recv_request(proc), status, ierr)
       assert(ierr==MPI_SUCCESS)
       recv_count = 0
@@ -1894,6 +1905,12 @@ contains
     allocate(statuses(1:MPI_STATUS_SIZE*nprocs))
     call MPI_WaitAll(nprocs, send_request, statuses, ierr)
     assert(ierr==MPI_SUCCESS)
+    do proc=1, nprocs
+      if (halo_send_count(halo, proc)/=0) then
+        deallocate(send_buffer(proc)%ptr)
+      end if
+    end do
+    send_request = MPI_REQUEST_NULL ! reuse send_request as well
 
     ! so we've collected our new halo 2 recv nodes per process
     ! now we need to tell these processes that we want these as recv nodes
@@ -1901,32 +1918,64 @@ contains
     allocate(new_halo_recv_count(nprocs), new_halo_send_count(nprocs))
     do proc=1, nprocs
       new_halo_recv_count(proc) = key_count(new_halo_recvs(proc))
-      deallocate(send_buffer(proc)%ptr)
-      allocate(send_buffer(proc)%ptr(new_halo_recv_count(proc)))
-      send_buffer(proc)%ptr = set2vector(new_halo_recvs(proc))
+      ! this assumes a symmetric communication pattern, where if processor A has
+      ! any recv nodes in the new expanded halo (which includes the old halo) from 
+      ! proc B - then proc B has receive nodes of proc A in the new expanded halo.
+      !  for the case where we're expanding from halo1 to halo2: if proc. A
+      ! has halo1 recv nodes of proc. B, then trivially the node attached to
+      ! it owned by proc. A is a recv node for proc B. If proc A only has halo2
+      ! recv nodes from proc B then such a node is connected to an owned node
+      ! via a inbetween node owned by a third proc. This means the node owned
+      ! by proc A is in the combined recv halo1+halo2 for proc B. NOTE that it
+      ! possible however that this node was already a halo1 node and is therefore
+      ! not a *new* halo2 node. See for instance the following scenario:
+      !
+      !   A - B
+      !   |   |  where the 4 nodes are labeled with their ownership by either
+      !   C - B  proc A and B, or the third owner C
+      !
+      ! therefore we cannot assume that we only get a request for *new* halo2 nodes
+      ! if we request *new* halo2 nodes as well. We might get a request from
+      ! any proc that has halo1 recv nodes owned by us (i.e. halo1 send nodes).
+      !
+      ! To make this more predictable we should therefore always send a request
+      ! (even if empty) to any proc for which we already have halo1 recv nodes
+      if (halo_receive_count(halo, proc)/=0 .or. new_halo_recv_count(proc)/=0) then
+        allocate(send_buffer(proc)%ptr(new_halo_recv_count(proc)))
+        send_buffer(proc)%ptr = set2vector(new_halo_recvs(proc))
+        call MPI_ISend(send_buffer(proc)%ptr, new_halo_recv_count(proc), getpinteger(), &
+          proc-1, tag,  comm, send_request(proc), ierr)
+        assert(ierr == MPI_SUCCESS)
+      end if
       call deallocate(new_halo_recvs(proc))
-      call MPI_ISend(send_buffer(proc)%ptr, new_halo_recv_count(proc), getpinteger(), &
-        proc-1, tag,  comm, send_request(proc), ierr)
-      assert(ierr == MPI_SUCCESS)
     end do
 
     ! the same request from other processes will tell us our new halo 2 send nodes
     do proc=1, nprocs
-      call mpi_probe(proc-1, tag, comm, status, ierr)
-      assert(ierr == MPI_SUCCESS)
-      
-      call mpi_get_count(status, getpinteger(), new_halo_send_count(proc), ierr)
-      allocate(recv_buffer(proc)%ptr(new_halo_send_count(proc)))
+      ! see comments above: we rely on this logic to be symmetric
+      ! and expect a request from any proc for which we have send nodes already or for
+      ! which we have new halo recv nodes
+      if (halo_send_count(halo, proc)/=0 .or. new_halo_recv_count(proc)/=0) then
+        call mpi_probe(proc-1, tag, comm, status, ierr)
+        assert(ierr == MPI_SUCCESS)
+        
+        call mpi_get_count(status, getpinteger(), new_halo_send_count(proc), ierr)
+        allocate(recv_buffer(proc)%ptr(new_halo_send_count(proc)))
 
-      call MPI_Recv(recv_buffer(proc)%ptr, new_halo_send_count(proc), getpinteger(), &
-        proc-1, tag, comm, status, ierr)
-      assert(ierr == MPI_SUCCESS)
+        call MPI_Recv(recv_buffer(proc)%ptr, new_halo_send_count(proc), getpinteger(), &
+          proc-1, tag, comm, status, ierr)
+        assert(ierr == MPI_SUCCESS)
+      else
+        new_halo_send_count(proc) = 0
+      end if
     end do
 
     ! again make sure all sends are dealt with
     call MPI_WaitAll(nprocs, send_request, statuses, ierr)
     assert(ierr==MPI_SUCCESS)
     deallocate(statuses)
+    deallocate(send_request)
+    deallocate(recv_request)
 
     ! the new halo should include the existing halo:
     allocate(old_halo_count(nprocs))
@@ -1943,25 +1992,30 @@ contains
       communicator = comm, data_type = halo%data_type)
     call get_universal_numbering_inverse(halo, uid_to_gid)
     assert(node_count(mesh)==key_count(uid_to_gid)) ! if this fails the old halo has duplicate nodes
-    new_node_count = node_count(mesh)
+    new_node_count = node_count(mesh) ! counter to number new recv nodes
     do proc=1, nprocs
-      allocate(buffer(1:halo_send_count(new_halo, proc)))
-      buffer(1:halo_send_count(halo,proc)) = halo_sends(halo, proc)
-      buffer(halo_send_count(halo,proc)+1:) = fetch(uid_to_gid, recv_buffer(proc)%ptr)
-      call set_halo_sends(new_halo, proc, buffer)
-      deallocate(buffer)
-      
-      allocate(buffer(1:halo_receive_count(new_halo, proc)))
-      new_recv_count = size(buffer)-halo_receive_count(halo, proc)
-      buffer(1:halo_receive_count(halo,proc)) = halo_receives(halo, proc)
-      buffer(halo_receive_count(halo,proc)+1:) = (/ ( i, i=new_node_count+1, new_node_count+new_recv_count)/)
-      call set_halo_receives(new_halo, proc, buffer)
-      deallocate(buffer)
-      deallocate(recv_buffer(proc)%ptr)
-      deallocate(send_buffer(proc)%ptr)
-      new_node_count = new_node_count+new_recv_count
+      if (new_halo_send_count(proc)/=0) then
+        allocate(buffer(1:new_halo_send_count(proc)))
+        buffer(1:halo_send_count(halo,proc)) = halo_sends(halo, proc)
+        buffer(halo_send_count(halo,proc)+1:) = fetch(uid_to_gid, recv_buffer(proc)%ptr)
+        call set_halo_sends(new_halo, proc, buffer)
+        deallocate(buffer)
+        
+        assert(new_halo_recv_count(proc)/=0)
+        allocate(buffer(1:new_halo_recv_count(proc)))
+        new_recv_count = new_halo_recv_count(proc) - halo_receive_count(halo, proc)
+        buffer(1:halo_receive_count(halo,proc)) = halo_receives(halo, proc)
+        buffer(halo_receive_count(halo,proc)+1:) = (/ ( i, i=new_node_count+1, new_node_count+new_recv_count)/)
+        call set_halo_receives(new_halo, proc, buffer)
+        deallocate(buffer)
+        deallocate(recv_buffer(proc)%ptr)
+        deallocate(send_buffer(proc)%ptr)
+        new_node_count = new_node_count + new_recv_count
+      end if
     end do
     call deallocate(uid_to_gid)
+    deallocate(new_halo_recv_count)
+    deallocate(new_halo_send_count)
 
     ewrite(1,*) "Exiting expand_halo"
 

--- a/femtools/Makefile.dependencies
+++ b/femtools/Makefile.dependencies
@@ -55,11 +55,11 @@ Bound_field.o ../include/bound_field_module.mod: Bound_field.F90 \
 	@true
 
 Boundary_Conditions.o ../include/boundary_conditions.mod: \
-   Boundary_Conditions.F90 ../include/fdebug.h ../include/fetools.mod \
-   ../include/fields.mod ../include/fldebug.mod ../include/futils.mod \
-   ../include/global_parameters.mod ../include/parallel_tools.mod \
-   ../include/sparse_tools.mod ../include/sparse_tools_petsc.mod \
-   ../include/state_module.mod
+   Boundary_Conditions.F90 ../include/data_structures.mod ../include/fdebug.h \
+   ../include/fetools.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/futils.mod ../include/global_parameters.mod \
+   ../include/parallel_tools.mod ../include/sparse_tools.mod \
+   ../include/sparse_tools_petsc.mod ../include/state_module.mod
 
 ../include/cgal_tools.mod: CGAL_Tools.o
 	@true
@@ -238,11 +238,10 @@ Detector_Move_Lagrangian.o ../include/detector_move_lagrangian.mod: \
 Detector_Parallel.o ../include/detector_parallel.mod: Detector_Parallel.F90 \
    ../include/detector_data_types.mod ../include/detector_tools.mod \
    ../include/elements.mod ../include/fdebug.h ../include/fields.mod \
-   ../include/fldebug.mod ../include/futils.mod ../include/halo_data_types.mod \
-   ../include/halos_numbering.mod ../include/integer_hash_table_module.mod \
-   ../include/mpi_interfaces.mod ../include/parallel_fields.mod \
-   ../include/parallel_tools.mod ../include/pickers.mod \
-   ../include/state_module.mod
+   ../include/fldebug.mod ../include/futils.mod ../include/halos.mod \
+   ../include/integer_hash_table_module.mod ../include/mpi_interfaces.mod \
+   ../include/parallel_fields.mod ../include/parallel_tools.mod \
+   ../include/pickers.mod ../include/state_module.mod
 
 ../include/detector_tools.mod: Detector_Tools.o
 	@true
@@ -1087,7 +1086,8 @@ Sparse_Tools.o ../include/sparse_tools.mod: Sparse_Tools.F90 \
 	@true
 
 Sparse_Tools_Petsc.o ../include/sparse_tools_petsc.mod: Sparse_Tools_Petsc.F90 \
-   ../include/fdebug.h ../include/fields_base.mod \
+   ../include/data_structures.mod ../include/fdebug.h \
+   ../include/fields_allocates.mod ../include/fields_base.mod \
    ../include/fields_data_types.mod ../include/fields_manipulation.mod \
    ../include/fldebug.mod ../include/futils.mod \
    ../include/global_parameters.mod ../include/halo_data_types.mod \

--- a/main/Makefile.dependencies
+++ b/main/Makefile.dependencies
@@ -15,20 +15,20 @@ Fluids.o ../include/fluids_module.mod: Fluids.F90 \
    ../include/diagnostic_children.mod ../include/diagnostic_fields_new.mod \
    ../include/diagnostic_fields_wrapper.mod \
    ../include/diagnostic_variables.mod \
-   ../include/discrete_properties_module.mod ../include/elements.mod \
-   ../include/equation_of_state.mod ../include/eventcounter.mod \
-   ../include/fdebug.h ../include/field_equations_cv.mod \
-   ../include/field_priority_lists.mod ../include/fields.mod \
-   ../include/fldebug.mod ../include/foam_flow_module.mod \
-   ../include/free_surface_module.mod ../include/futils.mod \
-   ../include/global_parameters.mod ../include/gls.mod ../include/goals.mod \
-   ../include/halos.mod ../include/iceshelf_meltrate_surf_normal.mod \
-   ../include/implicit_solids.mod ../include/k_epsilon.mod \
-   ../include/memory_diagnostics.mod ../include/meshdiagnostics.mod \
-   ../include/meshmovement.mod ../include/momentum_diagnostic_fields.mod \
-   ../include/momentum_equation.mod ../include/multimaterial_module.mod \
-   ../include/multiphase_module.mod ../include/parallel_tools.mod \
-   ../include/populate_state_module.mod \
+   ../include/discrete_properties_module.mod ../include/dqmom.mod \
+   ../include/elements.mod ../include/equation_of_state.mod \
+   ../include/eventcounter.mod ../include/fdebug.h \
+   ../include/field_equations_cv.mod ../include/field_priority_lists.mod \
+   ../include/fields.mod ../include/fldebug.mod \
+   ../include/foam_flow_module.mod ../include/free_surface_module.mod \
+   ../include/futils.mod ../include/global_parameters.mod ../include/gls.mod \
+   ../include/goals.mod ../include/halos.mod \
+   ../include/iceshelf_meltrate_surf_normal.mod ../include/implicit_solids.mod \
+   ../include/k_epsilon.mod ../include/memory_diagnostics.mod \
+   ../include/meshdiagnostics.mod ../include/meshmovement.mod \
+   ../include/momentum_diagnostic_fields.mod ../include/momentum_equation.mod \
+   ../include/multimaterial_module.mod ../include/multiphase_module.mod \
+   ../include/parallel_tools.mod ../include/populate_state_module.mod \
    ../include/populate_sub_state_module.mod ../include/qmesh_module.mod \
    ../include/reduced_model_runtime.mod ../include/reference_counting.mod \
    ../include/reserve_state_module.mod \

--- a/population_balance/Makefile.dependencies
+++ b/population_balance/Makefile.dependencies
@@ -2,9 +2,21 @@
 ../include/dqmom.mod: DQMOM.o
 	@true
 
-DQMOM.o ../include/dqmom.mod: DQMOM.F90 ../include/fdebug.h \
-   ../include/fields.mod ../include/global_parameters.mod \
-   ../include/initialise_fields_module.mod ../include/spud.mod \
+DQMOM.o ../include/dqmom.mod: DQMOM.F90 ../include/elements.mod \
+   ../include/fdebug.h ../include/fetools.mod ../include/fields.mod \
+   ../include/fldebug.mod ../include/futils.mod \
+   ../include/global_parameters.mod ../include/initialise_fields_module.mod \
+   ../include/solvers.mod ../include/sparse_tools.mod \
    ../include/state_fields_module.mod ../include/state_module.mod \
    ../include/vector_tools.mod
+
+../include/dqmom.mod: DQMOM_node_source.o
+	@true
+
+DQMOM_node_source.o ../include/dqmom.mod: DQMOM_node_source.F90 \
+   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
+   ../include/futils.mod ../include/global_parameters.mod \
+   ../include/initialise_fields_module.mod ../include/solvers.mod \
+   ../include/sparse_tools.mod ../include/state_fields_module.mod \
+   ../include/state_module.mod ../include/vector_tools.mod
 


### PR DESCRIPTION
This aptly named branch removes spurious sends and recvs from the subroutine remove_spurious_sends() which is called from make_global_numbering whenever a mesh is derived with different polynomial degree or continuity. The current implementation calls MPI_ISend and MPI_RECV for every other process which causes issues on jobs with a large number of processes. This was seen on [Raijin](http://nci.org.au/systems-services/peak-system/raijin/) for nprocs>512. 

Regardless of whether a HPC platform should be able to handle this, this practice is not efficient as the very many zero-sized messages do not come for free. Therefore here we change this to only communicate with neighbouring processes in the halo.

A similar pattern was found in expand_halo (called to restore the L2 halo after an adapt). Here avoiding unnecessary communication proved a little more tricky as the halo is at that point still being constructed so neighbourship relations based on the halo still need to be estabilisged.

Finally this pattern has been fixed in the detectors code where detectors move into the halo and are therefore sent to their owners.

I believe this fixes all the places where MPI_(I)Send and MPI_(I)Recv is called from/to every process. There are two remaining cases in the code that look problematic (just mentioning here for documentation sake - not going to be fixed in this PR)
- in the detectors code if on any process a detector leaps outside the halo (and therefore the local processor no longer know where it should be sent to) a special communication is performed that involves N * NPROCS MPI_BCAST calls. Here N is the maximum number of "lost" detectors on any process. I'm not sure how often this actually happens or whether we can avoid it: if a detector moves out of the halo within a timestep, surely we should be able to break off its trajectory and pass it over to a new owner to continue the movement within that timesteps (who can then send it onwards to yet another process)?
- a similar pattern with NPROCS MPI_BCAST calls happens in the zoltan redestribution of detectors. The current strategy seems to involve not bothering zoltan at all with the detectors and then when all is done hoping that the detectors that we used to own are still within our domain - which is absurd - if it no longer is, we invoke the expensive NPROCS MPI_BCAST pattern. This presumably could be fixed by packing the detector information to let zoltan move the detector from the current element owner to the new one.