### PR TITLE
Bc smoothing

### DIFF
--- a/assemble/Makefile.dependencies
+++ b/assemble/Makefile.dependencies
@@ -23,9 +23,10 @@ Adapt_State.o ../include/adapt_state_module.mod: Adapt_State.F90 \
    ../include/detector_parallel.mod ../include/diagnostic_fields_wrapper.mod \
    ../include/diagnostic_fields_wrapper_new.mod \
    ../include/diagnostic_variables.mod \
-   ../include/discrete_properties_module.mod ../include/edge_length_module.mod \
-   ../include/elements.mod ../include/eventcounter.mod ../include/fdebug.h \
-   ../include/fefields.mod ../include/field_options.mod ../include/fields.mod \
+   ../include/discrete_properties_module.mod ../include/dqmom.mod \
+   ../include/edge_length_module.mod ../include/elements.mod \
+   ../include/eventcounter.mod ../include/fdebug.h ../include/fefields.mod \
+   ../include/field_options.mod ../include/fields.mod \
    ../include/fields_halos.mod ../include/fldebug.mod ../include/futils.mod \
    ../include/global_parameters.mod ../include/hadapt_extrude.mod \
    ../include/hadapt_metric_based_extrude.mod ../include/halos.mod \
@@ -141,12 +142,13 @@ Advection_Diffusion_FV.o ../include/advection_diffusion_fv.mod: \
 	@true
 
 Assemble_CMC.o ../include/assemble_cmc.mod: Assemble_CMC.F90 \
-   ../include/elements.mod ../include/fdebug.h ../include/fefields.mod \
-   ../include/fetools.mod ../include/field_options.mod ../include/fields.mod \
-   ../include/fldebug.mod ../include/global_parameters.mod \
-   ../include/linked_lists.mod ../include/sparse_matrices_fields.mod \
-   ../include/sparse_tools.mod ../include/sparse_tools_petsc.mod \
-   ../include/state_module.mod ../include/transform_elements.mod
+   ../include/boundary_conditions.mod ../include/elements.mod \
+   ../include/fdebug.h ../include/fefields.mod ../include/fetools.mod \
+   ../include/field_options.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/global_parameters.mod ../include/linked_lists.mod \
+   ../include/sparse_matrices_fields.mod ../include/sparse_tools.mod \
+   ../include/sparse_tools_petsc.mod ../include/state_module.mod \
+   ../include/transform_elements.mod
 
 ../include/biology.mod: Biology.o
 	@true
@@ -214,9 +216,10 @@ Diagnostic_Fields_Matrices.o ../include/diagnostic_fields_matrices.mod: \
 
 Diagnostic_fields_wrapper.o ../include/diagnostic_fields_wrapper.mod: \
    Diagnostic_fields_wrapper.F90 ../include/diagnostic_fields.mod \
-   ../include/diagnostic_fields_matrices.mod ../include/equation_of_state.mod \
-   ../include/fdebug.h ../include/fetools.mod ../include/field_derivatives.mod \
-   ../include/field_options.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/diagnostic_fields_matrices.mod ../include/dqmom.mod \
+   ../include/equation_of_state.mod ../include/fdebug.h ../include/fetools.mod \
+   ../include/field_derivatives.mod ../include/field_options.mod \
+   ../include/fields.mod ../include/fldebug.mod \
    ../include/free_surface_module.mod ../include/futils.mod \
    ../include/geostrophic_pressure.mod ../include/global_parameters.mod \
    ../include/momentum_diagnostic_fields.mod \
@@ -356,8 +359,10 @@ Free_Surface.o ../include/free_surface_module.mod: Free_Surface.F90 \
 	@true
 
 Full_Projection.o ../include/full_projection.mod: Full_Projection.F90 \
-   ../include/boundary_conditions_from_options.mod ../include/elements.mod \
-   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
+   ../include/boundary_conditions.mod \
+   ../include/boundary_conditions_from_options.mod \
+   ../include/data_structures.mod ../include/elements.mod ../include/fdebug.h \
+   ../include/fields.mod ../include/fldebug.mod \
    ../include/global_parameters.mod ../include/halos.mod \
    ../include/multigrid.mod ../include/parallel_tools.mod \
    ../include/petsc_legacy.h ../include/petsc_solve_state_module.mod \

--- a/femtools/Bound_field.F90
+++ b/femtools/Bound_field.F90
@@ -156,7 +156,7 @@ module bound_field_module
     call addto(diffused, deviation, -1.0)
     call addto(field, diffused, 2.0)
 
