### PR TITLE
Petsc38 changes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,9 +101,6 @@ endif
 ifneq (@HAVE_EXODUSII@,yes)
 	EXCLUDE_TAGS := $(EXCLUDE_TAGS) -e exodusii
 endif
-ifneq (@HAVE_PETSC33@,yes)
-	EXCLUDE_TAGS := $(EXCLUDE_TAGS) -e petsc33
-endif
 
 .SUFFIXES: .f90 .F90 .c .cpp .o .a
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -433,27 +433,24 @@ PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null |
 CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
-# Horrible hacks needed for cx1
-# Somehow /apps/intel/ict/mpi/3.1.038/lib64 gets given as /apps/intel/ict/mpi/3.1.038/lib/64
-# maybe the directory got moved after building petsc? Anyhow next time we
-# request a new petsc package on cx1, this hack can be removed - and we
-# can check if the new packages passes the test without any hacks.
-fixedLIBS=`echo $LIBS |sed 's@/apps/intel/ict/mpi/3.1.038/lib/64@/apps/intel/ict/mpi/3.1.038/lib64@g'`
-
-if test ! "$LIBS" == "$fixedLIBS"; then
-  # more fixes needed:
-  # also -lmpichcxx got mangled to -lmpichxx
-  LIBS=`echo $fixedLIBS |sed 's@mpichxx@mpichcxx@g'`
-  # remove -lPEPCF90, -lpromfei and -lprometheus
-  LIBS=`echo $LIBS |sed 's@-lPEPCF90@@g'`
-  LIBS=`echo $LIBS |sed 's@-lpromfei@@g'`
-  LIBS=`echo $LIBS |sed 's@-lprometheus@@g'`
+# first check we have the right petsc version
+AC_COMPUTE_INT(PETSC_VERSION_MAJOR, "PETSC_VERSION_MAJOR", [#include "petscversion.h"], 
+  [AC_MSG_ERROR([Unknown petsc major version])])
+AC_COMPUTE_INT(PETSC_VERSION_MINOR, "PETSC_VERSION_MINOR", [#include "petscversion.h"], 
+  [AC_MSG_ERROR([Unknown petsc minor version])])
+AC_MSG_NOTICE([Detected PETSc version "$PETSC_VERSION_MAJOR"."$PETSC_VERSION_MINOR"])
+# if major<3 or minor<4
+if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 4; then
+  AC_MSG_ERROR([Fluidity needs PETSc version >=3.4])
 fi
 
 AC_LANG(Fortran)
 # F90 (capital F) to invoke preprocessing
-# it's only 20 years ago now!
 ac_ext=F90
+
+# may need some extra flags for testing that we don't want to use in the end
+SAVE_FCFLAGS="$FCFLAGS"
+
 if test "$enable_petsc_fortran_modules" != "no" ; then
   # now try if the petsc fortran modules work:
   AC_LINK_IFELSE(
@@ -466,13 +463,13 @@ if test "$enable_petsc_fortran_modules" != "no" ; then
           [
               AC_MSG_NOTICE([PETSc modules are working.])
               AC_DEFINE(HAVE_PETSC_MODULES,1,[Define if you have petsc fortran modules.] )
+              FCFLAGS="$FCFLAGS -DHAVE_PETSC_MODULES"
           ],
           [
               AC_MSG_NOTICE([PETSc modules don't work, using headers instead.])
-              unset HAVE_PETSC_MODULES
           ])
-else
-  unset HAVE_PETSC_MODULES
+elif test "0$PETSC_VERSION_MINOR" -ge 8; then
+  AC_MSG_ERROR([PETSc v3.8 and newer requires petsc fortran modules. Do not use the --disable-petsc-fortran-modules option])
 fi
 
 # now try a more realistic program, it's a stripped down
@@ -486,15 +483,13 @@ program test_petsc
 implicit none
 #include "petsc_legacy.h"
       double precision  norm
-      PetscInt  i,j,II,JJ,m,n,its
+      PetscInt  i,j,II0,m,n,its
+      PetscInt, dimension(1) ::  II, JJ
       PetscInt  Istart,Iend,ione
       PetscErrorCode ierr
-#if PETSC_VERSION_MINOR>=2
       PetscBool flg
-#else
-      PetscTruth  flg
-#endif
-      PetscScalar v,one,neg_one
+      PetscScalar, dimension(1) :: v
+      PetscScalar one,neg_one
       Vec         x,b,u
       Mat         A 
       KSP         ksp
@@ -505,8 +500,8 @@ implicit none
       one  = 1.0
       neg_one = -1.0
       ione    = 1
-      call PetscOptionsGetInt(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER,'-m',m,flg,ierr)
-      call PetscOptionsGetInt(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER,'-n',n,flg,ierr)
+      call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER,'-m',m,flg,ierr)
+      call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER,'-n',n,flg,ierr)
 
       call MatCreate(PETSC_COMM_WORLD,A,ierr)
       call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,m*n,m*n,ierr)
@@ -514,10 +509,11 @@ implicit none
 
       call MatGetOwnershipRange(A,Istart,Iend,ierr)
       
-      do 10, II=Istart,Iend-1
+      do 10, II0=Istart,Iend-1
+        II = II0
         v = -1.0
-        i = II/n
-        j = II - i*n  
+        i = II0/n
+        j = II0 - i*n  
         if (i.gt.0) then
           JJ = II - n
           call MatSetValues(A,ione,II,ione,JJ,v,INSERT_VALUES,ierr)
@@ -575,29 +571,11 @@ AC_MSG_NOTICE([PETSc program succesfully compiled and linked.])
 cp conftest.F90 test_petsc.F90
 AC_MSG_FAILURE([Failed to compile and link PETSc program.])])
 
+FCFLAGS="$SAVE_FCFLAGS"
 AC_LANG_RESTORE
 
-# finally check we have the right petsc version
-AC_COMPUTE_INT(PETSC_VERSION_MAJOR, "PETSC_VERSION_MAJOR", [#include "petscversion.h"], 
-  [AC_MSG_ERROR([Unknown petsc major version])])
-AC_COMPUTE_INT(PETSC_VERSION_MINOR, "PETSC_VERSION_MINOR", [#include "petscversion.h"], 
-  [AC_MSG_ERROR([Unknown petsc minor version])])
-AC_MSG_NOTICE([Detected PETSc version "$PETSC_VERSION_MAJOR"."$PETSC_VERSION_MINOR"])
-# if major<3 or minor<1
-if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 1; then
-  AC_MSG_ERROR([Fluidity needs PETSc version >=3.1])
-fi
 
 AC_DEFINE(HAVE_PETSC,1,[Define if you have the PETSc library.])
-
-# define HAVE_PETSC33 for use in the Makefiles (including petsc's makefiles
-# would require having PETSC_DIR+PETSC_ARCH set correctly for every make)
-if test "0$PETSC_VERSION_MINOR" -ge 3; then
-  HAVE_PETSC33=yes
-else
-  HAVE_PETSC33=no
-fi
-AC_SUBST(HAVE_PETSC33)
 
 ])dnl ACX_PETSc
 

