### PR TITLE
Ksp caching

### DIFF
--- a/assemble/Full_Projection.F90
+++ b/assemble/Full_Projection.F90
@@ -207,7 +207,7 @@
       character(len=OPTION_PATH_LEN) :: inner_option_path, inner_solver_option_path
       integer, dimension(:,:), pointer :: save_gnn2unn
       type(integer_set), dimension(velocity%dim):: boundary_row_set      
-      integer reference_node, stat, i, rotation_stat
+      integer reference_node, i, rotation_stat
       logical parallel, have_auxiliary_matrix, have_preconditioner_matrix
 
       logical :: apply_reference_node, apply_reference_node_from_coordinates, reference_node_owned
@@ -365,25 +365,22 @@
          end if
       end if
       
-      if (have_option(trim(inner_option_path)//"/solver") .or. inner_M%ksp==PETSC_NULL_OBJECT) then
-        if (inner_M%ksp/=PETSC_NULL_OBJECT) then
-          ! for the moment, if separate solver options are specified under inner_option_path,
-          ! we throw away the existing ksp, which is based on the velocity option path
-          ! do this before setting up the new one to save memory
-          call KSPDestroy(inner_M%ksp, ierr)
-        end if
-        if (.not. have_option(trim(inner_option_path)//"/solver")) then
-          ! for FullMomentum solver/ is optional - if it's not there we reuse the option path of velocity
-          inner_option_path = velocity%option_path
-        end if
+      if (have_option(trim(inner_option_path)//"/solver")) then
+        ! for FullMass solver/ is required - and this is the first time we use these options
+        ! for FullMomentum solver/ is optional - if present the specified nullspace options are possibly different
+        ! in both cases we need to setup the null spaces of the inner matrix here
 
-        ! Set ksp for M block solver inside the Schur Complement (the inner, inner solve!).
-        call MatSchurComplementGetKSP(A,ksp_schur,ierr)
+        ! this call returns, depending on options, prolongators and mesh_positions needed for setting
+        ! up the ksp and the nullspaces
         call petsc_solve_state_setup(inner_solver_option_path, prolongators, surface_nodes, &
           state, inner_mesh, blocks(div_matrix_comp,2), inner_option_path, matrix_has_solver_cache=.false., &
           mesh_positions=mesh_positions)
-        rotation_matrix => extract_petsc_csr_matrix(state, "RotationMatrix", stat=rotation_stat)
 
+        if (associated(prolongators))then
+          FLExit("mg vertical_lumping and higher_order_lumping not supported for inner_matrix solve")
+        end if
+
+        rotation_matrix => extract_petsc_csr_matrix(state, "RotationMatrix", stat=rotation_stat)
         if (associated(mesh_positions)) then
           if (rotation_stat==0) then
             call attach_null_space_from_options(inner_M%M, inner_solver_option_path, &
@@ -393,6 +390,8 @@
             call attach_null_space_from_options(inner_M%M, inner_solver_option_path, &
               positions=mesh_positions, petsc_numbering=petsc_numbering_u)
           end if
+          call deallocate(mesh_positions)
+          deallocate(mesh_positions)
         elseif (rotation_stat==0) then
           call attach_null_space_from_options(inner_M%M, inner_solver_option_path, &
             rotation_matrix=rotation_matrix%M, petsc_numbering=petsc_numbering_u)
@@ -401,39 +400,27 @@
             petsc_numbering=petsc_numbering_u)
         end if
 
-        if (associated(prolongators)) then
-          if (rotation_stat==0) then
-            FLExit("Rotated boundary conditions do not work with mg prolongators")
-          end if
+      else
+        ! for FullMomentum solver/ is optional - if it's not there we reuse the option path of velocity
+        inner_solver_option_path = complete_solver_option_path(velocity%option_path)
+      end if
 
-          if (associated(surface_nodes)) then
-            FLExit("Internal smoothing not available for inner solve")
-          end if
-          call setup_ksp_from_options(ksp_schur, inner_M%M, inner_M%M, &
-            inner_solver_option_path, petsc_numbering=petsc_numbering_u, startfromzero_in=.true., &
-            prolongators=prolongators)
-          do i=1, size(prolongators)
-            call deallocate(prolongators(i))
-          end do
-          deallocate(prolongators)
-        else
-          call setup_ksp_from_options(ksp_schur, inner_M%M, inner_M%M, &
-            inner_solver_option_path, petsc_numbering=petsc_numbering_u, startfromzero_in=.true.)
-        end if
 
-        if (associated(mesh_positions)) then
-          call deallocate(mesh_positions)
-          deallocate(mesh_positions)
-        end if
+      if (inner_M%ksp==PETSC_NULL_OBJECT) then
+        ! use the one that's just been created for us
+        call MatSchurComplementGetKSP(A,ksp_schur,ierr)
 
         ! we keep our own reference, so it can be re-used in the velocity correction solve
         call PetscObjectReference(ksp_schur, ierr)
         inner_M%ksp = ksp_schur
       else
         ! we have a ksp (presumably from the first velocity solve), try to reuse it
+        ewrite(2,*) "Reusing the ksp from the initial velocity solve"
         call MatSchurComplementSetKSP(A, inner_M%ksp, ierr)
       end if
-       
+
+      call setup_ksp_from_options(inner_M%ksp, inner_M%M, inner_M%M, &
+          inner_solver_option_path, petsc_numbering=petsc_numbering_u, startfromzero_in=.true.)
       ! leaving out petsc_numbering and mesh, so "iteration_vtus" monitor won't work!
 
       ! Assemble preconditioner matrix in petsc format (if required):

--- a/assemble/Full_Projection.F90
+++ b/assemble/Full_Projection.F90
@@ -457,7 +457,7 @@
       parallel=IsParallel()
 
       call attach_null_space_from_options(A, solver_option_path, pmat=pmat, petsc_numbering=petsc_numbering_p)
-      call SetupKSP(ksp,A,pmat,solver_option_path,parallel,petsc_numbering_p, lstartfromzero)
+      call create_ksp_from_options(ksp,A,pmat,solver_option_path,parallel,petsc_numbering_p, lstartfromzero)
       
       ! Destroy the matrices setup for the schur complement computation. While
       ! these matrices are destroyed here, they are still required for the inner solve,

--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -60,7 +60,7 @@
     use field_derivatives
     use coordinates, only: radial_inward_normal_at_quad_face,&
          rotate_diagonal_to_sphere_face, radial_inward_normal_at_quad_ele,&
-	 rotate_diagonal_to_sphere_gi
+         rotate_diagonal_to_sphere_gi
     use boundary_conditions_from_options
     use petsc_solve_state_module, only: petsc_solve
     use coriolis_module, only: coriolis, set_coriolis_parameters
@@ -2597,6 +2597,11 @@
       delta_u2%option_path = trim(delta_p%option_path)//&
                                   &"/prognostic/scheme/use_projection_method"//&
                                   &"/full_schur_complement/inner_matrix[0]"
+      if (.not. have_option(trim(delta_u2%option_path)//"/solver")) then
+        ! inner solver options are optional (for FullMomemtumMatrix), if not
+        ! present use the same as those for the initial velocity solve
+        delta_u2%option_path = u%option_path
+      end if
       
       ! compute delta_u1=grad delta_p
       call mult_t(delta_u1, ct_m, delta_p)

--- a/femtools/Multigrid.F90
+++ b/femtools/Multigrid.F90
@@ -365,6 +365,13 @@ logical, intent(in), optional :: no_top_smoothing
     ! this might be already done, but it doesn't hurt:
     call PCSetType(prec, PCMG, ierr)
 
+    call PCMGGetLevels(prec, nolevels, ierr)
+    if (ierr==0 .and. nolevels>0) then
+      ewrite(2,*) "Assuming mg preconditioner is used with the same matrix and same options as before"
+      ierror = 0
+      return
+    end if
+
     lno_top_smoothing = .false.
     if(present(no_top_smoothing)) then
        lno_top_smoothing = no_top_smoothing

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -1014,14 +1014,15 @@ Mat, intent(in), optional:: rotation_matrix
     parallel= .false.
   end if
 
+  ewrite(2, *) 'Using solver options defined at: ', trim(solver_option_path)
   if (matrix%ksp==PETSC_NULL_OBJECT) then
   
-    ewrite(2, *) 'Using solver options defined at: ', trim(solver_option_path)
     call create_ksp_from_options(matrix%ksp, matrix%M, matrix%M, solver_option_path, parallel, &
         matrix%column_numbering, &
         startfromzero_in=startfromzero_in, &
        prolongators=prolongators, surface_node_list=surface_node_list)
   else
+    ewrite(2, *) "Reusing ksp from a previous solve"
     call setup_ksp_from_options(matrix%ksp, matrix%M, matrix%M, solver_option_path, &
         matrix%column_numbering, &
         startfromzero_in=startfromzero_in, &
@@ -1652,6 +1653,9 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
       max_its, atol, rtol, dtol
     ewrite(2, *) 'startfromzero:', startfromzero
     
+    ! cancel all existing monitors (if reusing the same ksp)
+    call KSPMonitorCancel(ksp, ierr)
+
     ! Set up the monitors:
     if (have_option(trim(solver_option_path)// &
        '/diagnostics/monitors/preconditioned_residual')) then

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -84,7 +84,7 @@ public petsc_solve, set_solver_options, &
 ! meant for unit-testing solver code only:
 public petsc_solve_setup, petsc_solve_core, petsc_solve_destroy, &
   petsc_solve_copy_vectors_from_scalar_fields, &
-  setup_ksp_from_options, SetupKSP, petsc_solve_monitor_exact, &
+  setup_ksp_from_options, create_ksp_from_options, petsc_solve_monitor_exact, &
   petsc_solve_monitor_iteration_vtus, attach_null_space_from_options
 
 interface petsc_solve
@@ -864,7 +864,7 @@ type(vector_field), intent(in), optional :: positions
     call attach_null_space_from_options(A, solver_option_path, pmat=pmat, &
       positions=positions, petsc_numbering=petsc_numbering)
 
-    call SetupKSP(ksp, A, pmat, solver_option_path, parallel, &
+    call create_ksp_from_options(ksp, A, pmat, solver_option_path, parallel, &
       petsc_numbering, &
       startfromzero_in=startfromzero_in, &
       prolongators=prolongators, surface_node_list=surface_node_list, &
@@ -1017,11 +1017,15 @@ Mat, intent(in), optional:: rotation_matrix
   if (matrix%ksp==PETSC_NULL_OBJECT) then
   
     ewrite(2, *) 'Using solver options defined at: ', trim(solver_option_path)
-    call SetupKSP(matrix%ksp, matrix%M, matrix%M, solver_option_path, parallel, &
+    call create_ksp_from_options(matrix%ksp, matrix%M, matrix%M, solver_option_path, parallel, &
         matrix%column_numbering, &
         startfromzero_in=startfromzero_in, &
-        prolongators=prolongators, surface_node_list=surface_node_list)
-
+       prolongators=prolongators, surface_node_list=surface_node_list)
+  else
+    call setup_ksp_from_options(matrix%ksp, matrix%M, matrix%M, solver_option_path, &
+        matrix%column_numbering, &
+        startfromzero_in=startfromzero_in, &
+       prolongators=prolongators, surface_node_list=surface_node_list)
   end if
   
   b=PetscNumberingCreateVec(matrix%column_numbering)
@@ -1503,7 +1507,7 @@ subroutine dump_matrix_option(solver_option_path, startfromzero, A, b, &
  
 end subroutine dump_matrix_option
 
-subroutine SetupKSP(ksp, mat, pmat, solver_option_path, parallel, &
+subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel, &
        petsc_numbering, &
        startfromzero_in, &
        prolongators, surface_node_list, matrix_csr, &
@@ -1544,7 +1548,7 @@ subroutine SetupKSP(ksp, mat, pmat, solver_option_path, parallel, &
       matrix_csr=matrix_csr, &
       internal_smoothing_option=internal_smoothing_option)
       
-  end subroutine SetupKSP
+  end subroutine create_ksp_from_options
     
   recursive subroutine setup_ksp_from_options(ksp, mat, pmat, solver_option_path, &
       petsc_numbering, startfromzero_in, prolongators, surface_node_list, matrix_csr, &

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -852,23 +852,26 @@ type(vector_field), intent(in), optional :: positions
   if (have_cache) then
     ! write the cached solver options to log:
     call ewrite_ksp_options(ksp)
-  else if (present(preconditioner_matrix)) then
-    ewrite(2,*)  'Using provided preconditioner matrix'
-    pmat=csr2petsc(preconditioner_matrix, petsc_numbering)
   else
-    pmat=A
-  end if
 
-  ewrite(2, *) 'Using solver options defined at: ', trim(solver_option_path)
-  call attach_null_space_from_options(A, solver_option_path, pmat=pmat, &
-    positions=positions, petsc_numbering=petsc_numbering)
-    
-  call SetupKSP(ksp, A, pmat, solver_option_path, parallel, &
-    petsc_numbering, &
-    startfromzero_in=startfromzero_in, &
-    prolongators=prolongators, surface_node_list=surface_node_list, &
-    matrix_csr=matrix, &
-    internal_smoothing_option=internal_smoothing_option)
+    if (present(preconditioner_matrix)) then
+      ewrite(2,*)  'Using provided preconditioner matrix'
+      pmat=csr2petsc(preconditioner_matrix, petsc_numbering)
+    else
+      pmat=A
+    end if
+
+    ewrite(2, *) 'Using solver options defined at: ', trim(solver_option_path)
+    call attach_null_space_from_options(A, solver_option_path, pmat=pmat, &
+      positions=positions, petsc_numbering=petsc_numbering)
+
+    call SetupKSP(ksp, A, pmat, solver_option_path, parallel, &
+      petsc_numbering, &
+      startfromzero_in=startfromzero_in, &
+      prolongators=prolongators, surface_node_list=surface_node_list, &
+      matrix_csr=matrix, &
+      internal_smoothing_option=internal_smoothing_option)
+  end if
   
   if (.not. have_cache .and. have_option(trim(solver_option_path)// &
     &'/cache_solver_context')) then

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -85,7 +85,8 @@ public petsc_solve, set_solver_options, &
 public petsc_solve_core, petsc_solve_destroy, &
   petsc_solve_copy_vectors_from_scalar_fields, &
   setup_ksp_from_options, create_ksp_from_options, petsc_solve_monitor_exact, &
-  petsc_solve_monitor_iteration_vtus, attach_null_space_from_options
+  petsc_solve_monitor_iteration_vtus, attach_null_space_from_options, &
+  petsc_solve_setup
 
 interface petsc_solve
    module procedure petsc_solve_scalar, petsc_solve_vector, &

--- a/femtools/Sparse_Tools_Petsc.F90
+++ b/femtools/Sparse_Tools_Petsc.F90
@@ -65,6 +65,9 @@ module sparse_tools_petsc
      !! if .false. we need to call assemble before extracting info
      !! and or go into a solve:
      logical:: is_assembled=.false.
+     !! this ksp solver object can be used to cache ksp/pc setup between subsequent solves:
+     !! ( should always be allocated, to ensure different references all point to the same KSP)
+     KSP, pointer :: ksp => null()
   end type petsc_csr_matrix
 
   type petsc_csr_matrix_pointer
@@ -269,6 +272,9 @@ contains
       matrix%column_halo = sparsity%column_halo
       call incref(matrix%column_halo)
     end if
+
+    allocate(matrix%ksp)
+    matrix%ksp = PETSC_NULL_OBJECT
     
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
@@ -478,6 +484,9 @@ contains
       matrix%column_halo = lcolumn_halo
       call incref(matrix%column_halo)
     end if
+
+    allocate(matrix%ksp)
+    matrix%ksp = PETSC_NULL_OBJECT
     
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
@@ -553,6 +562,9 @@ contains
       end if
     end if
 
+    allocate(matrix%ksp)
+    matrix%ksp = PETSC_NULL_OBJECT
+
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
     call addref(matrix)
@@ -588,6 +600,23 @@ contains
        call deallocate(matrix%column_halo)
        deallocate(matrix%column_halo)
     end if
+
+    if (.not. associated(matrix%ksp)) then
+      FLAbort("Attempt made to deallocate a non-allocated or damaged petsc_csr_matrix.")
+    end if
+
+    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+      call KSPDestroy(matrix%ksp, lstat)
+      if (lstat/=0) then
+        if (present(stat)) then
+          ewrite(0,*) "Error from KSPDestroy in deallocate_csr_matrix."
+          stat=lstat
+          return
+        end if
+        FLAbort("Error from KSPDestroy in deallocate_csr_matrix.")
+      end if
+    end if
+    deallocate(matrix%ksp)
     
 42  if (present(stat)) then
        stat=lstat

--- a/femtools/Sparse_Tools_Petsc.F90
+++ b/femtools/Sparse_Tools_Petsc.F90
@@ -1002,6 +1002,9 @@ contains
     
     ! make up a name
     c%name=trim(a%name)//"_"//trim(p%name)//"_ptap"
+
+    allocate(c%ksp)
+    c%ksp = PETSC_NULL_OBJECT
     
     ! the new c get its own reference:
     nullify(c%refcount) ! Hack for gfortran component initialisation

--- a/python/fluidity_tools.py
+++ b/python/fluidity_tools.py
@@ -460,6 +460,32 @@ def test_steady(vals, error, test_count = 1):
 
   return
 
+def petsc_memory_stats(log):
+    """Return the memory stats section of PETSc's -log_view output as a dictionary."""
+    # first search for the 'Memory usage' header, then match anything that follows
+    # after the first line starting with --- up until the first line starting with =====
+    # re.DOTALL makes . match newlines as well
+    try:
+        memory_profile = re.finditer('Memory usage is given in bytes:.*?\n---[^\n].*?\n(.*?)\n===========', log, re.DOTALL).next().group(1)
+    except StopIteration:
+        # no memory stats section found (did you run with -log_view ?)
+        return None
+
+    stats = {}
+    for line in memory_profile.split('\n'):
+        try:
+            (object, profile) = re.finditer('(\s.*?)([0-9]+.*)', line).next().groups()
+        except StopIteration:
+            continue
+        profile = profile.split()
+        stats[object.strip()] = [int(x) for x in profile[0:3]] + [float(profile[3]),]
+
+    # when the memory stats are written out to STDOUT or a file, PETSC uses a viewer itself
+    # therefore the log_summary always seems to have one missing ViewerDestroy which is called after the log is written
+    stats['Viewer'][1] += 1
+
+    return stats
+
 if __name__ == "__main__":
     import sys
     var = parse_s(sys.argv[1])

--- a/python/fluidity_tools.py
+++ b/python/fluidity_tools.py
@@ -480,10 +480,6 @@ def petsc_memory_stats(log):
         profile = profile.split()
         stats[object.strip()] = [int(x) for x in profile[0:3]] + [float(profile[3]),]
 
-    # when the memory stats are written out to STDOUT or a file, PETSC uses a viewer itself
-    # therefore the log_summary always seems to have one missing ViewerDestroy which is called after the log is written
-    stats['Viewer'][1] += 1
-
     return stats
 
 if __name__ == "__main__":

--- a/schemas/prognostic_field_options.rnc
+++ b/schemas/prognostic_field_options.rnc
@@ -1484,6 +1484,8 @@ prognostic_pressure_field =
                 ## Make sure you've not lumped your mass in the velocity spatial_discretisation if you want to be consistent!
                 element inner_matrix {
                   attribute name { "FullMassMatrix" },
+                  ## Solver options to solve the inner (mass) matrix in the schur complement solve, also used
+                  ## to solve the correction solve afterwards.
                   element solver {
                     linear_solver_options_sym
                   }
@@ -1494,9 +1496,11 @@ prognostic_pressure_field =
                 ## Doesn't really matter if you've lumped your mass or not but why would you if you're doing a full inner solve anyway?
                 element inner_matrix {
                   attribute name { "FullMomentumMatrix" },
+                  ## Solver options to solve the inner (momentum) matrix in the schur complement solve, also used
+                  ## to solve the correction solve afterwards. If not provided uses the solver options under Velocity
                   element solver {
                     linear_solver_options_asym_vector
-                  }
+                  }?
                 }
               ),
               (

--- a/schemas/prognostic_field_options.rng
+++ b/schemas/prognostic_field_options.rng
@@ -1838,6 +1838,8 @@ Make sure you've not lumped your mass in the velocity spatial_discretisation if 
                   <value>FullMassMatrix</value>
                 </attribute>
                 <element name="solver">
+                  <a:documentation>Solver options to solve the inner (mass) matrix in the schur complement solve, also used
+to solve the correction solve afterwards. </a:documentation>
                   <ref name="linear_solver_options_sym"/>
                 </element>
               </element>
@@ -1849,9 +1851,13 @@ Doesn't really matter if you've lumped your mass or not but why would you if you
                 <attribute name="name">
                   <value>FullMomentumMatrix</value>
                 </attribute>
-                <element name="solver">
-                  <ref name="linear_solver_options_asym_vector"/>
-                </element>
+                <optional>
+                  <element name="solver">
+                    <a:documentation>Solver options to solve the inner (momentum) matrix in the schur complement solve, also used
+to solve the correction solve afterwards. If not provided uses the solver options under Velocity</a:documentation>
+                    <ref name="linear_solver_options_asym_vector"/>
+                  </element>
+                </optional>
               </element>
             </choice>
             <choice>

--- a/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes-may-sinker-stepxy-gamg.flml
@@ -136,26 +136,7 @@
           </poisson_pressure_solution>
           <use_projection_method>
             <full_schur_complement>
-              <inner_matrix name="FullMomentumMatrix">
-                <solver>
-                  <iterative_method name="cg"/>
-                  <preconditioner name="gamg"/>
-                  <relative_error>
-                    <real_value rank="0">1.0e-6</real_value>
-                  </relative_error>
-                  <max_iterations>
-                    <integer_value rank="0">10000</integer_value>
-                  </max_iterations>
-                  <multigrid_near_null_space>
-                    <all_components/>
-                    <all_rotations/>
-                  </multigrid_near_null_space>
-                  <never_ignore_solver_failures/>
-                  <diagnostics>
-                    <monitors/>
-                  </diagnostics>
-                </solver>
-              </inner_matrix>
+              <inner_matrix name="FullMomentumMatrix"/>
               <preconditioner_matrix name="ScaledPressureMassMatrix"/>
             </full_schur_complement>
           </use_projection_method>

--- a/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
@@ -19,14 +19,17 @@ DeltaU_iterations_MG = check_velocity_iterations('log_mg')</variable>
     <variable name="DeltaU_iterations_SOR" language="python">from check_iterations import *
 DeltaU_iterations_SOR = check_velocity_iterations('log_sor')</variable>
     <variable name="mem_stats_gamg" language="python">from fluidity_tools import petsc_memory_stats
-mem_stats_gamg = petsc_memory_stats(open('log_gamg', 'r').read())</variable>
+mem_stats_gamg = petsc_memory_stats(open('log_gamg', 'r').read())
+mem_stats_gamg.pop('Viewer')</variable>
     <variable name="mem_stats_fs" language="python">from fluidity_tools import petsc_memory_stats
-mem_stats_fs = petsc_memory_stats(open('log_fs', 'r').read())</variable>
+mem_stats_fs = petsc_memory_stats(open('log_fs', 'r').read())
+mem_stats_fs.pop('Viewer')</variable>
     <variable name="mem_stats_mg" language="python">from fluidity_tools import petsc_memory_stats
-mem_stats_mg = petsc_memory_stats(open('log_mg', 'r').read())</variable>
+mem_stats_mg = petsc_memory_stats(open('log_mg', 'r').read())
+mem_stats_mg.pop('Viewer')</variable>
     <variable name="mem_stats_sor" language="python">from fluidity_tools import petsc_memory_stats
 mem_stats_sor = petsc_memory_stats(open('log_sor', 'r').read())
-print all(stat[0]==stat[1] for stat in mem_stats_sor.itervalues())</variable>
+mem_stats_sor.pop('Viewer')</variable>
   </variables>
   <pass_tests>
     <test name="Solvers converged" language="python">assert(solvers_converged)</test>

--- a/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
@@ -1,73 +1,43 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version='1.0' encoding='utf-8'?>
 <testproblem>
   <name>Stokes-may-sinker</name>
   <owner userid="rhodrid"/>
   <tags>flml petsc33</tags>
-
   <problem_definition length="medium" nprocs="1">
-    <command_line>fluidity -v2 -l Stokes-may-sinker-stepxy-gamg.flml; mv fluidity.log-0 log_gamg; fluidity -v2 -l Stokes-may-sinker-stepxy-fs.flml; mv fluidity.log-0 log_fs; fluidity -v2 -l Stokes-may-sinker-stepxy-mg.flml; mv fluidity.log-0 log_mg; fluidity -v2 -l Stokes-may-sinker-stepxy-sor.flml; mv fluidity.log-0 log_sor</command_line>
+    <command_line>export PETSC_OPTIONS='-log_view'; fluidity -v2 -l Stokes-may-sinker-stepxy-gamg.flml; mv fluidity.log-0 log_gamg; fluidity -v2 -l Stokes-may-sinker-stepxy-fs.flml; mv fluidity.log-0 log_fs; fluidity -v2 -l Stokes-may-sinker-stepxy-mg.flml; mv fluidity.log-0 log_mg; fluidity -v2 -l Stokes-may-sinker-stepxy-sor.flml; mv fluidity.log-0 log_sor</command_line>
   </problem_definition>
-
-<variables>  
-
-<variable name="solvers_converged" language="python">
-import os
+  <variables>
+    <variable name="solvers_converged" language="python">import os
 files = os.listdir("./")
-solvers_converged = not "matrixdump" in files and not "matrixdump.info" in files
-</variable>
-
-<variable name="DeltaU_iterations_GAMG" language="python">
-from check_iterations import *
-DeltaU_iterations_GAMG = check_velocity_iterations('log_gamg')
-</variable>
-
-<variable name="DeltaU_iterations_FS" language="python">
-from check_iterations import *
-DeltaU_iterations_FS = check_velocity_iterations('log_fs')
-</variable>
-
-<variable name="DeltaU_iterations_MG" language="python">
-from check_iterations import *
-DeltaU_iterations_MG = check_velocity_iterations('log_mg')
-</variable>
-
-<variable name="DeltaU_iterations_SOR" language="python">
-from check_iterations import *
-DeltaU_iterations_SOR = check_velocity_iterations('log_sor')
-</variable>
-
-</variables>
-
-<pass_tests>
-
-<test name="Solvers converged" language="python">
-assert(solvers_converged)
-</test>
-
-<test name="GAMG solver behaving as expected" language="python">
-assert(DeltaU_iterations_GAMG &lt; 14)
-</test>
-
-<test name="Fieldsplit solver behaving as expected" language="python">
-assert(DeltaU_iterations_FS &lt; 17)
-</test>
-
-<test name="MG solver behaving as expected" language="python">
-assert(abs(DeltaU_iterations_MG - 251) &lt; 5)
-</test>
-
-<test name="SOR solver behaving as expected" language="python">
-assert(abs(DeltaU_iterations_SOR - 599) &lt; 5)
-</test>
-
-</pass_tests>
-                                                                                                                                                                              
-<warn_tests>
-</warn_tests>
-
+solvers_converged = not "matrixdump" in files and not "matrixdump.info" in files</variable>
+    <variable name="DeltaU_iterations_GAMG" language="python">from check_iterations import *
+DeltaU_iterations_GAMG = check_velocity_iterations('log_gamg')</variable>
+    <variable name="DeltaU_iterations_FS" language="python">from check_iterations import *
+DeltaU_iterations_FS = check_velocity_iterations('log_fs')</variable>
+    <variable name="DeltaU_iterations_MG" language="python">from check_iterations import *
+DeltaU_iterations_MG = check_velocity_iterations('log_mg')</variable>
+    <variable name="DeltaU_iterations_SOR" language="python">from check_iterations import *
+DeltaU_iterations_SOR = check_velocity_iterations('log_sor')</variable>
+    <variable name="mem_stats_gamg" language="python">from fluidity_tools import petsc_memory_stats
+mem_stats_gamg = petsc_memory_stats(open('log_gamg', 'r').read())</variable>
+    <variable name="mem_stats_fs" language="python">from fluidity_tools import petsc_memory_stats
+mem_stats_fs = petsc_memory_stats(open('log_fs', 'r').read())</variable>
+    <variable name="mem_stats_mg" language="python">from fluidity_tools import petsc_memory_stats
+mem_stats_mg = petsc_memory_stats(open('log_mg', 'r').read())</variable>
+    <variable name="mem_stats_sor" language="python">from fluidity_tools import petsc_memory_stats
+mem_stats_sor = petsc_memory_stats(open('log_sor', 'r').read())
+print all(stat[0]==stat[1] for stat in mem_stats_sor.itervalues())</variable>
+  </variables>
+  <pass_tests>
+    <test name="Solvers converged" language="python">assert(solvers_converged)</test>
+    <test name="GAMG solver behaving as expected" language="python">assert(DeltaU_iterations_GAMG &lt; 14)</test>
+    <test name="Fieldsplit solver behaving as expected" language="python">assert(DeltaU_iterations_FS &lt; 17)</test>
+    <test name="MG solver behaving as expected" language="python">assert(abs(DeltaU_iterations_MG - 251) &lt; 5)</test>
+    <test name="SOR solver behaving as expected" language="python">assert(abs(DeltaU_iterations_SOR - 599) &lt; 5)</test>
+    <test name="no_petsc_mem_leaks_sor" language="python">assert all(stat[0]==stat[1] for stat in mem_stats_sor.itervalues())</test>
+    <test name="no_petsc_mem_leaks_gamg" language="python">assert all(stat[0]==stat[1] for stat in mem_stats_gamg.itervalues())</test>
+    <test name="no_petsc_mem_leaks_fs" language="python">assert all(stat[0]==stat[1] for stat in mem_stats_fs.itervalues())</test>
+    <test name="no_petsc_mem_leaks_mg" language="python">assert all(stat[0]==stat[1] for stat in mem_stats_mg.itervalues())</test>
+  </pass_tests>
+  <warn_tests/>
 </testproblem>
-
-
-
-
-


### PR DESCRIPTION
This PR does two things:

* it fixes the cache_solver_context option under the solver/ options of  scalar prognostic fields. It was creating a new ksp regardless of the option, so the only thing it did was create a memory leak by not destroying the previous one. This is now fixed. It's still a bit of a feeble option as it relies on users to know whether a matrix changes between subsequent solves.

* it introduces reusing of the ksp for momentum solves. This only applies for full_momentum or mass_matrix solves where there are in fact 3 different places that require setting up of a ksp for a momentum solve:

1) the initial velocity solve
2) the "inner" velocity solve of the Schur complement solve in the pressure projection
3) the velocity correction

Solver options for 1) are directly under Velocity/prognostic/solver whereas solver options for both 2) and 3) are in Pressure/prognostic/scheme/use_projection_method/full_schur_complement/inner_matrix/solver. For full_momentum 1), 2) and 3) in fact solve the same system - for the (consistent) mass_matrix approach 1) is the full momentum matrix and 2) and 3) are a mass matrix solve. What this PR changes is, that it reuses the ksp where possible. For full_momentum this means the ksp setup time (which can be very large when solving a Stokes system with AMG) is divided by three. This reuse is always done automatically without any option. It does not reuse the ksp between, nonlinear iterations or timesteps. 

To accommodate people wanting to use different solver settings in 1) from those used in 2) and 3), the setting of solver options of 2) and 3) under inner_matrix is now optional. If these are not specified, the same solver options are used for both (and for full_momentum the same ksp is used) - if they are specified, we still reuse the ksp (if possible) but set its options again and PETSc should be clever enough to figure out whether it can reuse the preconditioner in that case (e.g. only setting a tighter ksp tolerance does not require the PC to be setup again, whereas if we choose a different pctype it does).