-    call halo_update(field, 1)
+    call halo_update(field, 1, verbose=.false.)
   end do iterloop
   
   ewrite(2,*) "Bounded interpolation for field ", trim(field%name), " took ", k, " iterations"

--- a/femtools/Halos_Communications.F90
+++ b/femtools/Halos_Communications.F90
@@ -407,15 +407,18 @@ contains
 
   end subroutine halo_update_array_real_star
   
-  subroutine halo_update_scalar_on_halo(halo, s_field)
+  subroutine halo_update_scalar_on_halo(halo, s_field, verbose)
     !!< Update the supplied scalar field on the suppied halo.
     
     type(halo_type), intent(in) :: halo
     type(scalar_field), intent(inout) :: s_field
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
     
     real, dimension(:), allocatable :: buffer
 
-    ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(s_field%name)
+    if (.not. present_and_false(verbose)) then
+      ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(s_field%name)
+    end if
     
     select case(s_field%field_type)
       case(FIELD_TYPE_NORMAL)
@@ -423,7 +426,9 @@ contains
         if(s_field%val_stride == 1) then
           call halo_update(halo, s_field%val)
         else
-          ewrite(2,*) "Need to copy into temp. buffer because field has stride", s_field%val_stride
+          if (.not. present_and_false(verbose)) then
+            ewrite(2,*) "Need to copy into temp. buffer because field has stride", s_field%val_stride
+          end if
           ! A stride argument should be passed to halo_update_real_array. For
           ! now just use a buffer.
           allocate(buffer(node_count(s_field)))
@@ -440,15 +445,18 @@ contains
     
   end subroutine halo_update_scalar_on_halo
   
-  subroutine halo_update_vector_on_halo(halo, v_field)
+  subroutine halo_update_vector_on_halo(halo, v_field, verbose)
     !!< Update the supplied vector field on the suppied halo.
     
     type(halo_type), intent(in) :: halo
     type(vector_field), intent(inout) :: v_field
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
     
     integer :: i
     
-    ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(v_field%name)
+    if (.not. present_and_false(verbose)) then
+      ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(v_field%name)
+    end if
 
     select case(v_field%field_type)
       case(FIELD_TYPE_NORMAL)
@@ -461,15 +469,18 @@ contains
     
   end subroutine halo_update_vector_on_halo
   
-  subroutine halo_update_tensor_on_halo(halo, t_field)
+  subroutine halo_update_tensor_on_halo(halo, t_field, verbose)
     !!< Update the supplied tensor field on the suppied halo.
 
     type(halo_type), intent(in) :: halo
     type(tensor_field), intent(inout) :: t_field
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
 
     integer :: i, j
 
-    ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(t_field%name)
+    if (.not. present_and_false(verbose)) then
+      ewrite(2, *) "Updating halo " // trim(halo%name) // " for field " // trim(t_field%name)
+    end if
 
     select case(t_field%field_type)
       case(FIELD_TYPE_NORMAL)              
@@ -483,12 +494,13 @@ contains
 
   end subroutine halo_update_tensor_on_halo
   
-  subroutine halo_update_scalar(s_field, level)
+  subroutine halo_update_scalar(s_field, level, verbose)
     !!< Update the halos of the supplied field. If level is not supplied, the
     !!< field is updated on its largest halo.
   
     type(scalar_field), intent(inout) :: s_field
     integer, optional, intent(in) :: level
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
     
     integer :: llevel, nhalos
     
@@ -501,17 +513,18 @@ contains
     end if
     
     if(nhalos > 0) then
-      call halo_update(s_field%mesh%halos(llevel), s_field)
+      call halo_update(s_field%mesh%halos(llevel), s_field, verbose=verbose)
     end if
     
   end subroutine halo_update_scalar
   
-  subroutine halo_update_vector(v_field, level)
+  subroutine halo_update_vector(v_field, level, verbose)
     !!< Update the halos of the supplied field. If level is not supplied, the
     !!< field is updated on its largest halo.
   
     type(vector_field), intent(inout) :: v_field
     integer, optional, intent(in) :: level
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
     
     integer :: llevel, nhalos
     
@@ -524,17 +537,18 @@ contains
     end if
     
     if(nhalos > 0) then
-      call halo_update(v_field%mesh%halos(llevel), v_field)
+      call halo_update(v_field%mesh%halos(llevel), v_field, verbose=verbose)
     end if
     
   end subroutine halo_update_vector
   