--- a/configure
+++ b/configure
@@ -646,7 +646,6 @@ PROFILING_FLAG
 IO_ADVANCE_BUG
 HAVE_ZOLTAN
 CXXCPP
-HAVE_PETSC33
 X_EXTRA_LIBS
 X_LIBS
 X_PRE_LIBS
@@ -12647,21 +12646,24 @@ PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null |
 CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
 
-# Horrible hacks needed for cx1
-# Somehow /apps/intel/ict/mpi/3.1.038/lib64 gets given as /apps/intel/ict/mpi/3.1.038/lib/64
-# maybe the directory got moved after building petsc? Anyhow next time we
-# request a new petsc package on cx1, this hack can be removed - and we
-# can check if the new packages passes the test without any hacks.
-fixedLIBS=`echo $LIBS |sed 's@/apps/intel/ict/mpi/3.1.038/lib/64@/apps/intel/ict/mpi/3.1.038/lib64@g'`
+# first check we have the right petsc version
+if ac_fn_c_compute_int "$LINENO" ""PETSC_VERSION_MAJOR"" "PETSC_VERSION_MAJOR"        "#include \"petscversion.h\""; then :
 
-if test ! "$LIBS" == "$fixedLIBS"; then
-  # more fixes needed:
-  # also -lmpichcxx got mangled to -lmpichxx
-  LIBS=`echo $fixedLIBS |sed 's@mpichxx@mpichcxx@g'`
-  # remove -lPEPCF90, -lpromfei and -lprometheus
-  LIBS=`echo $LIBS |sed 's@-lPEPCF90@@g'`
-  LIBS=`echo $LIBS |sed 's@-lpromfei@@g'`
-  LIBS=`echo $LIBS |sed 's@-lprometheus@@g'`
+else
+  as_fn_error $? "Unknown petsc major version" "$LINENO" 5
+fi
+
+if ac_fn_c_compute_int "$LINENO" ""PETSC_VERSION_MINOR"" "PETSC_VERSION_MINOR"        "#include \"petscversion.h\""; then :
+
+else
+  as_fn_error $? "Unknown petsc minor version" "$LINENO" 5
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&5
+$as_echo "$as_me: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&6;}
+# if major<3 or minor<4
+if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 4; then
+  as_fn_error $? "Fluidity needs PETSc version >=3.4" "$LINENO" 5
 fi
 
 ac_ext=${ac_fc_srcext-f}
@@ -12670,8 +12672,11 @@ ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest
 ac_compiler_gnu=$ac_cv_fc_compiler_gnu
 
 # F90 (capital F) to invoke preprocessing
-# it's only 20 years ago now!
 ac_ext=F90
+
+# may need some extra flags for testing that we don't want to use in the end
+SAVE_FCFLAGS="$FCFLAGS"
+
 if test "$enable_petsc_fortran_modules" != "no" ; then
   # now try if the petsc fortran modules work:
   cat > conftest.$ac_ext <<_ACEOF
@@ -12691,18 +12696,18 @@ $as_echo "$as_me: PETSc modules are working." >&6;}
 
 $as_echo "#define HAVE_PETSC_MODULES 1" >>confdefs.h
 
+              FCFLAGS="$FCFLAGS -DHAVE_PETSC_MODULES"
 
 else
 
               { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc modules don't work, using headers instead." >&5
 $as_echo "$as_me: PETSc modules don't work, using headers instead." >&6;}
-              unset HAVE_PETSC_MODULES
 
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-else
-  unset HAVE_PETSC_MODULES
+elif test "0$PETSC_VERSION_MINOR" -ge 8; then
+  as_fn_error $? "PETSc v3.8 and newer requires petsc fortran modules. Do not use the --disable-petsc-fortran-modules option" "$LINENO" 5
 fi
 
 # now try a more realistic program, it's a stripped down
@@ -12716,15 +12721,13 @@ program test_petsc
 implicit none
 #include "petsc_legacy.h"
       double precision  norm
-      PetscInt  i,j,II,JJ,m,n,its
+      PetscInt  i,j,II0,m,n,its
+      PetscInt, dimension(1) ::  II, JJ
       PetscInt  Istart,Iend,ione
       PetscErrorCode ierr
-#if PETSC_VERSION_MINOR>=2
       PetscBool flg
-#else
-      PetscTruth  flg
-#endif
-      PetscScalar v,one,neg_one
+      PetscScalar, dimension(1) :: v
+      PetscScalar one,neg_one
       Vec         x,b,u
       Mat         A
       KSP         ksp
@@ -12735,8 +12738,8 @@ implicit none
       one  = 1.0
       neg_one = -1.0
       ione    = 1
-      call PetscOptionsGetInt(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER,'-m',m,flg,ierr)
-      call PetscOptionsGetInt(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER,'-n',n,flg,ierr)
+      call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER,'-m',m,flg,ierr)
+      call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER,'-n',n,flg,ierr)
 
       call MatCreate(PETSC_COMM_WORLD,A,ierr)
       call MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,m*n,m*n,ierr)
@@ -12744,10 +12747,11 @@ implicit none
 
       call MatGetOwnershipRange(A,Istart,Iend,ierr)
 
-      do 10, II=Istart,Iend-1
+      do 10, II0=Istart,Iend-1
+        II = II0
         v = -1.0
-        i = II/n
-        j = II - i*n
+        i = II0/n
+        j = II0 - i*n
         if (i.gt.0) then
           JJ = II - n
           call MatSetValues(A,ione,II,ione,JJ,v,INSERT_VALUES,ierr)
@@ -12815,6 +12819,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
+FCFLAGS="$SAVE_FCFLAGS"
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -12822,37 +12827,9 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-# finally check we have the right petsc version
-if ac_fn_c_compute_int "$LINENO" ""PETSC_VERSION_MAJOR"" "PETSC_VERSION_MAJOR"        "#include \"petscversion.h\""; then :
-
-else
-  as_fn_error $? "Unknown petsc major version" "$LINENO" 5
-fi
-
-if ac_fn_c_compute_int "$LINENO" ""PETSC_VERSION_MINOR"" "PETSC_VERSION_MINOR"        "#include \"petscversion.h\""; then :
-
-else
-  as_fn_error $? "Unknown petsc minor version" "$LINENO" 5
-fi
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&5
-$as_echo "$as_me: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&6;}
-# if major<3 or minor<1
-if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 1; then
-  as_fn_error $? "Fluidity needs PETSc version >=3.1" "$LINENO" 5
-fi
 
 
 $as_echo "#define HAVE_PETSC 1" >>confdefs.h
