### PR TITLE
Poiseuille test case

### DIFF
--- a/tests/Stokes_Poiseuille/Makefile
+++ b/tests/Stokes_Poiseuille/Makefile
@@ -1,0 +1,5 @@
+input: clean
+	gmsh -2 -bin -o mesh/Rectangular_Pipe.msh mesh/Rectangular_Pipe.geo
+
+clean:
+	rm -rf *Poiseuille_* fluidity.* P4* *.pyc *.stat mesh/*.msh

--- a/tests/Stokes_Poiseuille/Setup.py
+++ b/tests/Stokes_Poiseuille/Setup.py
@@ -18,4 +18,4 @@ h = 1.
 # Driving pressure, the pressure applied at the inflow boundary
 drvP = 1e6
 # Pressure at the outflow boundary
-outP = 0.
+outP = 5e5

--- a/tests/Stokes_Poiseuille/Setup.py
+++ b/tests/Stokes_Poiseuille/Setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Setup values for the Poiseuille flow simulation
+
+# Please note that the values listed below are only read by Fluidity through
+# the .flml file and that the rectangular domain itself is defined in the .geo
+# file (loacted in the mesh directory). Please ensure that the domain sizes are
+# the same in both files.
+
+# The reference density is set to 1 in the .flml file, but any value would do
+# as the velocity field of a Poiseuille flow is independent on the density
+# (however density is assumed to be constant).
+
+# Dynamic viscosity of the fluid
+visc = 1e-3
+# Half-height of the rectangular domain
+h = 1.
+# Driving pressure, the pressure applied at the inflow boundary
+drvP = 1e6
+# Pressure at the outflow boundary
+outP = 0.

--- a/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
+++ b/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
@@ -75,7 +75,7 @@
     </adaptive_timestep>
     <steady_state>
       <tolerance>
-        <real_value rank="0">1e-2</real_value>
+        <real_value rank="0">1e-7</real_value>
         <infinity_norm/>
       </tolerance>
     </steady_state>
@@ -159,7 +159,7 @@
             </python>
           </type>
         </boundary_conditions>
-        <boundary_conditions name="NoPressureRight">
+        <boundary_conditions name="AppliedPressureRight">
           <surface_ids>
             <integer_value shape="1" rank="1">2</integer_value>
           </surface_ids>

--- a/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
+++ b/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
@@ -1,0 +1,502 @@
+<?xml version='1.0' encoding='utf-8'?>
+<fluidity_options>
+  <simulation_name>
+    <string_value lines="1">Stokes-Poiseuille</string_value>
+  </simulation_name>
+  <problem_type>
+    <string_value lines="1">stokes</string_value>
+  </problem_type>
+  <geometry>
+    <dimension>
+      <integer_value rank="0">2</integer_value>
+    </dimension>
+    <mesh name="CoordinateMesh">
+      <from_file file_name="mesh/Rectangular_Pipe">
+        <format name="gmsh"/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+      </from_file>
+    </mesh>
+    <mesh name="VelocityMesh">
+      <from_mesh>
+        <mesh name="CoordinateMesh"/>
+        <mesh_shape>
+          <polynomial_degree>
+            <integer_value rank="0">2</integer_value>
+          </polynomial_degree>
+        </mesh_shape>
+        <stat>
+          <exclude_from_stat/>
+        </stat>
+      </from_mesh>
+    </mesh>
+    <quadrature>
+      <degree>
+        <integer_value rank="0">5</integer_value>
+      </degree>
+    </quadrature>
+  </geometry>
+  <io>
+    <dump_format>
+      <string_value>vtk</string_value>
+    </dump_format>
+    <dump_period_in_timesteps>
+      <constant>
+        <integer_value rank="0">100</integer_value>
+      </constant>
+    </dump_period_in_timesteps>
+    <output_mesh name="VelocityMesh"/>
+    <stat/>
+  </io>
+  <timestepping>
+    <current_time>
+      <real_value rank="0">0.</real_value>
+    </current_time>
+    <timestep>
+      <real_value rank="0">1e-2</real_value>
+    </timestep>
+    <finish_time>
+      <real_value rank="0">1e1</real_value>
+    </finish_time>
+    <final_timestep>
+      <integer_value rank="0">100</integer_value>
+    </final_timestep>
+    <adaptive_timestep>
+      <requested_cfl>
+        <real_value rank="0">2.5</real_value>
+      </requested_cfl>
+      <courant_number name="ControlVolumeCFLNumber">
+        <mesh name="CoordinateMesh"/>
+      </courant_number>
+      <increase_tolerance>
+        <real_value rank="0">1.25</real_value>
+      </increase_tolerance>
+    </adaptive_timestep>
+    <steady_state>
+      <tolerance>
+        <real_value rank="0">1e-2</real_value>
+        <infinity_norm/>
+      </tolerance>
+    </steady_state>
+  </timestepping>
+  <material_phase name="Fluid">
+    <equation_of_state>
+      <fluids>
+        <linear>
+          <reference_density>
+            <real_value rank="0">1</real_value>
+          </reference_density>
+        </linear>
+      </fluids>
+    </equation_of_state>
+    <scalar_field name="Pressure" rank="0">
+      <prognostic>
+        <mesh name="CoordinateMesh"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <remove_stabilisation_term/>
+            <integrate_continuity_by_parts/>
+          </continuous_galerkin>
+        </spatial_discretisation>
+        <scheme>
+          <poisson_pressure_solution>
+            <string_value lines="1">never</string_value>
+          </poisson_pressure_solution>
+          <use_projection_method>
+            <full_schur_complement>
+              <inner_matrix name="FullMomentumMatrix"/>
+              <preconditioner_matrix name="ScaledPressureMassMatrix"/>
+            </full_schur_complement>
+          </use_projection_method>
+        </scheme>
+        <solver>
+          <iterative_method name="fgmres"/>
+          <preconditioner name="ksp">
+            <solver>
+              <iterative_method name="cg"/>
+              <preconditioner name="sor"/>
+              <relative_error>
+                <real_value rank="0">1e-7</real_value>
+              </relative_error>
+              <max_iterations>
+                <integer_value rank="0">1000</integer_value>
+              </max_iterations>
+              <never_ignore_solver_failures/>
+              <diagnostics>
+                <monitors/>
+              </diagnostics>
+            </solver>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">5000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors>
+              <preconditioned_residual/>
+            </monitors>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value rank="0">0.</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="AppliedPressureLeft">
+          <surface_ids>
+            <integer_value shape="1" rank="1">4</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <apply_weakly/>
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  from Setup import drvP
+  return drvP</string_value>
+            </python>
+          </type>
+        </boundary_conditions>
+        <boundary_conditions name="NoPressureRight">
+          <surface_ids>
+            <integer_value shape="1" rank="1">2</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <apply_weakly/>
+            <python>
+              <string_value lines="20" type="code" language="python">def val(X, t):
+  from Setup import outP
+  return outP</string_value>
+            </python>
+          </type>
+        </boundary_conditions>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <exclude_from_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+        <no_interpolation/>
+      </prognostic>
+    </scalar_field>
+    <scalar_field name="Density" rank="0">
+      <diagnostic>
+        <algorithm name="Internal" material_phase_support="multiple"/>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat/>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </scalar_field>
+    <vector_field name="Velocity" rank="1">
+      <prognostic>
+        <mesh name="VelocityMesh"/>
+        <equation name="LinearMomentum"/>
+        <spatial_discretisation>
+          <continuous_galerkin>
+            <stabilisation>
+              <no_stabilisation/>
+            </stabilisation>
+            <mass_terms>
+              <exclude_mass_terms/>
+            </mass_terms>
+            <advection_terms>
+              <exclude_advection_terms/>
+            </advection_terms>
+            <stress_terms>
+              <tensor_form/>
+            </stress_terms>
+            <buoyancy/>
+          </continuous_galerkin>
+          <conservative_advection>
+            <real_value rank="0">0.0</real_value>
+          </conservative_advection>
+        </spatial_discretisation>
+        <temporal_discretisation>
+          <theta>
+            <real_value rank="0">1.0</real_value>
+          </theta>
+          <relaxation>
+            <real_value rank="0">1.0</real_value>
+          </relaxation>
+        </temporal_discretisation>
+        <solver>
+          <iterative_method name="cg"/>
+          <preconditioner name="fieldsplit">
+            <fieldsplit_type name="symmetric_multiplicative"/>
+            <iterative_method name="preonly"/>
+            <preconditioner name="hypre">
+              <hypre_type name="boomeramg"/>
+            </preconditioner>
+            <relative_error>
+              <real_value rank="0">1e-7</real_value>
+            </relative_error>
+            <max_iterations>
+              <integer_value rank="0">1000</integer_value>
+            </max_iterations>
+            <never_ignore_solver_failures/>
+            <diagnostics>
+              <monitors/>
+            </diagnostics>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <initial_condition name="WholeMesh">
+          <constant>
+            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+          </constant>
+        </initial_condition>
+        <boundary_conditions name="Vertical">
+          <surface_ids>
+            <integer_value shape="2" rank="1">1 3</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_cartesian>
+              <x_component>
+                <constant>
+                  <real_value rank="0">0.</real_value>
+                </constant>
+              </x_component>
+              <y_component>
+                <constant>
+                  <real_value rank="0">0.</real_value>
+                </constant>
+              </y_component>
+            </align_bc_with_cartesian>
+          </type>
+        </boundary_conditions>
+        <boundary_conditions name="Horizontal">
+          <surface_ids>
+            <integer_value shape="2" rank="1">2 4</integer_value>
+          </surface_ids>
+          <type name="dirichlet">
+            <align_bc_with_cartesian>
+              <y_component>
+                <constant>
+                  <real_value rank="0">0.</real_value>
+                </constant>
+              </y_component>
+            </align_bc_with_cartesian>
+          </type>
+        </boundary_conditions>
+        <tensor_field name="Viscosity" rank="2">
+          <prescribed>
+            <value name="WholeMesh">
+              <isotropic>
+                <python>
+                  <string_value lines="20" type="code" language="python">def val(X, t):
+  from Setup import visc
+  return visc</string_value>
+                </python>
+              </isotropic>
+            </value>
+            <output/>
+          </prescribed>
+        </tensor_field>
+        <output/>
+        <stat>
+          <include_in_stat/>
+          <previous_time_step>
+            <exclude_from_stat/>
+          </previous_time_step>
+          <nonlinear_field>
+            <exclude_from_stat/>
+          </nonlinear_field>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <include_in_steady_state/>
+        </steady_state>
+        <adaptivity_options>
+          <absolute_measure>
+            <vector_field name="InterpolationErrorBound" rank="1">
+              <prescribed>
+                <value name="WholeMesh">
+                  <constant>
+                    <real_value shape="2" dim1="dim" rank="1">1.0e-13 1.0e-13</real_value>
+                  </constant>
+                </value>
+                <output/>
+                <stat>
+                  <include_in_stat/>
+                </stat>
+                <detectors>
+                  <exclude_from_detectors/>
+                </detectors>
+              </prescribed>
+            </vector_field>
+          </absolute_measure>
+        </adaptivity_options>
+        <consistent_interpolation/>
+      </prognostic>
+    </vector_field>
+    <vector_field name="VelocityAnalytical" rank="1">
+      <diagnostic>
+        <algorithm name="vector_python_diagnostic" material_phase_support="single">
+          <string_value lines="20" type="code" language="python">from Setup import visc, h
+X = state.vector_fields["DiagnosticCoordinate"]
+assert(X.node_count == field.node_count)
+dP = state.vector_fields["FiniteElementGradient"]
+assert(dP.node_count == field.node_count)
+for i in range(field.node_count):
+    y = X.node_val(i)[1]
+    dpdx = dP.node_val(i)[0]
+    u = dpdx / 2 / visc * (y ** 2 - h ** 2)
+    field.set(i, (u, 0))</string_value>
+          <depends>
+            <string_value lines="1">DiagnosticCoordinate, FiniteElementGradient</string_value>
+          </depends>
+        </algorithm>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+    <vector_field name="VectorAbsoluteDifference" rank="1">
+      <diagnostic field_name_b="Velocity" field_name_a="VelocityAnalytical">
+        <algorithm name="Internal" material_phase_support="multiple"/>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+    <vector_field name="FiniteElementGradient" rank="1">
+      <diagnostic field_name="Pressure">
+        <algorithm name="Internal" material_phase_support="multiple"/>
+        <mesh name="VelocityMesh"/>
+        <solver>
+          <iterative_method name="preonly"/>
+          <preconditioner name="lu">
+            <factorization_package name="mumps"/>
+          </preconditioner>
+          <relative_error>
+            <real_value rank="0">1e-7</real_value>
+          </relative_error>
+          <max_iterations>
+            <integer_value rank="0">1000</integer_value>
+          </max_iterations>
+          <never_ignore_solver_failures/>
+          <diagnostics>
+            <monitors/>
+          </diagnostics>
+        </solver>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+    <vector_field name="DiagnosticCoordinate" rank="1">
+      <diagnostic>
+        <algorithm name="Internal" material_phase_support="multiple"/>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+    <vector_field name="VectorRelativeDifference" rank="1">
+      <diagnostic>
+        <algorithm name="vector_python_diagnostic" material_phase_support="single">
+          <string_value lines="20" type="code" language="python">Va = state.vector_fields["VelocityAnalytical"]
+assert(Va.node_count == field.node_count)
+VAD = state.vector_fields["VectorAbsoluteDifference"]
+assert(VAD.node_count == field.node_count)
+for i in range(field.node_count):
+    u = Va.node_val(i)[0]
+    v = Va.node_val(i)[1]
+    du = VAD.node_val(i)[0]
+    dv = VAD.node_val(i)[1]
+    field.set(i, (du / u, dv / v))</string_value>
+          <depends>
+            <string_value lines="1">VectorAbsoluteDifference, VelocityAnalytical</string_value>
+          </depends>
+        </algorithm>
+        <mesh name="VelocityMesh"/>
+        <output/>
+        <stat>
+          <include_in_stat/>
+        </stat>
+        <convergence>
+          <include_in_convergence/>
+        </convergence>
+        <detectors>
+          <include_in_detectors/>
+        </detectors>
+        <steady_state>
+          <exclude_from_steady_state/>
+        </steady_state>
+      </diagnostic>
+    </vector_field>
+  </material_phase>
+</fluidity_options>

--- a/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
+++ b/tests/Stokes_Poiseuille/Stokes-Poiseuille.flml
@@ -474,10 +474,11 @@ VAD = state.vector_fields["VectorAbsoluteDifference"]
 assert(VAD.node_count == field.node_count)
 for i in range(field.node_count):
     u = Va.node_val(i)[0]
-    v = Va.node_val(i)[1]
     du = VAD.node_val(i)[0]
-    dv = VAD.node_val(i)[1]
-    field.set(i, (du / u, dv / v))</string_value>
+    if u == 0:
+      field.set(i, (du, 0))
+    else:
+      field.set(i, (du / u, 0))</string_value>
           <depends>
             <string_value lines="1">VectorAbsoluteDifference, VelocityAnalytical</string_value>
           </depends>

--- a/tests/Stokes_Poiseuille/Stokes_Poiseuille.xml
+++ b/tests/Stokes_Poiseuille/Stokes_Poiseuille.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<testproblem>
+  <name>Stokes-Poiseuille</name>
+  <owner userid="Thomas_Duvernay"/>
+  <problem_definition length="short" nprocs="4">
+    <command_line>mpiexec ../../bin/flredecomp -i 1 -o 4 Stokes-Poiseuille P4-Stokes-Poiseuille &amp;&amp;
+      mpiexec ../../bin/fluidity -v2 -l P4-Stokes-Poiseuille.flml</command_line>
+  </problem_definition>
+
+  <variables>
+    <variable name="solvers_converged" language="python">
+import os
+files = os.listdir("./")
+solvers_converged = not "matrixdump" in files and not "matrixdump.info" in files
+    </variable>
+
+    <variable name="max_vx_rel_diff" language="python">
+from fluidity_tools import stat_parser as stat
+max_vx_rel_diff = stat("Stokes-Poiseuille.stat")["Fluid"]["VectorRelativeDifference%1"]["max"][-1]
+    </variable>
+
+    <variable name="max_vy" language="python">
+from fluidity_tools import stat_parser as stat
+max_vy = stat("Stokes-Poiseuille.stat")["Fluid"]["Velocity%2"]["max"][-1]
+    </variable>
+  </variables>
+
+  <pass_tests>
+    <test name="Have the solvers converged ?" language="python">
+assert(solvers_converged)
+    </test>
+
+    <test name="Is the horizontal velocity component close enough to the analytical one ?" language="python">
+assert(abs(max_vx_rel_diff) &lt; 1e-7)
+    </test>
+
+    <test name="Is the vertical velocity component close enough to the analytical one ?" language="python">
+assert(abs(max_vy) &lt; 1e-7)
+    </test>
+  </pass_tests>
+
+  <warn_tests>
+  </warn_tests>
+
+</testproblem>

--- a/tests/Stokes_Poiseuille/Stokes_Poiseuille.xml
+++ b/tests/Stokes_Poiseuille/Stokes_Poiseuille.xml
@@ -2,9 +2,8 @@
 <testproblem>
   <name>Stokes-Poiseuille</name>
   <owner userid="Thomas_Duvernay"/>
-  <problem_definition length="short" nprocs="4">
-    <command_line>mpiexec ../../bin/flredecomp -i 1 -o 4 Stokes-Poiseuille P4-Stokes-Poiseuille &amp;&amp;
-      mpiexec ../../bin/fluidity -v2 -l P4-Stokes-Poiseuille.flml</command_line>
+  <problem_definition length="short" nprocs="1">
+    <command_line>../../bin/fluidity -v2 -l Stokes-Poiseuille.flml</command_line>
   </problem_definition>
 
   <variables>

--- a/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
+++ b/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
@@ -1,0 +1,43 @@
+// Define rectangular half-height
+h = 1;
+// Define rectangular length
+l = 2e1;
+
+// Define the four corners of the rectangle, clockwise starting from the
+// top-left one
+Point(1) = {0, h, 0};
+Point(2) = {l, h, 0};
+Point(3) = {l, -h, 0};
+Point(4) = {0, -h, 0};
+
+// Define the boundary lines of the rectangular domain, clockwise starting from
+// the top-left corner
+Line(1) = {1, 2};
+Line(2) = {2, 3};
+Line(3) = {3, 4};
+Line(4) = {4, 1};
+Physical Line(1) = {1};
+Physical Line(2) = {2};
+Physical Line(3) = {3};
+Physical Line(4) = {4};
+// Define the surface delimited by the lines
+Line Loop(1) = {1, 2, 3, 4};
+Plane Surface(1) = {1};
+Physical Surface(1) = {1};
+
+// Set the elements sizes : a box is defined inside the domain and the
+// resolution of the mesh both inside and outside the box is set to be the same
+Field[1] = Box;
+Field[1].VIn = 2e-1;
+Field[1].VOut = 2e-1;
+Field[1].XMax = 3 * l / 4;
+Field[1].XMin = l / 4;
+Field[1].YMax = h / 2;
+Field[1].YMin = -h / 2;
+
+Background Field = 1;
+
+// Force triangular elements
+Mesh.RecombineAll = 0;
+// Prevent elements sizes to be modified close to the boundaries
+Mesh.CharacteristicLengthExtendFromBoundary = 0;

--- a/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
+++ b/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
@@ -28,8 +28,8 @@ Physical Surface(1) = {1};
 // Set the elements sizes : a box is defined inside the domain and the
 // resolution of the mesh both inside and outside the box is set to be the same
 Field[1] = Box;
-Field[1].VIn = 2e-1;
-Field[1].VOut = 2e-1;
+Field[1].VIn = 3e-1;
+Field[1].VOut = 3e-1;
 Field[1].XMax = 3 * l / 4;
 Field[1].XMin = l / 4;
 Field[1].YMax = h / 2;

--- a/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
+++ b/tests/Stokes_Poiseuille/mesh/Rectangular_Pipe.geo
@@ -2,6 +2,12 @@
 h = 1;
 // Define rectangular length
 l = 2e1;
+// Define the mesh resolution
+r = 4e-1;
+// Define number of points on the horizontal lines
+nh = Round(l / r);
+// Define number of points on the vertical lines
+nv = Round(2 * h / r);
 
 // Define the four corners of the rectangle, clockwise starting from the
 // top-left one
@@ -25,19 +31,6 @@ Line Loop(1) = {1, 2, 3, 4};
 Plane Surface(1) = {1};
 Physical Surface(1) = {1};
 
-// Set the elements sizes : a box is defined inside the domain and the
-// resolution of the mesh both inside and outside the box is set to be the same
-Field[1] = Box;
-Field[1].VIn = 3e-1;
-Field[1].VOut = 3e-1;
-Field[1].XMax = 3 * l / 4;
-Field[1].XMin = l / 4;
-Field[1].YMax = h / 2;
-Field[1].YMin = -h / 2;
-
-Background Field = 1;
-
-// Force triangular elements
-Mesh.RecombineAll = 0;
-// Prevent elements sizes to be modified close to the boundaries
-Mesh.CharacteristicLengthExtendFromBoundary = 0;
+Transfinite Line{1, 3} = nh;
+Transfinite Line{2, 4} = nv;
+Transfinite Surface{1} = {1, 2, 3, 4};


### PR DESCRIPTION
This branch adds a new test case to Fluidity, which is the classical two-dimensional Poiseuille flow in a rectangular cartesian domain. Fluidity solves for the Pressure and the Velocity. The values of the Velocity are then compared to the well-known analytical solution, which depends on the Pressure Gradient that Fluidity works out as well.

Everything seems to work well, however two remarks :
- the pressure boundary conditions are weakly applied, which requires to turn ON "scalar_field (Pressure)/prognostic/spatial_discretisation/continuous_galerkin/integrate_continuity_by_parts". If it is OFF, Fluidity does not raise any Error or Warning and the calculated Pressure field is zero.
- calculating the Pressure Gradient in Fluidity requires to add a FiniteElementGradient field, however the output field name does not specify which field's gradient has been calculated, which can be annoying when multiple FiniteElementGradient fields are defined.