-  subroutine halo_update_tensor(t_field, level)
+  subroutine halo_update_tensor(t_field, level, verbose)
     !!< Update the halos of the supplied field. If level is not supplied, the
     !!< field is updated on its largest halo.
   
     type(tensor_field), intent(inout) :: t_field
     integer, optional, intent(in) :: level
+    logical, intent(in), optional :: verbose ! set to .false. to leave out any verbosity 1 or 2 messages
     
     integer :: llevel, nhalos
     
@@ -547,7 +561,7 @@ contains
     end if
     
     if(nhalos > 0) then
-      call halo_update(t_field%mesh%halos(llevel), t_field)
+      call halo_update(t_field%mesh%halos(llevel), t_field, verbose)
     end if
     
   end subroutine halo_update_tensor

--- a/femtools/Makefile.dependencies
+++ b/femtools/Makefile.dependencies
@@ -55,11 +55,11 @@ Bound_field.o ../include/bound_field_module.mod: Bound_field.F90 \
 	@true
 
 Boundary_Conditions.o ../include/boundary_conditions.mod: \
-   Boundary_Conditions.F90 ../include/fdebug.h ../include/fetools.mod \
-   ../include/fields.mod ../include/fldebug.mod ../include/futils.mod \
-   ../include/global_parameters.mod ../include/parallel_tools.mod \
-   ../include/sparse_tools.mod ../include/sparse_tools_petsc.mod \
-   ../include/state_module.mod
+   Boundary_Conditions.F90 ../include/data_structures.mod ../include/fdebug.h \
+   ../include/fetools.mod ../include/fields.mod ../include/fldebug.mod \
+   ../include/futils.mod ../include/global_parameters.mod \
+   ../include/parallel_tools.mod ../include/sparse_tools.mod \
+   ../include/sparse_tools_petsc.mod ../include/state_module.mod
 
 ../include/cgal_tools.mod: CGAL_Tools.o
 	@true
@@ -1087,7 +1087,8 @@ Sparse_Tools.o ../include/sparse_tools.mod: Sparse_Tools.F90 \
 	@true
 
 Sparse_Tools_Petsc.o ../include/sparse_tools_petsc.mod: Sparse_Tools_Petsc.F90 \
-   ../include/fdebug.h ../include/fields_base.mod \
+   ../include/data_structures.mod ../include/fdebug.h \
+   ../include/fields_allocates.mod ../include/fields_base.mod \
    ../include/fields_data_types.mod ../include/fields_manipulation.mod \
    ../include/fldebug.mod ../include/futils.mod \
    ../include/global_parameters.mod ../include/halo_data_types.mod \

--- a/femtools/Transform_elements.F90
+++ b/femtools/Transform_elements.F90
@@ -1112,10 +1112,10 @@ contains
                   J = jacobian_on_sphere(x_shape, gi, X_val, r_val, J)
                 end if
                 ! outer product
-                det=abs( &
-                     J(2,1)*J(3,2)-J(3,1)*J(2,2) &
-                     -J(3,1)*J(1,2)+J(1,1)*J(3,2) &
-                     +J(1,1)*J(2,2)-J(2,1)*J(1,2))
+                det=sqrt( &
+                      (J(2,1)*J(3,2)-J(3,1)*J(2,2))**2 &
+                     +(J(3,1)*J(1,2)-J(1,1)*J(3,2))**2 &
+                     +(J(1,1)*J(2,2)-J(2,1)*J(1,2))**2)
              end if
              ! outer product times quad. weight
              detwei(gi)=det *x_shape%quadrature%weight(gi)

--- a/main/Makefile.dependencies
+++ b/main/Makefile.dependencies
@@ -15,20 +15,20 @@ Fluids.o ../include/fluids_module.mod: Fluids.F90 \
    ../include/diagnostic_children.mod ../include/diagnostic_fields_new.mod \
    ../include/diagnostic_fields_wrapper.mod \
    ../include/diagnostic_variables.mod \