-
-
-# define HAVE_PETSC33 for use in the Makefiles (including petsc's makefiles
-# would require having PETSC_DIR+PETSC_ARCH set correctly for every make)
-if test "0$PETSC_VERSION_MINOR" -ge 3; then
-  HAVE_PETSC33=yes
-else
-  HAVE_PETSC33=no
-fi
 
 
 
@@ -12924,14 +12901,6 @@ LIBS=$tmpLIBS
 CPPFLAGS=$tmpCPPFLAGS
 
 CPPFLAGS="$CPPFLAGS -DHAVE_PETSC"
-if test "$HAVE_PETSC_MODULES" == "1"; then
-  CPPFLAGS="$CPPFLAGS -DHAVE_PETSC_MODULES"
-fi
-if test "$HAVE_HYPRE" == "1"; then
-  CPPFLAGS="$CPPFLAGS -DHAVE_HYPRE"
-fi
-CPPFLAGS=`echo $CPPFLAGS | sed 's/-petsc-version-/3.4.2.0/' | sed 's/x86_64\/x86_64/x86_64/'`
-FCFLAGS=`echo $FCFLAGS | sed 's/-petsc-version-/3.4.2.0/' | sed 's/x86_64\/x86_64/x86_64/'`
 
 # Metis, ParMetis
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can compile and link without using -lparmetis" >&5

--- a/configure.in
+++ b/configure.in
@@ -830,14 +830,6 @@ AC_ARG_ENABLE(petsc-fortran-modules,
 ACX_PETSc([AC_MSG_NOTICE(["PETSc found, enabling scalable solver"])], [AC_MSG_ERROR(["PETSc not found"])])
 ACX_hypre([AC_MSG_NOTICE(["hypre found, enabling hypre preconditioners"])], [AC_MSG_WARN(["hypre not found"])])
 CPPFLAGS="$CPPFLAGS -DHAVE_PETSC"
-if test "$HAVE_PETSC_MODULES" == "1"; then
-  CPPFLAGS="$CPPFLAGS -DHAVE_PETSC_MODULES"
-fi
-if test "$HAVE_HYPRE" == "1"; then
-  CPPFLAGS="$CPPFLAGS -DHAVE_HYPRE"
-fi
-CPPFLAGS=`echo $CPPFLAGS | sed 's/-petsc-version-/3.4.2.0/' | sed 's/x86_64\/x86_64/x86_64/'`
-FCFLAGS=`echo $FCFLAGS | sed 's/-petsc-version-/3.4.2.0/' | sed 's/x86_64\/x86_64/x86_64/'`
 
 # Metis, ParMetis
 AC_MSG_CHECKING([if we can compile and link without using -lparmetis])

--- a/error_measures/tests/test_main.cpp
+++ b/error_measures/tests/test_main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();

--- a/examples/stokes_square_convection/Makefile
+++ b/examples/stokes_square_convection/Makefile
@@ -8,6 +8,7 @@ preprocess: envcheck
 run:
 	@echo **********To run this case at a grid resolution of 24x24, use make run_24.
 	@echo **********To run this case at a grid resolution of 48x48, use make run_48.
+	@echo **********Note that you need to run both cases.
 
 run_24: envcheck
 	@echo **********Calling fluidity with verbose log output enabled:

--- a/femtools/Multigrid.F90
+++ b/femtools/Multigrid.F90
@@ -71,18 +71,6 @@ PetscReal, dimension(:), pointer, save :: surface_values => null()
 private
 public SetupSmoothedAggregation, SetupMultigrid, DestroyMultigrid
   
-  ! see at the bottom of Petsc_Tools.F90
-  ! For some reason "use"ing the interface from the petsc_tools module
-  ! - if made public - doesn't work.
-  interface
-    subroutine myMatGetInfo(A, flag, info, ierr)
-       Mat, intent(in):: A
-       MatInfoType, intent(in):: flag
-       double precision, dimension(:), intent(out):: info
-       PetscErrorCode, intent(out):: ierr
-    end subroutine myMatGetInfo
-  end interface
-
 contains
 
 subroutine SetUpInternalSmoother(surface_node_list_in,matrix,pc, &
@@ -94,7 +82,6 @@ subroutine SetUpInternalSmoother(surface_node_list_in,matrix,pc, &
   PC, intent(inout) :: pc
   logical, intent(in), optional :: no_top_smoothing
   !
-  PetscObject:: myPETSC_NULL_OBJECT
   type(csr_matrix) :: matrix_internal
   integer :: row,i, ierr, nsurface
   integer, dimension(:), pointer :: r_ptr
@@ -155,11 +142,7 @@ subroutine SetUpInternalSmoother(surface_node_list_in,matrix,pc, &
   call pcsetoperators(internal_smoother_pc,Internal_Smoother_Mat, Internal_Smoother_Mat, ierr)
 
   !set up pc to output
-  myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-  call PCShellSetApply(pc,ApplySmoother,PETSC_NULL_OBJECT,ierr)
-  if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-    FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-  end if  
+  call PCShellSetApply(pc,ApplySmoother,ierr)
 
   surface_node_list = surface_node_list - 1
 
@@ -355,7 +338,6 @@ logical, intent(in), optional :: no_top_smoothing
   PetscScalar :: Px2
   Vec:: eigvec, Px
   PetscReal, allocatable, dimension(:):: emin, emax
-  PetscObject:: myPETSC_NULL_OBJECT
   integer, allocatable, dimension(:):: contexts
   integer i, j, ri, nolevels, m, n, top_level
   integer nosmd, nosmu, clustersize, no_external_prolongators
@@ -414,7 +396,7 @@ logical, intent(in), optional :: no_top_smoothing
          epsilon=epsilon/epsilon_decay
       end if
 
-      if (prolongators(i)==PETSC_NULL_OBJECT) then
+      if (prolongators(i)==PETSC_NULL_MAT) then
         if (IsParallel()) then
           ! in parallel we give up
           ewrite(-1,*) "ERROR: mg preconditioner setup failed"
@@ -430,11 +412,8 @@ logical, intent(in), optional :: no_top_smoothing
         end do
         deallocate(matrices, prolongators, contexts)
         ! Need to set n/o levels (to 1) otherwise PCDestroy will fail:
-        myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-        call PCMGSetLevels(prec, 1, PETSC_NULL_OBJECT, ierr)
-        if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-           FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-        end if
+        ! See note below about PETSC_NULL_KSP argument
+        call PCMGSetLevels(prec, 1, PETSC_NULL_KSP, ierr)
         ierror=1
         return
       end if
@@ -456,11 +435,10 @@ logical, intent(in), optional :: no_top_smoothing
       nolevels=i
     end if
     
-    myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-    call PCMGSetLevels(prec, nolevels, PETSC_NULL_OBJECT, ierr)
-    if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-       FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-    end if
+    ! NOTE: in petsc v3.8 it's unclear what the legal null argument should be for MPI_Comm *comms
+    ! it does not accept any scalar null object (e.g. PETSC_NULL_INTEGER) - luckily there's no
+    ! explicit interface so we can pass this instead which does get correctly translated to a null argument
+    call PCMGSetLevels(prec, nolevels, PETSC_NULL_KSP, ierr)
     
     if (lno_top_smoothing) then
       top_level=nolevels-2
@@ -484,11 +462,7 @@ logical, intent(in), optional :: no_top_smoothing
         call PowerMethod(matrices(ri), eigval, eigvec)
         emax(ri)=eigval
         
-        myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-        call MatCreateVecs(prolongators(ri-1), PETSC_NULL_OBJECT, Px, ierr)
-        if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-           FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-        end if
+        call MatCreateVecs(prolongators(ri-1), PETSC_NULL_VEC, Px, ierr)
         call MatMult(prolongators(ri-1), eigvec, Px, ierr)
         call VecNorm(Px, NORM_2, Px2, ierr)
         emin(ri-1)=eigval/Px2**2.
@@ -583,7 +557,7 @@ logical, intent(in), optional :: no_top_smoothing
     call PCMGGetCoarseSolve(prec, ksp_smoother, ierr)
     call KSPGetPC(ksp_smoother, prec_smoother, ierr)
     call MatGetNullSpace(matrix, nullsp, ierr)
-    if (IsParallel() .or. (nullsp/=PETSC_NULL_OBJECT .and. ierr==0)) then
+    if (IsParallel() .or. (ierr==0 .and. .not. IsNullMatNullSpace(nullsp))) then
       ! if parallel or if we have a null space: use smoothing instead of direct solve
       call SetupSORSmoother(ksp_smoother, matrices(nolevels), &
         SOR_LOCAL_SYMMETRIC_SWEEP, 20)
@@ -682,23 +656,23 @@ integer, intent(out):: nosmd, nosmu, clustersize
   PetscBool flag
   PetscErrorCode ierr
 
-    call PetscOptionsGetReal(PETSC_NULL_OBJECT, '', '-mymg_epsilon', epsilon, flag, ierr)
+    call PetscOptionsGetReal(PETSC_NULL_OPTIONS, '', '-mymg_epsilon', epsilon, flag, ierr)
     if (.not. flag) then
       epsilon=MULTIGRID_EPSILON_DEFAULT
     end if
-    call PetscOptionsGetReal(PETSC_NULL_OBJECT, '', '-mymg_epsilon_decay', epsilon_decay, flag, ierr)
+    call PetscOptionsGetReal(PETSC_NULL_OPTIONS, '', '-mymg_epsilon_decay', epsilon_decay, flag, ierr)
     if (.not. flag) then
       epsilon_decay=MULTIGRID_EPSILON_DECAY_DEFAULT
     end if
-    call PetscOptionsGetReal(PETSC_NULL_OBJECT, '', '-mymg_omega', omega, flag, ierr)
+    call PetscOptionsGetReal(PETSC_NULL_OPTIONS, '', '-mymg_omega', omega, flag, ierr)
     if (.not. flag) then
       omega=MULTIGRID_OMEGA_DEFAULT
     end if
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, '', '-mymg_maxlevels', maxlevels, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, '', '-mymg_maxlevels', maxlevels, flag, ierr)
     if (.not. flag) then
       maxlevels=MULTIGRID_MAXLEVELS_DEFAULT
     end if
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, '', '-mymg_coarsesize', coarsesize, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, '', '-mymg_coarsesize', coarsesize, flag, ierr)
     if (.not. flag) then
       if (IsParallel()) then
         coarsesize=MULTIGRID_COARSESIZE_DEFAULT_PARALLEL
@@ -706,15 +680,15 @@ integer, intent(out):: nosmd, nosmu, clustersize
         coarsesize=MULTIGRID_COARSESIZE_DEFAULT_SERIAL
       end if
     end if
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, '', '-mymg_nosmd', nosmd, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, '', '-mymg_nosmd', nosmd, flag, ierr)
     if (.not. flag) then
       nosmd=MULTIGRID_NOSMD_DEFAULT
     end if
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, '', '-mymg_nosmu', nosmu, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, '', '-mymg_nosmu', nosmu, flag, ierr)
     if (.not. flag) then
       nosmu=MULTIGRID_NOSMU_DEFAULT
     end if
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, '', '-mymg_clustersize', clustersize, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, '', '-mymg_clustersize', clustersize, flag, ierr)
     if (.not. flag) then
       clustersize=MULTIGRID_CLUSTERSIZE_DEFAULT
     end if
