### PR TITLE
VTK Fortan MPI communication: Version --> 7

### DIFF
--- a/configure
+++ b/configure
@@ -15838,7 +15838,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#if VTK_MAJOR_VERSION>7
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/configure
+++ b/configure
@@ -15838,7 +15838,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>7
+#if VTK_MAJOR_VERSION>6
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/configure.in
+++ b/configure.in
@@ -1685,7 +1685,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#if VTK_MAJOR_VERSION>7 
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/configure.in
+++ b/configure.in
@@ -1685,7 +1685,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>7 
+#if VTK_MAJOR_VERSION>6 
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure
+++ b/libvtkfortran/configure
@@ -7563,7 +7563,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>7
+#if VTK_MAJOR_VERSION>6
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure
+++ b/libvtkfortran/configure
@@ -7563,7 +7563,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6
+#if VTK_MAJOR_VERSION>7
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure
+++ b/libvtkfortran/configure
@@ -682,6 +682,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -766,6 +767,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1018,6 +1020,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1155,7 +1166,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1308,6 +1319,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -7551,7 +7563,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#if VTK_MAJOR_VERSION>6
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure.in
+++ b/libvtkfortran/configure.in
@@ -460,7 +460,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>7
+#if VTK_MAJOR_VERSION>6
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure.in
+++ b/libvtkfortran/configure.in
@@ -460,7 +460,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6
+#if VTK_MAJOR_VERSION>7
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/configure.in
+++ b/libvtkfortran/configure.in
@@ -460,7 +460,7 @@ cat > include/vtk.h <<EOF
 #include <${vtk_header_relative_path}vtkXMLUnstructuredGridWriter.h>
 #include <${vtk_header_relative_path}vtkZLibDataCompressor.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#if VTK_MAJOR_VERSION>6
 #include <${vtk_header_relative_path}vtkMPIController.h>
 #include <${vtk_header_relative_path}vtkMPICommunicator.h>
 #endif

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -37,7 +37,7 @@
 
 #include <vtk.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
+#if VTK_MAJOR_VERSION>6
 #define VTK_USES_MPI 1
 #endif
 

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -37,7 +37,7 @@
 
 #include <vtk.h>
 
-#if VTK_MAJOR_VERSION>7
+#if VTK_MAJOR_VERSION>6
 #define VTK_USES_MPI 1
 #endif
 

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -37,7 +37,7 @@
 
 #include <vtk.h>
 
-#if VTK_MAJOR_VERSION>6
+#if VTK_MAJOR_VERSION>7
 #define VTK_USES_MPI 1
 #endif
 


### PR DESCRIPTION
VTK introduced the MPI communication after, rather than before, version 6.3. Fix this by checking for VTK_MAJOR_VERSION > 6 (and excluding minor version checks). Tested locally but should probably go through buildbot. @tmbgreaves could you set up a buildbot and trigger it? If all goes green, I'm hoping @jrper can quickly check, approve and merge. 