-   ../include/discrete_properties_module.mod ../include/elements.mod \
-   ../include/equation_of_state.mod ../include/eventcounter.mod \
-   ../include/fdebug.h ../include/field_equations_cv.mod \
-   ../include/field_priority_lists.mod ../include/fields.mod \
-   ../include/fldebug.mod ../include/foam_flow_module.mod \
-   ../include/free_surface_module.mod ../include/futils.mod \
-   ../include/global_parameters.mod ../include/gls.mod ../include/goals.mod \
-   ../include/halos.mod ../include/iceshelf_meltrate_surf_normal.mod \
-   ../include/implicit_solids.mod ../include/k_epsilon.mod \
-   ../include/memory_diagnostics.mod ../include/meshdiagnostics.mod \
-   ../include/meshmovement.mod ../include/momentum_diagnostic_fields.mod \
-   ../include/momentum_equation.mod ../include/multimaterial_module.mod \
-   ../include/multiphase_module.mod ../include/parallel_tools.mod \
-   ../include/populate_state_module.mod \
+   ../include/discrete_properties_module.mod ../include/dqmom.mod \
+   ../include/elements.mod ../include/equation_of_state.mod \
+   ../include/eventcounter.mod ../include/fdebug.h \
+   ../include/field_equations_cv.mod ../include/field_priority_lists.mod \
+   ../include/fields.mod ../include/fldebug.mod \
+   ../include/foam_flow_module.mod ../include/free_surface_module.mod \
+   ../include/futils.mod ../include/global_parameters.mod ../include/gls.mod \
+   ../include/goals.mod ../include/halos.mod \
+   ../include/iceshelf_meltrate_surf_normal.mod ../include/implicit_solids.mod \
+   ../include/k_epsilon.mod ../include/memory_diagnostics.mod \
+   ../include/meshdiagnostics.mod ../include/meshmovement.mod \
+   ../include/momentum_diagnostic_fields.mod ../include/momentum_equation.mod \
+   ../include/multimaterial_module.mod ../include/multiphase_module.mod \
+   ../include/parallel_tools.mod ../include/populate_state_module.mod \
    ../include/populate_sub_state_module.mod ../include/qmesh_module.mod \
    ../include/reduced_model_runtime.mod ../include/reference_counting.mod \
    ../include/reserve_state_module.mod \

--- a/population_balance/Makefile.dependencies
+++ b/population_balance/Makefile.dependencies
@@ -2,9 +2,21 @@
 ../include/dqmom.mod: DQMOM.o
 	@true
 
-DQMOM.o ../include/dqmom.mod: DQMOM.F90 ../include/fdebug.h \
-   ../include/fields.mod ../include/global_parameters.mod \
-   ../include/initialise_fields_module.mod ../include/spud.mod \
+DQMOM.o ../include/dqmom.mod: DQMOM.F90 ../include/elements.mod \
+   ../include/fdebug.h ../include/fetools.mod ../include/fields.mod \
+   ../include/fldebug.mod ../include/futils.mod \
+   ../include/global_parameters.mod ../include/initialise_fields_module.mod \
+   ../include/solvers.mod ../include/sparse_tools.mod \
    ../include/state_fields_module.mod ../include/state_module.mod \
    ../include/vector_tools.mod
+
+../include/dqmom.mod: DQMOM_node_source.o
+	@true
+
+DQMOM_node_source.o ../include/dqmom.mod: DQMOM_node_source.F90 \
+   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
+   ../include/futils.mod ../include/global_parameters.mod \
+   ../include/initialise_fields_module.mod ../include/solvers.mod \
+   ../include/sparse_tools.mod ../include/state_fields_module.mod \
+   ../include/state_module.mod ../include/vector_tools.mod
 

--- a/preprocessor/Boundary_Conditions_From_Options.F90
+++ b/preprocessor/Boundary_Conditions_From_Options.F90
@@ -1285,9 +1285,9 @@ contains
       end if
       call set(field, rhs)
       call scale(field, masslump)
-      call halo_update(field)
-      ewrite_minmax(field)
+      call halo_update(field, verbose=.false.)
     end do
+    ewrite_minmax(field)
 
     call deallocate(masslump)
     call deallocate(rhs)

--- a/preprocessor/Boundary_Conditions_From_Options.F90
+++ b/preprocessor/Boundary_Conditions_From_Options.F90
@@ -1268,6 +1268,7 @@ contains
       end if
       call set(field, rhs)
       call scale(field, masslump)
+      call halo_update(field)
       ewrite_minmax(field)
     end do
 

--- a/preprocessor/Boundary_Conditions_From_Options.F90
+++ b/preprocessor/Boundary_Conditions_From_Options.F90
@@ -1153,7 +1153,7 @@ contains
           bc_position = get_coordinates_remapped_to_surface(position, surface_mesh, surface_element_list) 
           surface_field_component=extract_scalar_field(surface_field, 1)
           call initialise_vector_field_component(surface_field_component, state,  &
-            bc_component_path, bc_position, surface_element_list, 1, time)
+            bc_path_i, bc_position, surface_element_list, 1, time)
 
           call deallocate(bc_position)
 