@@ -752,20 +726,22 @@ integer, optional, dimension(:), intent(out):: cluster
   double precision, dimension(MAT_INFO_SIZE):: matrixinfo
   integer, dimension(:), allocatable:: findN, N, R
   integer:: nrows, nentries, ncols
-  integer:: jc, ccnt, base
+  integer:: jc, ccnt, base, end_of_range
     
   ! find out basic dimensions of A
   call MatGetLocalSize(A, nrows, ncols, ierr)
   ! use Petsc_Tools's MatGetInfo because of bug in earlier patch levels of petsc 3.0
-  call myMatGetInfo(A, MAT_LOCAL, matrixinfo, ierr)
+  call MatGetInfo(A, MAT_LOCAL, matrixinfo, ierr)
   nentries=matrixinfo(MAT_INFO_NZ_USED)
-  call MatGetOwnerShipRange(A, base, PETSC_NULL_INTEGER, ierr)
+  call MatGetOwnerShipRange(A, base, end_of_range, ierr)
   ! we decrease by 1, so base+i gives 0-based petsc index if i is the local fortran index:
   base=base-1
   
   allocate(findN(1:nrows+1), N(1:nentries), R(1:nrows))
      
   ! rescale the matrix: a_ij -> a_ij/sqrt(aii*ajj)
+  ! ensure we don't pass PETSC_NULL_VEC
+  diag = PETSC_NOTANULL_VEC; sqrt_diag = PETSC_NOTANULL_VEC
   call MatCreateVecs(A, diag, sqrt_diag, ierr)
   call MatGetDiagonal(A, diag, ierr)
   call VecMin(diag, diagminloc, diagmin, ierr)
@@ -793,7 +769,7 @@ integer, optional, dimension(:), intent(out):: cluster
     if (present(cluster)) cluster=ISOLATED
     deallocate(findN, N, R)
     ! we return PETSC_NULL; callers of this function should check for this
-    P=PETSC_NULL_OBJECT
+    P=PETSC_NULL_MAT
     return
   else if (100*ccnt<99*nrows .and. .not. IsParallel()) then
     ! more than 1% isolated nodes, give a warning
