### PR TITLE
Update vtkfortran for VTK MPI communication.

### DIFF
--- a/configure
+++ b/configure
@@ -15869,6 +15869,11 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
+#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#include <${vtk_header_relative_path}vtkMPIController.h>
+#include <${vtk_header_relative_path}vtkMPICommunicator.h>
+#endif
+
 #ifndef vtkFloatingPointType
 #define vtkFloatingPointType vtkFloatingPointType
 typedef float vtkFloatingPointType;

--- a/configure.in
+++ b/configure.in
@@ -1693,6 +1693,11 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
+#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#include <${vtk_header_relative_path}vtkMPIController.h>
+#include <${vtk_header_relative_path}vtkMPICommunicator.h>
+#endif
+
 #ifndef vtkFloatingPointType
 #define vtkFloatingPointType vtkFloatingPointType
 typedef float vtkFloatingPointType;

--- a/libvtkfortran/configure
+++ b/libvtkfortran/configure
@@ -7551,6 +7551,11 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
+#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#include <${vtk_header_relative_path}vtkMPIController.h>
+#include <${vtk_header_relative_path}vtkMPICommunicator.h>
+#endif
+
 #ifndef vtkFloatingPointType
 #define vtkFloatingPointType vtkFloatingPointType
 typedef float vtkFloatingPointType;

--- a/libvtkfortran/configure.in
+++ b/libvtkfortran/configure.in
@@ -460,6 +460,11 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
+#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#include <${vtk_header_relative_path}vtkMPIController.h>
+#include <${vtk_header_relative_path}vtkMPICommunicator.h>
+#endif
+
 #ifndef vtkFloatingPointType
 #define vtkFloatingPointType vtkFloatingPointType
 typedef float vtkFloatingPointType;

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -37,6 +37,10 @@
 
 #include <vtk.h>
 
+#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#define VTK_USES_MPI 1
+#endif
+
 #include <vector>
 #include <string>
 
@@ -734,8 +738,18 @@ extern "C" {
     // Set to true binary format (not encoded as base 64)
     writer->SetDataModeToAppended();
     writer->EncodeAppendedDataOff();
+#ifdef VTK_USES_MPI
+    // From version 6.3 VTK uses parallel communication to decide
+    // which files have been written
+    if (!writer->GetController()) {
+      vtkMPIController *cont = vtkMPIController::New();
+      cont->SetCommunicator(vtkMPICommunicator::GetWorldCommunicator());
+      writer->SetController(cont);
+    }
+    writer->SetWriteSummaryFile(true);
+#else
     writer->SetWriteSummaryFile((*rank)==0);
-
+#endif
     
     writer->Write();
     writer->Delete();


### PR DESCRIPTION
It appears that since about VTK 6.3, their code now uses parallel communication to identify which pieces of a parallel file have been written. See line 213 and onward in their github repository [here](https://github.com/Kitware/VTK/blob/3276be1e1f3d44eb403ebda9ad589869c5b7d4bf/IO/ParallelXML/vtkXMLPDataObjectWriter.cxx). 

The net result on an unlucky setup is that our VTK writers produce a summary .pvtu file referencing only one of the .vtus, even though they have all been written. This changeset attempts to deal with this by doing the necessary work to allow the MPI communication to succeed, but has only been tested locally on one system. Possibly @jmn114 might be able to assist with testing.