--- a/preprocessor/Boundary_Conditions_From_Options.F90
+++ b/preprocessor/Boundary_Conditions_From_Options.F90
@@ -27,10 +27,9 @@
 
 #include "fdebug.h"
 module boundary_conditions_from_options
-
   use fldebug
   use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN, pi,&
-       current_debug_level, FIELD_NAME_LEN
+current_debug_level, FIELD_NAME_LEN
   use futils, only: int2str, present_and_true
   use vector_tools
   use quadrature
@@ -44,12 +43,12 @@ module boundary_conditions_from_options
   use transform_elements
   use halos_numbering
   use halos_derivation
+  use transform_elements
+  use fetools
   use fields
   use sparse_tools_petsc
   use state_module
   use field_options
-  use transform_elements
-  use fetools
   use vtk_interfaces
   use fefields
   use boundary_conditions

--- a/preprocessor/Makefile.dependencies
+++ b/preprocessor/Makefile.dependencies
@@ -8,18 +8,18 @@ Boundary_Conditions_From_Options.o \
    Boundary_Conditions_From_Options.F90 ../include/boundary_conditions.mod \
    ../include/bulk_parameterisations.mod ../include/coordinates.mod \
    ../include/elements.mod ../include/embed_python.mod ../include/fdebug.h \
-   ../include/fefields.mod ../include/field_options.mod ../include/fields.mod \
-   ../include/fldebug.mod ../include/futils.mod \
+   ../include/fefields.mod ../include/fetools.mod ../include/field_options.mod \
+   ../include/fields.mod ../include/fldebug.mod ../include/futils.mod \
    ../include/global_parameters.mod ../include/halos_base.mod \