@@ -859,13 +835,12 @@ subroutine create_prolongator(P, nrows, ncols, findN, N, R, A, base, omega)
   integer, intent(in):: base
   PetscReal, intent(in):: omega
   
-  PetscObject:: myPETSC_NULL_OBJECT
   PetscErrorCode:: ierr
   Vec:: rowsum_vec
   PetscReal, dimension(:), allocatable:: Arowsum
   PetscReal:: aij(1), rowsum
   integer, dimension(:), allocatable:: dnnz, onnz
-  integer:: i, j, k, coarse_base
+  integer:: i, j, k, coarse_base, end_of_range
   
   allocate(dnnz(1:nrows), Arowsum(1:nrows))
   
@@ -894,7 +869,7 @@ subroutine create_prolongator(P, nrows, ncols, findN, N, R, A, base, omega)
     call MatSetOption(P, MAT_USE_INODES, PETSC_FALSE, ierr)
       
     ! get base for coarse node/cluster numbering
-    call MatGetOwnerShipRangeColumn(P, coarse_base, PETSC_NULL_INTEGER, ierr)
+    call MatGetOwnerShipRangeColumn(P, coarse_base, end_of_range, ierr)
     ! subtract 1 to convert from 1-based fortran to 0 based petsc
     coarse_base=coarse_base-1
   else
@@ -906,11 +881,7 @@ subroutine create_prolongator(P, nrows, ncols, findN, N, R, A, base, omega)
   end if
   call MatSetup(P, ierr)
   
-  myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-  call MatCreateVecs(A, rowsum_vec, PETSC_NULL_OBJECT, ierr)
-  if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-    FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-  end if
+  call MatCreateVecs(A, rowsum_vec, PETSC_NULL_VEC, ierr)
   call VecPlaceArray(rowsum_vec, Arowsum, ierr)
   call MatGetRowSum(A, rowsum_vec, ierr)
     
@@ -1112,17 +1083,12 @@ Vec, intent(out):: eigvec
   PetscReal:: rho_k, rho_kp1, norm2
   integer:: i
   PetscRandom:: pr
-  PetscObject:: myPETSC_NULL_OBJECT  
   
   call MatCreateVecs(matrix, x_kp1, x_k, ierr)
   
   ! initial guess
   call PetscRandomCreate(PETSC_COMM_WORLD, pr, ierr)
-  myPETSC_NULL_OBJECT=PETSC_NULL_OBJECT
-  call VecSetRandom(x_k, PETSC_NULL_OBJECT, ierr)
-  if (myPETSC_NULL_OBJECT/=PETSC_NULL_OBJECT) then
-    FLAbort("PETSC_NULL_OBJECT has changed please report to skramer")
-  end if
+  call VecSetRandom(x_k, pr, ierr)
   call PetscRandomDestroy(pr, ierr)
 
   rho_k=0.0

--- a/femtools/Petsc_Tools.F90
+++ b/femtools/Petsc_Tools.F90
@@ -446,11 +446,10 @@ contains
   end subroutine Array2Petsc
   
   subroutine VectorFields2Petsc(fields, petsc_numbering, vec)
-    !!< Assembles contiguous petsc array using the specified numbering from the given fields.
-    !!< Allocates a petsc Vec that should be destroyed with VecDestroy
+    !!< Assembles field into (previously created) petsc Vec using petsc_numbering for the DOFs of the fields combined
     type(vector_field), dimension(:), intent(in):: fields
     type(petsc_numbering_type), intent(in):: petsc_numbering
-    Vec :: vec
+    Vec, intent(inout) :: vec
   
     integer ierr, nnodp, b, nfields, nnodes
     integer i, j
@@ -497,17 +496,17 @@ contains
   end subroutine VectorFields2Petsc
   
   subroutine VectorField2Petsc(field, petsc_numbering, vec)
-    !!< Assembles contiguous petsc array using the specified numbering from the given field.
+    !!< Assembles given field into (previously created) petsc Vec using petsc_numbering
     type(vector_field), intent(in):: field
     type(petsc_numbering_type), intent(in):: petsc_numbering
-    Vec, intent(out) :: vec
+    Vec, intent(inout) :: vec
   
     call VectorFields2Petsc( (/ field /), petsc_numbering, vec)
     
   end subroutine VectorField2Petsc
   
   subroutine ScalarFields2Petsc(fields, petsc_numbering, vec)
-    !!< Assembles contiguous petsc array using the specified numbering from the given fields.
+    !!< Assembles field into (previously created) petsc Vec using petsc_numbering for the DOFs of the fields combined
     type(scalar_field), dimension(:), intent(in):: fields
     type(petsc_numbering_type), intent(in):: petsc_numbering
     Vec, intent(inout) :: vec
@@ -551,8 +550,7 @@ contains
   end subroutine ScalarFields2Petsc
   
   subroutine ScalarField2Petsc(field, petsc_numbering, vec)
-    !!< Assembles petsc array using the specified numbering.
-    !!< Allocates a petsc Vec that should be destroyed with VecDestroy
+    !!< Assembles given field into (previously created) petsc Vec using petsc_numbering
     type(scalar_field), intent(in):: field
     type(petsc_numbering_type), intent(in):: petsc_numbering
     Vec, intent(inout) :: vec

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -1569,7 +1569,7 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
       internal_smoothing_option)
   !!< Sets options for the given ksp according to the options
   !!< in the options tree.
-    KSP, intent(out) :: ksp
+    KSP, intent(inout) :: ksp
     ! PETSc mat and pmat used to solve
     Mat, intent(in):: mat, pmat
     ! path to solver block (including '/solver')

--- a/femtools/Sparse_Tools.F90
+++ b/femtools/Sparse_Tools.F90
@@ -852,7 +852,7 @@ contains
     nullify(matrix%inactive%ptr)
     ! same story for ksp
     allocate(matrix%ksp)
-    matrix%ksp=PETSC_NULL_OBJECT ! to indicate no ksp cache available
+    matrix%ksp=PETSC_NULL_KSP ! to indicate no ksp cache available
 
     select case (ltype)
     case (CSR_REAL)
@@ -985,7 +985,7 @@ contains
       FLAbort("Attempt made to deallocate a non-allocated or damaged CSR matrix.")
     end if
     
-    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+    if (matrix%ksp/=PETSC_NULL_KSP) then
       call KSPDestroy(matrix%ksp, lstat)
       if (lstat/=0) then
         if (present(stat)) then
@@ -1115,7 +1115,7 @@ contains
     
     ! always allocate to make sure all references see the same %ksp
     allocate(matrix%ksp)
-    matrix%ksp=PETSC_NULL_OBJECT ! to indicate no ksp cache available
+    matrix%ksp=PETSC_NULL_KSP ! to indicate no ksp cache available
 
 
 42  if (present(stat)) then
