### PR TITLE
Make schema spud base language compliant for flredecomp zoltan option

### DIFF
--- a/schemas/flredecomp.rnc
+++ b/schemas/flredecomp.rnc
@@ -26,7 +26,13 @@ flredecomp =
                 ## Currently hypergraph partitioning is the simplest implementation
                 ## and can produce non-contiguous partitions for certain problems.
                 element method {
-                "graph"|"hypergraph"
+		  element string_value {
+		     # Lines is a hint to the gui about the size of the text box.
+		     # It is not an enforced limit on string length.
+                     attribute lines { "1" },
+                     ( "graph" | "hypergraph" )
+                  },
+                comment
                 }
             }
         }?,

--- a/schemas/flredecomp.rng
+++ b/schemas/flredecomp.rng
@@ -28,10 +28,20 @@ closely as possible the setup used previously by Sam.</a:documentation>
                 <a:documentation>Select the partitioning method you would like used by Zoltan PHG.
 Currently hypergraph partitioning is the simplest implementation
 and can produce non-contiguous partitions for certain problems.</a:documentation>
-                <choice>
-                  <value>graph</value>
-                  <value>hypergraph</value>
-                </choice>
+                <element name="string_value">
+                  <!--
+                    Lines is a hint to the gui about the size of the text box.
+                    It is not an enforced limit on string length.
+                  -->
+                  <attribute name="lines">
+                    <value>1</value>
+                  </attribute>
+                  <choice>
+                    <value>graph</value>
+                    <value>hypergraph</value>
+                  </choice>
+                </element>
+                <ref name="comment"/>
               </element>
             </element>
           </choice>

--- a/tests/detectors_parallel_init/detectors.flml
+++ b/tests/detectors_parallel_init/detectors.flml
@@ -114,7 +114,9 @@
   <flredecomp>
     <final_partitioner>
       <zoltan>
-        <method>graph</method>
+        <method>
+          <string_value lines="1">graph</string_value>
+        </method>
       </zoltan>
     </final_partitioner>
   </flredecomp>


### PR DESCRIPTION
The schema currently isn't spud base language compliant when setting the partitioner option for zoltan (graph|hypergraph) under flredecomp. 

This commit fixes that and updates the only test that currently uses this option. Thanks to Cian for highlighting the issue.

Buildbot branch here:
http://buildbot-ocean.ese.ic.ac.uk:8080/builders/zoltan-option-schema-fix