-   ../include/halos_numbering.mod ../include/initialise_fields_module.mod \
-   ../include/integer_set_module.mod ../include/k_epsilon.mod \
-   ../include/parallel_tools.mod ../include/pickers_inquire.mod \
-   ../include/quadrature.mod ../include/samplenetcdf.mod \
-   ../include/sediment.mod ../include/sparse_tools.mod \
-   ../include/sparse_tools_petsc.mod ../include/state_module.mod \
-   ../include/synthetic_bc.mod ../include/tidal_module.mod \
-   ../include/transform_elements.mod ../include/vector_tools.mod \
-   ../include/vtk_interfaces.mod
+   ../include/halos_derivation.mod ../include/halos_numbering.mod \
+   ../include/initialise_fields_module.mod ../include/integer_set_module.mod \
+   ../include/k_epsilon.mod ../include/parallel_tools.mod \
+   ../include/pickers_inquire.mod ../include/quadrature.mod \
+   ../include/samplenetcdf.mod ../include/sediment.mod \
+   ../include/sparse_tools.mod ../include/sparse_tools_petsc.mod \
+   ../include/state_module.mod ../include/synthetic_bc.mod \
+   ../include/tidal_module.mod ../include/transform_elements.mod \
+   ../include/vector_tools.mod ../include/vtk_interfaces.mod
 
 ../include/field_priority_lists.mod: Field_Priority_Lists.o
 	@true

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -3098,24 +3098,30 @@ velocity_components_choice =
       (
          element align_bc_with_cartesian {
             element x_component {
-               input_choice_real_bc_component
+               input_choice_real_bc_component,
+               bc_smoothing
             }?,
             element y_component {
-               input_choice_real_bc_component
+               input_choice_real_bc_component,
+               bc_smoothing
             }?,
             element z_component {
-               input_choice_real_bc_component
+               input_choice_real_bc_component,
+               bc_smoothing
             }?
          }|
          element align_bc_with_surface {
             element normal_component {
-               input_choice_real_plus_field
+               input_choice_real_plus_field,
+               bc_smoothing
             }?,
             element tangent_component_1 {
-               input_choice_real_plus_field
+               input_choice_real_plus_field,
+               bc_smoothing
             }?,
             element tangent_component_2 {
-               input_choice_real_plus_field
+               input_choice_real_plus_field,
+               bc_smoothing
             }?,
             rotation_matrix_components,
             ## this will calculate the determinant of the

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -4239,16 +4239,19 @@ If off then fluidity computes the tangent.  </a:documentation>
         <optional>
           <element name="x_component">
             <ref name="input_choice_real_bc_component"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
         <optional>
           <element name="y_component">
             <ref name="input_choice_real_bc_component"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
         <optional>
           <element name="z_component">
             <ref name="input_choice_real_bc_component"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
       </element>
@@ -4256,16 +4259,19 @@ If off then fluidity computes the tangent.  </a:documentation>
         <optional>
           <element name="normal_component">
             <ref name="input_choice_real_plus_field"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
         <optional>
           <element name="tangent_component_1">
             <ref name="input_choice_real_plus_field"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
         <optional>
           <element name="tangent_component_2">
             <ref name="input_choice_real_plus_field"/>
+            <ref name="bc_smoothing"/>
           </element>
         </optional>
         <ref name="rotation_matrix_components"/>

--- a/schemas/input_output.rnc
+++ b/schemas/input_output.rnc
@@ -128,6 +128,19 @@ input_choice_real_contents =
       python_code
    }
 
+bc_smoothing =
+   (
+      ## Smoothing on mesh. This uses the lumped mass approach. When the mesh is not
+      ## linear and continuous, the boundary values are evaluated on a continuous
+      ## linear mesh first, then smoothed and then interpolated onto the actual mesh.
+      element smoothing {
+         ## Number of smoothing iterations. More iterations means more smoothing
+         element iterations {
+             integer
+         }
+      }?
+   )
+
 initial_condition_scalar = 
    (
       ## Initial condition for WholeMesh

--- a/schemas/input_output.rng
+++ b/schemas/input_output.rng
@@ -166,6 +166,19 @@ where X is a tuple of length geometry dimension.</a:documentation>
       </element>
     </choice>
   </define>
+  <define name="bc_smoothing">
+    <optional>
+      <element name="smoothing">
+        <a:documentation>Smoothing on mesh. This uses the lumped mass approach. When the mesh is not
+linear and continuous, the boundary values are evaluated on a continuous
+linear mesh first, then smoothed and then interpolated onto the actual mesh.</a:documentation>
+        <element name="iterations">
+          <a:documentation>Number of smoothing iterations. More iterations means more smoothing</a:documentation>
+          <ref name="integer"/>
+        </element>
+      </element>
+    </optional>
+  </define>
   <define name="initial_condition_scalar">
     <choice>
       <element name="initial_condition">

--- a/tests/bc-smoothing/Makefile
+++ b/tests/bc-smoothing/Makefile
@@ -2,5 +2,5 @@ input: clean
 	gmsh -3 -o cube.msh src/cube.geo
 
 clean:
-	rm -f out* cube.msh
-	rm -f matrixdump matrixdump.info
+	rm -rf out* cube.msh
+	rm -rf matrixdump matrixdump.info

--- a/tests/bc-smoothing/Makefile
+++ b/tests/bc-smoothing/Makefile
@@ -1,0 +1,6 @@
+input: clean
+	gmsh -3 -o cube.msh src/cube.geo
+
+clean:
+	rm -f out* cube.msh
+	rm -f matrixdump matrixdump.info

--- a/tests/bc-smoothing/bc-smoothing.xml
+++ b/tests/bc-smoothing/bc-smoothing.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testproblem>
+  <name>bc-smoothing</name>
+  <owner userid="skramer"/>
+  <problem_definition length="short" nprocs="1">
+    <command_line>mpiexec fluidity -v2 -l smoothed_bcs.flml</command_line>
+  </problem_definition>
+  <variables>
+    <variable name="velocity_max" language="python">from fluidity_tools import stat_parser
+from numpy import array
+stat = stat_parser('out.stat')
+velocity_max = []
+for i in '123':
+    velocity_max.append(stat['Fields']['Velocity%'+i]['max'][0])
+velocity_max=array(velocity_max)</variable>
+    <variable name="velocity_min" language="python">from fluidity_tools import stat_parser
+from numpy import array
+stat = stat_parser('out.stat')
+velocity_min = []
+for i in '123':
+    velocity_min.append(stat['Fields']['Velocity%'+i]['min'][0])
+velocity_min=array(velocity_min)</variable>
+    <variable name="velocity_grad_min" language="python">from fluidity_tools import stat_parser
+from numpy import array
+stat = stat_parser('out.stat')
+velocity_grad_min = []
+for i in '123':
+    velocity_grad_min.append(stat['Fields']['VelocityGradAlongSurface%'+i]['min'][0])
+velocity_grad_min=array(velocity_grad_min)</variable>
+    <variable name="velocity_grad_max" language="python">from fluidity_tools import stat_parser
+from numpy import array
+stat = stat_parser('out.stat')
+velocity_grad_max = []
+for i in '123':
+    velocity_grad_max.append(stat['Fields']['VelocityGradAlongSurface%'+i]['max'][0])
+velocity_grad_max=array(velocity_grad_max)</variable>
+  </variables>
+  <pass_tests>
+    <test name="check_velocity_max" language="python">assert all(velocity_max&gt;1-1e-5) and all(velocity_max&lt;1+1e-5)<comment>Both smoothed and non-smoothed bc values should be bounded (and not have smoothed so much that the extremum has changed)</comment></test>
+    <test name="check_velocity_min" language="python">assert all(velocity_min&gt;-1-1e-5) and all(velocity_min&lt;-1+1e-5)<comment>Both smoothed and non-smoothed bc values should be bounded (and not have smoothed so much that the extremum has changed)</comment></test>
+    <test name="check_velocity_grad_min" language="python">assert abs(velocity_grad_min[0]+20.)&lt;1e-5 and all(velocity_grad_min[1:]&gt;-1e-5)<comment>Non-smoothed bc (x-component) overshoots, causing a negative gradient, whereas the smoothed y and z components are a monotonic with a positive gradient.</comment></test>
+    <test name="check_velocity_grad_max" language="python">assert abs(velocity_grad_max[0]-60.)&lt;1e-5 and all(velocity_grad_max[1:]&lt;10.)<comment>Non-smoothed bc (x-component) overshoots, causing a negative gradient, whereas the smoothed y and z components are a monotonic with a positive gradient.</comment></test>
+  </pass_tests>
+</testproblem>

--- a/tests/bc-smoothing/bc-smoothing.xml
+++ b/tests/bc-smoothing/bc-smoothing.xml
@@ -2,8 +2,9 @@
 <testproblem>
   <name>bc-smoothing</name>
   <owner userid="skramer"/>
-  <problem_definition length="short" nprocs="1">
-    <command_line>mpiexec fluidity -v2 -l smoothed_bcs.flml</command_line>
+  <problem_definition length="short" nprocs="2">
+    <command_line>mpiexec flredecomp -i 1 -o 2 smoothed_bcs smoothed_bcs_parallel &amp;&amp;
+mpiexec fluidity -v2 -l smoothed_bcs_parallel.flml</command_line>
   </problem_definition>
   <variables>
     <variable name="velocity_max" language="python">from fluidity_tools import stat_parser

--- a/tests/bc-smoothing/smoothed_bcs.flml
+++ b/tests/bc-smoothing/smoothed_bcs.flml
@@ -1,0 +1,478 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">out</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">fluids</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">3</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="cube">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <mesh name="P1DG">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_continuity>
+          <string_value>discontinuous</string_value>
+        </mesh_continuity>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period>
+      <constant>
+        <real_value rank="0">1</real_value>
+      </constant>
+    </dump_period>
+    <output_mesh name="VelocityMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">1</integer_value>
+    </final_timestep>
+  </timestepping>
+  <material_phase name="Fields">
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="Boussinesq"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms/>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
+              <tensor_form/>
+            </stress_terms>
+            <buoyancy/>
+          </continuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">1.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="gmres"/>
+          <preconditioner name="sor"/>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <print_norms/>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <python>
+            <string_value type="code" lines="20" language="python">def val(X,t):
+  uvw = [0,0,0]
+  for i in range(3):
+    if X[i]&lt;0.499:
+      uvw[i] = -1
+    else:
+      uvw[i] = 1
+  return uvw</string_value>
+          </python>
+        </initial_condition>
+        <boundary_conditions name="LeftRight">
+          <surface_ids>
+            <integer_value shape="6" rank="1">1 2 3 4 5 6</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_cartesian>
+              <x_component>
+                <python>
+                  <string_value type="code" lines="20" language="python">def val(X,t):
+  if X[0]&lt;0.499:
+    return -1.0
+  else:
+    return 1.0</string_value>
+                </python>
+              </x_component>
+              <y_component>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X,t):
+  if X[1]&lt;0.499:
+    return -1.0
+  else:
+    return 1.0</string_value>
+                </python>
+                <smoothing>
+                  <iterations>
+                    <integer_value rank="0">10</integer_value>
+                  </iterations>
+                </smoothing>
+              </y_component>
+              <z_component>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X,t):
+  if X[2]&lt;0.499:
+    return -1.0
+  else:
+    return 1.0</string_value>
+                </python>
+                <smoothing>
+                  <iterations>
+                    <integer_value rank="0">10</integer_value>
+                  </iterations>
+                </smoothing>
+              </z_component>
+            </align_bc_with_cartesian>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <scalar_field name="SurfaceMarkerX" rank="0">
+      <prognostic>
+        <mesh name="P1DG"/>
+        <equation name="AdvectionDiffusion"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <diffusion_scheme>
+              <compact_discontinuous_galerkin/>
+            </diffusion_scheme>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">1</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1</real_value>
+          </theta>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="gmres"/>
+          <preconditioner name="sor"/>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value rank="0">0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="SurfaceOne">
+          <surface_ids>
+            <integer_value shape="4" rank="1">3 4 5 6</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">1</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <boundary_conditions name="Ends">
+          <surface_ids>
+            <integer_value shape="2" rank="1">1 2</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">0</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <scalar_field name="SurfaceMarkerY" rank="0">
+      <prognostic>
+        <mesh name="P1DG"/>
+        <equation name="AdvectionDiffusion"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <diffusion_scheme>
+              <compact_discontinuous_galerkin/>
+            </diffusion_scheme>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">1</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1</real_value>
+          </theta>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="gmres"/>
+          <preconditioner name="sor"/>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value rank="0">0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Surface">
+          <surface_ids>
+            <integer_value shape="4" rank="1">1 2 5 6</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">1</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <boundary_conditions name="Ends">
+          <surface_ids>
+            <integer_value shape="2" rank="1">3 4</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">0</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <scalar_field name="SurfaceMarkerZ" rank="0">
+      <prognostic>
+        <mesh name="P1DG"/>
+        <equation name="AdvectionDiffusion"/>
+        <spatial_discretisation>
+          <discontinuous_galerkin>
+            <advection_scheme>
+              <none/>
+              <integrate_advection_by_parts>
+                <twice/>
+              </integrate_advection_by_parts>
+            </advection_scheme>
+            <diffusion_scheme>
+              <compact_discontinuous_galerkin/>
+            </diffusion_scheme>
+          </discontinuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">1</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1</real_value>
+          </theta>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="gmres"/>
+          <preconditioner name="sor"/>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value rank="0">0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Surface">
+          <surface_ids>
+            <integer_value shape="4" rank="1">1 2 3 4</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">1</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <boundary_conditions name="Ends">
+          <surface_ids>
+            <integer_value shape="2" rank="1">5 6</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <constant>
+              <real_value rank="0">0</real_value>
+            </constant>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <consistent_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <vector_field name="VelocityGradAlongSurface" rank="1">
+      <diagnostic>
+        <algorithm name="vector_python_diagnostic" material_phase_support="single">
+          <string_value type="code" lines="20" language="python"># compute the x-derivative of the u component of velocity
+# only at those surfaces where this component is along the surface
+# followed by y-derivative of v-velocity, and z-derivative of w-velocity
+grad=state.tensor_fields['VelocityGrad']
+for i, component in enumerate('XYZ'):
+  marker = state.scalar_fields['SurfaceMarker'+component]
+  field.val[:,i] = grad.val[:,i,i] * marker.val</string_value>
+          <depends>
+            <string_value lines="1">VelocityGrad</string_value>
+          </depends>
+        </algorithm>
+        <mesh name="P1DG"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+    <tensor_field name="VelocityGrad" rank="2">
+      <diagnostic>
+        <algorithm material_phase_support="single " source_field_type="vector" source_field_name="Velocity" name="grad_vector"/>
+        <mesh name="P1DG"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </diagnostic>
+    </tensor_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/bc-smoothing/src/cube.geo
+++ b/tests/bc-smoothing/src/cube.geo
@@ -1,0 +1,23 @@
+Point(1) = {0,0,0,1.0};
+Extrude {1,0,0} {
+  Point{1}; Layers{10};
+}
+Extrude {0,1,0} {
+  Line{1}; Layers{10};
+}
+Extrude {0,0,1} {
+  Surface{5}; Layers{10};
+}
+Physical Volume(1) = {1};
+// Left x=0
+Physical Surface(1) = {26};
+// Right x=1
+Physical Surface(2) = {18};
+// Front y=0
+Physical Surface(3) = {14};
+// Back y=1
+Physical Surface(4) = {22};
+// Bottom z=0
+Physical Surface(5) = {5};
+// Top z=1
+Physical Surface(6) = {27};


### PR DESCRIPTION
Adds an option to smooth the values applied as a boundary condition. The smoothing is done via a simple masslumped projection - higher order functions are evaluated on a P1 mesh, then smoothed, then mapped to the bc value field. Currently only implemented for the components of vector bcs, but could easily be extended to scalar bcs.

Includes test for new functionality (testing monotonicity of a step valued bc)

Includes fix for transform_to_physical on embedde mesh meshes (mesh_dim<positions%dim)