@@ -1191,7 +1191,7 @@ contains
     if (.not. associated(matrix%ksp)) then
       FLAbort("Attempt made to deallocate a non-allocated or damaged CSR matrix.")
     end if
-    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+    if (matrix%ksp/=PETSC_NULL_KSP) then
       call KSPDestroy(matrix%ksp, lstat)
       if (lstat/=0) then
         if (present(stat)) then
@@ -1491,7 +1491,7 @@ contains
 
     ! always allocate to make sure all references see the same %ksp
     allocate(matrix%ksp)
-    matrix%ksp=PETSC_NULL_OBJECT ! to indicate no ksp cache available
+    matrix%ksp=PETSC_NULL_KSP ! to indicate no ksp cache available
     
     ! Wrapped matrices can have inactive nodes
     allocate( matrix%inactive, stat=lstat )
@@ -1578,7 +1578,7 @@ contains
 
     ! always allocate to make sure all references see the same %ksp
     allocate(matrix%ksp)
-    matrix%ksp=PETSC_NULL_OBJECT ! to indicate no ksp cache available
+    matrix%ksp=PETSC_NULL_KSP ! to indicate no ksp cache available
     
     if (present(stat)) then
        stat=lstat
@@ -2187,12 +2187,12 @@ contains
   
   end function has_inactive
   
-  pure function csr_has_solver_cache(matrix)
+  function csr_has_solver_cache(matrix)
     logical :: csr_has_solver_cache
     type(csr_matrix), intent(in) :: matrix
     
     if (associated(matrix%ksp)) then
-      csr_has_solver_cache = matrix%ksp/=PETSC_NULL_OBJECT
+      csr_has_solver_cache = matrix%ksp/=PETSC_NULL_KSP
     else
       ! this should only be possible for a csr_matrix returned from block()
       csr_has_solver_cache = .false.
@@ -2200,12 +2200,12 @@ contains
     
   end function csr_has_solver_cache
   
-  pure function block_csr_has_solver_cache(matrix)
+  function block_csr_has_solver_cache(matrix)
     logical :: block_csr_has_solver_cache
     type(block_csr_matrix), intent(in) :: matrix
     
     if (associated(matrix%ksp)) then
-      block_csr_has_solver_cache = matrix%ksp/=PETSC_NULL_OBJECT
+      block_csr_has_solver_cache = matrix%ksp/=PETSC_NULL_KSP
     else
       ! don't think this is possible, but hey
       block_csr_has_solver_cache = .false.
@@ -2220,10 +2220,10 @@ contains
     
     if (.not. associated(matrix%ksp)) return
     
-    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+    if (matrix%ksp/=PETSC_NULL_KSP) then
       call KSPDestroy(matrix%ksp, ierr)
     end if
-    matrix%ksp=PETSC_NULL_OBJECT
+    matrix%ksp=PETSC_NULL_KSP
     
   end subroutine csr_destroy_solver_cache
   
@@ -2234,10 +2234,10 @@ contains
     
     if (.not. associated(matrix%ksp)) return
     
-    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+    if (matrix%ksp/=PETSC_NULL_KSP) then
       call KSPDestroy(matrix%ksp, ierr)
     end if
-    matrix%ksp=PETSC_NULL_OBJECT
+    matrix%ksp=PETSC_NULL_KSP
     
   end subroutine block_csr_destroy_solver_cache
     

--- a/femtools/Sparse_Tools_Petsc.F90
+++ b/femtools/Sparse_Tools_Petsc.F90
@@ -274,7 +274,7 @@ contains
     end if
 
     allocate(matrix%ksp)
-    matrix%ksp = PETSC_NULL_OBJECT
+    matrix%ksp = PETSC_NULL_KSP
     
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
@@ -486,7 +486,7 @@ contains
     end if
 
     allocate(matrix%ksp)
-    matrix%ksp = PETSC_NULL_OBJECT
+    matrix%ksp = PETSC_NULL_KSP
     
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
@@ -563,7 +563,7 @@ contains
     end if
 
     allocate(matrix%ksp)
-    matrix%ksp = PETSC_NULL_OBJECT
+    matrix%ksp = PETSC_NULL_KSP
 
     nullify(matrix%refcount) ! Hack for gfortran component initialisation
     !                         bug.
@@ -605,7 +605,7 @@ contains
       FLAbort("Attempt made to deallocate a non-allocated or damaged petsc_csr_matrix.")
     end if
 
-    if (matrix%ksp/=PETSC_NULL_OBJECT) then
+    if (matrix%ksp/=PETSC_NULL_KSP) then
       call KSPDestroy(matrix%ksp, lstat)
       if (lstat/=0) then
         if (present(stat)) then
@@ -741,7 +741,7 @@ contains
     PetscErrorCode:: ierr
 
     ! get the necessary info about the matrix:
-    call myMatGetInfo(matrix%M, MAT_LOCAL, matrixinfo, ierr)
+    call MatGetInfo(matrix%M, MAT_LOCAL, matrixinfo, ierr)
     entries=matrixinfo(MAT_INFO_NZ_USED)
 
   end function petsc_csr_entries
@@ -1004,7 +1004,7 @@ contains
     c%name=trim(a%name)//"_"//trim(p%name)//"_ptap"
 
     allocate(c%ksp)
-    c%ksp = PETSC_NULL_OBJECT
+    c%ksp = PETSC_NULL_KSP
     
     ! the new c get its own reference:
     nullify(c%refcount) ! Hack for gfortran component initialisation
@@ -1196,8 +1196,8 @@ contains
 
     else
 
-      xvec = PETSC_NULL_OBJECT
-      bvec = PETSC_NULL_OBJECT
+      xvec = PETSC_NULL_VEC
+      bvec = PETSC_NULL_VEC
       if (fix_scaling) then
         diag = PetscNumberingCreateVec(A%row_numbering)
       end if

--- a/femtools/tests/test_main.cpp
+++ b/femtools/tests/test_main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   

--- a/horizontal_adaptivity/tests/test_main.cpp
+++ b/horizontal_adaptivity/tests/test_main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();

--- a/include/petsc_legacy.h
+++ b/include/petsc_legacy.h
@@ -6,13 +6,17 @@
 ! still need #ifdef PETSC_VERSION>... in the main code
 #include "petscversion.h"
 #ifdef HAVE_PETSC_MODULES
-#if PETSC_VERSION_MINOR>=6
+#if PETSC_VERSION_MINOR>=8
+#include "petsc/finclude/petsc.h"
+#elif PETSC_VERSION_MINOR>=6
 #include "petsc/finclude/petscdef.h"
 #else
 #include "finclude/petscdef.h"
 #endif
 #else
-#if PETSC_VERSION_MINOR>=6
+#if PETSC_VERSION_MINOR>=8
+#error "From PETSc v3.8, petsc fortran modules are required. Ensure petsc fortran modules, compiled with the same fortran compiler, are installed and configure without the --disable-petsc-fortran-modules option."
+#elif PETSC_VERSION_MINOR>=6
 #include "petsc/finclude/petsc.h"
 #else
 #include "finclude/petsc.h"
@@ -52,4 +56,21 @@
 #if PETSC_VERSION_MINOR<7
 #define PetscViewerAndFormatCreate NullPetscViewerAndFormatCreate
 #define PetscViewerAndFormatDestroy PETSC_NULL_FUNCTION
+#endif
+! from petsc 3.8 onward PETSC_NULL_OBJECT is gone, a specific PETSC_NULL_XXX needs to be used
+#if PETSC_VERSION_MINOR<8
+#define PETSC_NULL_OPTIONS PETSC_NULL_OBJECT
+#define PETSC_NULL_KSP PETSC_NULL_OBJECT
+#define PETSC_NULL_VEC PETSC_NULL_OBJECT
+#define PETSC_NULL_MAT PETSC_NULL_OBJECT
+#define PETSC_NULL_VECSCATTER PETSC_NULL_OBJECT
+#define PETSC_NULL_VIEWER PETSC_NULL_OBJECT
+#endif
+#if PETSC_VERSION_MINOR>=8
+#define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x%v, ierr)
+#else
+#define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x, ierr)
+#endif
+#if PETSC_VERSION_MINOR<8
+#define MatCreateSubMatrix MatGetSubMatrix
 #endif

--- a/ocean_forcing/tests/test_main.cpp
+++ b/ocean_forcing/tests/test_main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   

--- a/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
+++ b/tests/Stokes_may_sinker_stepxy/Stokes_may_sinker_stepxy.xml
@@ -2,7 +2,7 @@
 <testproblem>
   <name>Stokes-may-sinker</name>
   <owner userid="rhodrid"/>
-  <tags>flml petsc33</tags>
+  <tags>flml</tags>
   <problem_definition length="medium" nprocs="1">
     <command_line>export PETSC_OPTIONS='-log_view'; fluidity -v2 -l Stokes-may-sinker-stepxy-gamg.flml; mv fluidity.log-0 log_gamg; fluidity -v2 -l Stokes-may-sinker-stepxy-fs.flml; mv fluidity.log-0 log_fs; fluidity -v2 -l Stokes-may-sinker-stepxy-mg.flml; mv fluidity.log-0 log_mg; fluidity -v2 -l Stokes-may-sinker-stepxy-sor.flml; mv fluidity.log-0 log_sor</command_line>
   </problem_definition>

--- a/tests/Stokes_may_solcx_stepx/Stokes_may_solcx_stepx.xml
+++ b/tests/Stokes_may_solcx_stepx/Stokes_may_solcx_stepx.xml
@@ -2,7 +2,7 @@
 <testproblem>
   <name>Stokes-may-step-x</name>
   <owner userid="rhodrid"/>
-  <tags>flml petsc33</tags>
+  <tags>flml</tags>
 
   <problem_definition length="medium" nprocs="1">
     <command_line>fluidity -v2 -l Stokes-may-solcx-stepx-gamg.flml; mv fluidity.log-0 log_gamg; fluidity -v2 -l Stokes-may-solcx-stepx-fs.flml; mv fluidity.log-0 log_fs; fluidity -v2 -l Stokes-may-solcx-stepx-mg.flml; mv fluidity.log-0 log_mg; fluidity -v2 -l Stokes-may-solcx-stepx-sor.flml; mv fluidity.log-0 log_sor</command_line>

--- a/tests/Stokes_may_solky_exponential/Stokes_may_solky_exponential.xml
+++ b/tests/Stokes_may_solky_exponential/Stokes_may_solky_exponential.xml
@@ -2,7 +2,7 @@
 <testproblem>
   <name>Stokes-may-exponential</name>
   <owner userid="rhodrid"/>
-  <tags>flml petsc33</tags>
+  <tags>flml</tags>
   <problem_definition length="medium" nprocs="1">
     <command_line>fluidity -v2 -l Stokes-may-solky-exponential-gamg.flml; mv fluidity.log-0 log_gamg; fluidity -v2 -l Stokes-may-solky-exponential-fs.flml; mv fluidity.log-0 log_fs; fluidity -v2 -l Stokes-may-solky-exponential-mg.flml; mv fluidity.log-0 log_mg; fluidity -v2 -l Stokes-may-solky-exponential-sor.flml; mv fluidity.log-0 log_sor</command_line>
   </problem_definition>

--- a/tests/Stokes_slab_detachment/Stokes_slab_detachment.xml
+++ b/tests/Stokes_slab_detachment/Stokes_slab_detachment.xml
@@ -2,7 +2,7 @@
 <testproblem>
   <name>Stokes-slab-detachment</name>
   <owner userid="rhodrid"/>
-  <tags>flml parallel petsc33</tags>
+  <tags>flml parallel</tags>
 
   <problem_definition length="medium" nprocs="3">
     <command_line>mpiexec ../../bin/flredecomp -i 1 -o 3 -v -l Slab-detachment Parallel_NP3_Slab-detachment &amp;&amp; 

--- a/tools/petsc_readnsolve.F90
+++ b/tools/petsc_readnsolve.F90
@@ -86,7 +86,7 @@ implicit none
   call PetscViewerDestroy(viewer, ierr)
   if (random_rhs) then
     call PetscRandomCreate(PETSC_COMM_WORLD, pr, ierr)
-    call VecSetRandom(rhs, PETSC_NULL_OBJECT, ierr)
+    call VecSetRandom(rhs, pr, ierr)
     call PetscRandomDestroy(pr, ierr)
   end if
 
@@ -185,8 +185,8 @@ contains
     krylov_method=KSPGMRES
     pc_method=PCSOR
     
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, '', "-ksp_type", krylov_method, flag, ierr)
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, '', "-pc_type", pc_method, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, '', "-ksp_type", krylov_method, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, '', "-pc_type", pc_method, flag, ierr)
     call KSPCreate(MPI_COMM_FEMTOOLS, krylov, ierr)
     call KSPSetType(krylov, krylov_method, ierr)
     call KSPSetOperators(krylov, matrix, matrix, ierr)
@@ -712,7 +712,7 @@ contains
     ! still all columns of owned rows are stored locally)
     ! we only deal with square matrices (same d.o.f. for rows and columns)
     ! in fluidity, so we can simply reuse row_indexset as the col_indexset
-    call MatGetSubMatrix(matrix, row_indexset, row_indexset, &
+    call MatCreateSubMatrix(matrix, row_indexset, row_indexset, &
        MAT_INITIAL_MATRIX, new_matrix, ierr)
 
     ! destroy the old read-in matrix and replace by the new one
@@ -727,7 +727,7 @@ contains
     ! create a Vec according to the proper partioning:
     call VecCreateMPI(MPI_COMM_FEMTOOLS, n*ncomponents, m, new_x, ierr)
     ! fill it with values from the read x by asking for its row numbers
-    call VecScatterCreate(x, row_indexset, new_x, PETSC_NULL_OBJECT, &
+    call VecScatterCreate(x, row_indexset, new_x, PETSC_NULL_VECSCATTER, &
        scatter, ierr)
     call VecScatterBegin(scatter, x, new_x, INSERT_VALUES, &
        SCATTER_FORWARD, ierr)
@@ -760,28 +760,28 @@ contains
     PetscBool flag
     PetscErrorCode ierr
     
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, 'prns_', '-filename', filename, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, 'prns_', '-filename', filename, flag, ierr)
     if (.not. flag) then
       filename='matrixdump'
     end if
 
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, 'prns_', '-flml', flml, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, 'prns_', '-flml', flml, flag, ierr)
     if (.not. flag) then
       flml=''
     end if
     
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, 'prns_', '-field', field, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, 'prns_', '-field', field, flag, ierr)
     if (.not. flag) then
       field=''
     end if
     
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, 'prns_', '-zero_init_guess', zero_init_guess, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, 'prns_', '-zero_init_guess', zero_init_guess, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, 'prns_', '-scipy', scipy, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, 'prns_', '-scipy', scipy, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, 'prns_', '-random_rhs', random_rhs, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, 'prns_', '-random_rhs', random_rhs, ierr)
     
-    call PetscOptionsGetInt(PETSC_NULL_OBJECT, 'prns_', '-verbosity', current_debug_level, flag, ierr)
+    call PetscOptionsGetInt(PETSC_NULL_OPTIONS, 'prns_', '-verbosity', current_debug_level, flag, ierr)
     if (.not.flag) then
       current_debug_level=3
     end if

--- a/tools/petsc_readnsolve_main.cpp
+++ b/tools/petsc_readnsolve_main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   usage(argc, argv);

--- a/tools/test_pressure_solve.F90
+++ b/tools/test_pressure_solve.F90
@@ -321,31 +321,31 @@
     PetscErrorCode :: ierr
     PetscReal :: number_in=0.0
 
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-filename', filename, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-filename', filename, flag, ierr)
     if (.not. flag) then
        call usage()
     end if
 
-    call PetscOptionsGetReal(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-epsilon', number_in, flag, ierr)
+    call PetscOptionsGetReal(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-epsilon', number_in, flag, ierr)
     if(.not. flag) then
        call usage()
     end if
     eps0 = number_in
 
-    call PetscOptionsGetString(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-exact_solution', exact_sol_filename, flag, ierr)
+    call PetscOptionsGetString(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-exact_solution', exact_sol_filename, flag, ierr)
     if (.not. flag) then 
        call usage()
     end if
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-vl_as', vl_as, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-vl_as', vl_as, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-vl_as_wsor', vl_as_wsor, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-vl_as_wsor', vl_as_wsor, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-vl', vl, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-vl', vl, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-no_vl', no_vl, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-no_vl', no_vl, ierr)
 
-    call PetscOptionsHasName(PETSC_NULL_OBJECT, PETSC_NULL_CHARACTER, '-sor', sor, ierr)
+    call PetscOptionsHasName(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-sor', sor, ierr)
 
   end subroutine pressure_solve_options
 

--- a/tools/test_pressure_solve_main.cpp
+++ b/tools/test_pressure_solve_main.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
+  // This sets all kinds of objects such as PETSC_NULL_XXX, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   test_pressure_solve_();


### PR DESCRIPTION
Changes needed to build fluidity with petsc v3.8.

The main difference in petsc's fortran interface  from v3.8 is the introduction of PETSC_NULL_XXX,
where XXX=KSP,Vec,Mat,etc. instead of the generic PETSC_NULL_OBJECT. Compatibility for older
petsc versions is maintained by #define-ing PETSC_NULL_XXX PETSC_NULL_OBJECT. Unfortunately a number of bugs/complications were discovered associated with this change that I needed to work around:
  - MatCreateSchurComplement is missing a hand-rolled fortran wrapper with a CHKFORTRANNULLOBJECT, so that a PETSC_NULL_MAT is not correctly translated to a C (Mat *) null
  - PetscObjectReference is also missing a wrapper (passing the %v member works instead)
  - there is not PETSC_NULL_MATNULLSPACE and MatGetNullSpace is not wrapped correctly, workaround with IsNullMatNullSpace() function that tests the returned nullspace
  - in petsc 3.8, the check that petsc object arguments are null arguments (and thus meant to be omited/ignored) is now checked by checking whether the value of the associated fortran derived type with single attribute %v, has the value -1. It is therefore possible that uninitialised petsc object variables in fortran are uninintenionally initialised to be null. This has unintended consequences for some petsc routines, such as MatCreateVecs, with optional output arguments. If the provided uninitialised argument happens to contain -1 as input value, it will be interpreted as null and therefore no output result is returned for it. Thus such arguments now need to be initialized with a fortran petsc object that is known not to be equal to PETSC_NULL_XXX
  - routines with missing wrappers to recognize PETSC_NULL_INTEGER: MatGetOwnerShipRange and MatSeqAIJSetPreallocation
  - no such thing as PETSC_NULL_RANDOM, so VecSetRandom *needs* a Random object as input
  - the (MPI_Comm *) comms argument of PCMGSetLevels does not have a clear null option in fortran, PETSC_NULL_KSP seems to work as there is actually no explcit wrapper

Most of these issues (in particular the uninitialised fortran arguments) have been addressed in https://bitbucket.org/petsc/petsc/pull-requests/829/added-f90-interfaces-for-several/diff These will not be available in this petsc release (3.8) however, as the solution to uninitialised fortran arguments (using derived type initialisation) requires disallowing petsc fortran objects in common blocks. So this merge sticks with the workarounds.

Other changes in this merge:
* remove petsc33 testharness tests as petsc <v3.4 is no longer supported and other small cleanups
associated with older petsc versions.
* removing some erronous cruft from configure
*  although a very simple test of petsc fortran modules was run in our configure (which prior to v3.8
decides whether the fortran modules are "functional", i.e. not compiled with a different fortran compiler)
the longer test was unintentionally not using modules. From petsc v3.8, petsc fortran modules are required and the --disable-petsc-fortran-modules fluidity configure option is no longer supported (icw petsc 3.8)
* removing previous workarounds to do with bugs in MatGetInfo and PETSC_NULL_OBJECT
* PCGAMGSetThreshold is changed (and PCGAMGSetThreshold is added), need to discuss possibly better default for Stokes. For now attempted to keep the same.
