### PR TITLE
Switching C++ to C MPI bindings for compatibility with OpenMPI > v2.0

### DIFF
--- a/assemble/tests/test_main.cpp
+++ b/assemble/tests/test_main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
   set_global_debug_level_fc(&val);
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   PetscFinalize();
 #endif
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/debug/C++_Debug.cpp
+++ b/debug/C++_Debug.cpp
@@ -84,7 +84,7 @@ void FLAbort(const char *ErrorStr, const char *FromFile, int LineNumber){
   
   cerr<<"Error is terminal.";
 #ifdef HAVE_MPI
-  MPI::COMM_WORLD.Abort(MPI::ERR_OTHER);
+  MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER);
 #endif
 }
 
@@ -95,7 +95,7 @@ void FLExit(const char *ErrorStr, const char *FromFile, int LineNumber){
 #endif
       <<"Error message: "<<ErrorStr<<endl;
 #ifdef HAVE_MPI
-  MPI::COMM_WORLD.Abort(MPI::ERR_OTHER);
+  MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER);
 #endif
 }
 

--- a/error_measures/tests/test_main.cpp
+++ b/error_measures/tests/test_main.cpp
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();

--- a/error_measures/tests/test_main.cpp
+++ b/error_measures/tests/test_main.cpp
@@ -51,13 +51,14 @@ int main(int argc, char **argv) {
   val = 0;
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();
@@ -65,7 +66,7 @@ int main(int argc, char **argv) {
   PetscFinalize();
 #endif
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/femtools/tests/test_main.cpp
+++ b/femtools/tests/test_main.cpp
@@ -57,13 +57,14 @@ int main(int argc, char **argv)
   set_global_debug_level_fc(&val);
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   
@@ -81,7 +82,7 @@ int main(int argc, char **argv)
   PetscFinalize();
 #endif
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/femtools/tests/test_main.cpp
+++ b/femtools/tests/test_main.cpp
@@ -64,7 +64,6 @@ int main(int argc, char **argv)
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   

--- a/horizontal_adaptivity/tests/test_main.cpp
+++ b/horizontal_adaptivity/tests/test_main.cpp
@@ -51,18 +51,19 @@ int main(int argc, char **argv) {
   val = 0;
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/horizontal_adaptivity/tests/test_main.cpp
+++ b/horizontal_adaptivity/tests/test_main.cpp
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   TESTNAME();

--- a/libadaptivity/adapt3d/src/Adaptivity.cpp
+++ b/libadaptivity/adapt3d/src/Adaptivity.cpp
@@ -469,8 +469,9 @@ int Adaptivity::getNProcessors() const{
   if(verbose)
     cout<<"int Adaptivity::getNProcessors() const\n";
 #ifdef HAVE_MPI
-  if(MPI::Is_initialized()){
-    return MPI::COMM_WORLD.Get_size();
+  int init_flag,size;
+  if(MPI_Initialized(&init_flag)){
+    return MPI_Comm_size(MPI_COMM_WORLD,&size);
   }
 #endif
   return 1;

--- a/libadaptivity/load_balance/include/MI5.h
+++ b/libadaptivity/load_balance/include/MI5.h
@@ -50,8 +50,8 @@ class MI5{
  private:
   unsigned __nnodes;
   unsigned __nelems;
-  unsigned MyRank;
-  unsigned NProcs;
+  int MyRank;
+  int NProcs;
   
   // Given a node number, keep a list of partitions that 
   // already know its particulars.

--- a/libadaptivity/load_balance/include/NodeVector.h
+++ b/libadaptivity/load_balance/include/NodeVector.h
@@ -79,6 +79,7 @@ class NodeVector: public std::deque<NodeType>{
 
  private:
   int MyRank;
+  int init_flag;
   
   bool complete_unn2gnn;
   bool complete_pcnt;
@@ -90,8 +91,11 @@ class NodeVector: public std::deque<NodeType>{
 template<class NodeType>
 NodeVector<NodeType>::NodeVector(){
 #ifdef HAVE_MPI
-  if( MPI::Is_initialized() ){
-    MyRank = MPI::COMM_WORLD.Get_rank();
+
+  MPI_Initialized(&init_flag);
+
+  if(init_flag){
+    MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
   }else{
     MyRank = 0;
   }
@@ -158,7 +162,7 @@ void NodeVector<NodeType>::push_back(const NodeType& node){
   
   // Update count
   len++;
-  if( MPI::Is_initialized() ){
+  if(init_flag){
     if( ((unsigned)node.get_owner()) == (unsigned)(MyRank) )
       plen++;
   }
@@ -281,7 +285,8 @@ template<class NodeType>
 void NodeVector<NodeType>::refresh_pcnt(){
 #ifdef HAVE_MPI
   plen = 0;
-  if( MPI::Is_initialized() ){
+
+  if(init_flag){
     for(typename NodeVector<NodeType>::iterator it = this->begin(); it != this->end(); ++it){
       if( (*it).get_owner() == (unsigned)(MyRank))
 	plen++;

--- a/libadaptivity/load_balance/include/comTools.h
+++ b/libadaptivity/load_balance/include/comTools.h
@@ -107,7 +107,7 @@ void allSendRecv(std::vector< std::vector<T> >& inout){
   // Send
   for(size_t p=0;p<NProcs;p++){
     if(send_count[p]){
-      MPI_Isend(&(inout[p][0]), send_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &sendRequest[p]);
+      MPI_Isend(&(inout[p][0]), send_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &(sendRequest[p]));
     }
   }
   
@@ -118,7 +118,7 @@ void allSendRecv(std::vector< std::vector<T> >& inout){
       recvBuffer[p].resize(recv_count[p]);
       
       // initiate non-blocking receive
-      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &recvRequest[p]);
+      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &(recvRequest[p]));
     }
   }
   MPI_Waitall(NProcs, &(sendRequest[0]), MPI_STATUSES_IGNORE); // Wait all sends
@@ -228,8 +228,7 @@ void allSendRecv(const std::vector< std::vector<T> >& sendBuffer,
   // Send
   for(size_t p=0;p<NProcs;p++){
     if(send_count[p]){
-      //sendRequest[p]=MPI_COMM_WORLD.Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1);
-      MPI_Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1,MPI_COMM_WORLD, &sendRequest[p]);
+      MPI_Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1,MPI_COMM_WORLD, &(sendRequest[p]));
     }
   }
 
@@ -240,7 +239,7 @@ void allSendRecv(const std::vector< std::vector<T> >& sendBuffer,
       recvBuffer[p].resize(recv_count[p]);
       
       // initiate non-blocking receive
-      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &recvRequest[p]);
+      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &(recvRequest[p]));
     }
   }
 

--- a/libadaptivity/load_balance/include/comTools.h
+++ b/libadaptivity/load_balance/include/comTools.h
@@ -40,8 +40,9 @@
 // In-place send-receive.
 template<class T>
 void allSendRecv(std::vector< std::vector<T> >& inout){
-  size_t MyRank = MPI::COMM_WORLD.Get_rank();
-  size_t NProcs = MPI::COMM_WORLD.Get_size();
+  int MyRank, NProcs;
+  MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   assert(NProcs == inout.size());
   
   // Inform all process how much data they are receiving from every
@@ -52,61 +53,61 @@ void allSendRecv(std::vector< std::vector<T> >& inout){
   for(size_t p=0;p<NProcs;p++){
     send_count[p] = inout[p].size();
   }
-  MPI::COMM_WORLD.Alltoall(&(send_count[0]), 1, MPI::INT,
-                           &(recv_count[0]), 1, MPI::INT);
+  MPI_Alltoall(&(send_count[0]), 1, MPI_INT,
+               &(recv_count[0]), 1, MPI_INT, MPI_COMM_WORLD);
 
   // Receiving buffer space.
   std::vector< std::vector<T> > recvBuffer(NProcs);
 
   // MPI_Status sendStatus, recvStatus;
-  std::vector<MPI::Request> sendRequest(NProcs, MPI::REQUEST_NULL);
-  std::vector<MPI::Request> recvRequest(NProcs, MPI::REQUEST_NULL);
-  MPI::Status recvStatus;
+  std::vector<MPI_Request> sendRequest(NProcs, MPI_REQUEST_NULL);
+  std::vector<MPI_Request> recvRequest(NProcs, MPI_REQUEST_NULL);
+  MPI_Status recvStatus;
 
   // Determine the MPI datatype on the fly.
-  MPI::Datatype mpi_type;
+  MPI_Datatype mpi_type;
   if(typeid(T) == typeid(signed char)){
-    mpi_type =  MPI::CHAR;
+    mpi_type =  MPI_CHAR;
   }else if(typeid(T) == typeid(char)){
-    mpi_type =  MPI::CHAR;
+    mpi_type =  MPI_CHAR;
   }else if(typeid(T) == typeid(signed short int)){
-    mpi_type =  MPI::SHORT;
+    mpi_type =  MPI_SHORT;
   }else if(typeid(T) == typeid(signed int)){
-    mpi_type =  MPI::INT;
+    mpi_type =  MPI_INT;
   }else if(typeid(T) == typeid(int)){
-    mpi_type =  MPI::INT;
+    mpi_type =  MPI_INT;
   }else if(typeid(T) == typeid(signed long int)){
-    mpi_type =  MPI::LONG;
+    mpi_type =  MPI_LONG;
   }else if(typeid(T) == typeid(long)){
-    mpi_type =  MPI::LONG;
+    mpi_type =  MPI_LONG;
   }else if(typeid(T) == typeid(unsigned char)){
-    mpi_type =  MPI::UNSIGNED_CHAR;
+    mpi_type =  MPI_UNSIGNED_CHAR;
   }else if(typeid(T) == typeid(unsigned short int)){
-    mpi_type =  MPI::UNSIGNED_SHORT;
+    mpi_type =  MPI_UNSIGNED_SHORT;
   }else if(typeid(T) == typeid(unsigned int)){
-    mpi_type =  MPI::UNSIGNED;
+    mpi_type =  MPI_UNSIGNED;
   }else if(typeid(T) == typeid(unsigned)){
-    mpi_type =  MPI::UNSIGNED;
+    mpi_type =  MPI_UNSIGNED;
   }else if(typeid(T) == typeid(unsigned long int)){
-    mpi_type =  MPI::UNSIGNED_LONG;
+    mpi_type =  MPI_UNSIGNED_LONG;
   }else if(typeid(T) == typeid(float)){
-    mpi_type =  MPI::FLOAT;
+    mpi_type =  MPI_FLOAT;
   }else if(typeid(T) == typeid(double)){
-    mpi_type =  MPI::DOUBLE;
+    mpi_type =  MPI_DOUBLE;
   }else if(typeid(T) == typeid(long double)){
-    mpi_type =  MPI::LONG_DOUBLE;
+    mpi_type =  MPI_LONG_DOUBLE;
   }else{
     std::cerr << "ERROR: illegal type " << typeid(T).name()
               << " passed into allSendRecv(std::vector< std::vector<T> >& inout)"
               << std::endl;
-    MPI::COMM_WORLD.Abort(-1);
+    MPI_Abort(MPI_COMM_WORLD,-1);
   }
-  const MPI::Datatype const_mpi_type = mpi_type;
+  const MPI_Datatype const_mpi_type = mpi_type;
   
   // Send
   for(size_t p=0;p<NProcs;p++){
     if(send_count[p]){
-      sendRequest[p] = MPI::COMM_WORLD.Isend(&(inout[p][0]), send_count[p], const_mpi_type, p, 1);
+      MPI_Isend(&(inout[p][0]), send_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &sendRequest[p]);
     }
   }
   
@@ -117,11 +118,11 @@ void allSendRecv(std::vector< std::vector<T> >& inout){
       recvBuffer[p].resize(recv_count[p]);
       
       // initiate non-blocking receive
-      recvRequest[p]=MPI::COMM_WORLD.Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1);
+      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &recvRequest[p]);
     }
   }
-  MPI::Request::Waitall(NProcs, &(sendRequest[0])); // Wait all sends
-  MPI::Request::Waitall(NProcs, &(recvRequest[0])); // Wait all receives
+  MPI_Waitall(NProcs, &(sendRequest[0]), MPI_STATUSES_IGNORE); // Wait all sends
+  MPI_Waitall(NProcs, &(recvRequest[0]), MPI_STATUSES_IGNORE); // Wait all receives
 
   inout.swap(recvBuffer);
  
@@ -161,51 +162,52 @@ void allSendRecv(std::vector< std::set<T> >& inout){
 template<class T>
 void allSendRecv(const std::vector< std::vector<T> >& sendBuffer, 
 		 std::vector< std::vector<T> >& recvBuffer){
-  size_t MyRank = MPI::COMM_WORLD.Get_rank();
+  int MyRank; 
+  MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
   size_t NProcs = sendBuffer.size();
   recvBuffer.clear();
   recvBuffer.resize(NProcs);
   
   // Determine the MPI datatype on the fly.
-  MPI::Datatype mpi_type;
+  MPI_Datatype mpi_type;
 
   if(typeid(T) == typeid(signed char)){
-    mpi_type =  MPI::CHAR;
+    mpi_type =  MPI_CHAR;
   }else if(typeid(T) == typeid(char)){
-    mpi_type =  MPI::CHAR;
+    mpi_type =  MPI_CHAR;
   }else if(typeid(T) == typeid(signed short int)){
-    mpi_type =  MPI::SHORT;
+    mpi_type =  MPI_SHORT;
   }else if(typeid(T) == typeid(signed int)){
-    mpi_type =  MPI::INT;
+    mpi_type =  MPI_INT;
   }else if(typeid(T) == typeid(int)){
-    mpi_type =  MPI::INT;
+    mpi_type =  MPI_INT;
   }else if(typeid(T) == typeid(signed long int)){
-    mpi_type =  MPI::LONG;
+    mpi_type =  MPI_LONG;
   }else if(typeid(T) == typeid(long)){
-    mpi_type =  MPI::LONG;
+    mpi_type =  MPI_LONG;
   }else if(typeid(T) == typeid(unsigned char)){
-    mpi_type =  MPI::UNSIGNED_CHAR;
+    mpi_type =  MPI_UNSIGNED_CHAR;
   }else if(typeid(T) == typeid(unsigned short int)){
-    mpi_type =  MPI::UNSIGNED_SHORT;
+    mpi_type =  MPI_UNSIGNED_SHORT;
   }else if(typeid(T) == typeid(unsigned int)){
-    mpi_type =  MPI::UNSIGNED;
+    mpi_type =  MPI_UNSIGNED;
   }else if(typeid(T) == typeid(unsigned)){
-    mpi_type =  MPI::UNSIGNED;
+    mpi_type =  MPI_UNSIGNED;
   }else if(typeid(T) == typeid(unsigned long int)){
-    mpi_type =  MPI::UNSIGNED_LONG;
+    mpi_type =  MPI_UNSIGNED_LONG;
   }else if(typeid(T) == typeid(float)){
-    mpi_type =  MPI::FLOAT;
+    mpi_type =  MPI_FLOAT;
   }else if(typeid(T) == typeid(double)){
-    mpi_type =  MPI::DOUBLE;
+    mpi_type =  MPI_DOUBLE;
   }else if(typeid(T) == typeid(long double)){
-    mpi_type =  MPI::LONG_DOUBLE;
+    mpi_type =  MPI_LONG_DOUBLE;
   }else{
     std::cerr << "ERROR: illegal type " << typeid(T).name()
               << " passed into allSendRecv(std::vector< std::vector<T> >& inout)"
               << std::endl;
     exit(-1);
   }  
-  const MPI::Datatype const_mpi_type = mpi_type;
+  const MPI_Datatype const_mpi_type = mpi_type;
 
   // Inform all process how much data they are receiving from every
   // other process. This is implemented using MPI_Alltoall because
@@ -215,18 +217,19 @@ void allSendRecv(const std::vector< std::vector<T> >& sendBuffer,
   for(size_t p=0;p<NProcs;p++){
     send_count[p] = sendBuffer[p].size();
   }
-  MPI::COMM_WORLD.Alltoall(&(send_count[0]), 1, MPI::INT,
-                           &(recv_count[0]), 1, MPI::INT);
+  MPI_Alltoall(&(send_count[0]), 1, MPI_INT,
+                           &(recv_count[0]), 1, MPI_INT, MPI_COMM_WORLD);
   
   // MPI_Status sendStatus, recvStatus;
-  std::vector<MPI::Request> sendRequest(NProcs, MPI::REQUEST_NULL);
-  std::vector<MPI::Request> recvRequest(NProcs, MPI::REQUEST_NULL);
-  MPI::Status recvStatus;
+  std::vector<MPI_Request> sendRequest(NProcs, MPI_REQUEST_NULL);
+  std::vector<MPI_Request> recvRequest(NProcs, MPI_REQUEST_NULL);
+  MPI_Status recvStatus;
   
   // Send
   for(size_t p=0;p<NProcs;p++){
     if(send_count[p]){
-      sendRequest[p]=MPI::COMM_WORLD.Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1);
+      //sendRequest[p]=MPI_COMM_WORLD.Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1);
+      MPI_Isend(&(sendBuffer[p][0]), send_count[p], const_mpi_type, p, 1,MPI_COMM_WORLD, &sendRequest[p]);
     }
   }
 
@@ -237,13 +240,12 @@ void allSendRecv(const std::vector< std::vector<T> >& sendBuffer,
       recvBuffer[p].resize(recv_count[p]);
       
       // initiate non-blocking receive
-      recvRequest[p]=MPI::COMM_WORLD.Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1);
+      MPI_Irecv(&(recvBuffer[p][0]), recv_count[p], const_mpi_type, p, 1, MPI_COMM_WORLD, &recvRequest[p]);
     }
   }
 
-  MPI::Request::Waitall(NProcs, &(sendRequest[0])); // Wait all sends
-  MPI::Request::Waitall(NProcs, &(recvRequest[0])); // Wait all receives
-  
+  MPI_Waitall(NProcs, &(sendRequest[0]), MPI_STATUSES_IGNORE); // Wait all sends
+  MPI_Waitall(NProcs, &(recvRequest[0]), MPI_STATUSES_IGNORE); // Wait all receives
   return;
 }
 

--- a/libadaptivity/load_balance/include/packing.h
+++ b/libadaptivity/load_balance/include/packing.h
@@ -39,8 +39,8 @@
 
 class packing{
  private:
-  unsigned int NProcs;
-  unsigned int MyRank;
+  int NProcs;
+  int MyRank;
   unsigned int __nnodes;
   unsigned int __nelems;
 

--- a/libadaptivity/load_balance/include/samtypes.h
+++ b/libadaptivity/load_balance/include/samtypes.h
@@ -43,14 +43,14 @@ typedef unsigned unn_t;      // Universal Node Number.
 typedef unsigned gnn_t;      // Global (partition) Node Number.
 typedef unsigned eid_t;      // Element ID number
 
-#define UNN_T UNSIGNED
-#define GNN_T UNSIGNED
-#define EID_T UNSIGNED
+#define UNN_T MPI_UNSIGNED
+#define GNN_T MPI_UNSIGNED
+#define EID_T MPI_UNSIGNED
 
 #ifdef USING_DOUBLE_PRECISION
-#define SAMFLOAT DOUBLE
+#define SAMFLOAT MPI_DOUBLE
 #else
-#define SAMFLOAT FLOAT
+#define SAMFLOAT MPI_FLOAT
 #endif
 
 #endif

--- a/libadaptivity/load_balance/src/MI5.cpp
+++ b/libadaptivity/load_balance/src/MI5.cpp
@@ -41,8 +41,6 @@ MI5::MI5(int nnodes, int nelems){
   __nnodes = nnodes;
   __nelems = nelems;
 
-  int MyRank, NProcs;
-
   MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
   MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   

--- a/libadaptivity/load_balance/src/MI5.cpp
+++ b/libadaptivity/load_balance/src/MI5.cpp
@@ -40,8 +40,11 @@ using namespace std;
 MI5::MI5(int nnodes, int nelems){
   __nnodes = nnodes;
   __nelems = nelems;
-  MyRank   = MPI::COMM_WORLD.Get_rank();
-  NProcs   = MPI::COMM_WORLD.Get_size();
+
+  int MyRank, NProcs;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   
   nodeKnowers.resize( __nnodes );
   nodeKnowers_next.resize( __nnodes );

--- a/libadaptivity/load_balance/src/Mesh.cpp
+++ b/libadaptivity/load_balance/src/Mesh.cpp
@@ -389,8 +389,7 @@ void Mesh::halo_update(const vector< vector<int> >& data_in, vector< vector<int>
       RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{
       data_out[i].resize(cnt);
-      MPI_Irecv(&(data_out[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
-      //RecvRequest[i] = recieve
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &(RecvRequest[i]));
     }
   }
   
@@ -402,7 +401,7 @@ void Mesh::halo_update(const vector< vector<int> >& data_in, vector< vector<int>
     if((i==MyRank)||(cnt==0)){
       SendRequest[i] =  MPI_REQUEST_NULL;
     }else{    
-      MPI_Isend(&(data_in[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &(SendRequest[i]));
     }
   }
   
@@ -436,7 +435,7 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, vector< vector
       RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{    
       data_out[i].resize( cnt );
-      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &(RecvRequest[i]));
     }
   }
   
@@ -448,7 +447,7 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, vector< vector
     if((i==MyRank)||(cnt==0)){
       SendRequest[i] =  MPI_REQUEST_NULL;
     }else{    
-      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &(SendRequest[i]));
     }
   }
   
@@ -483,7 +482,7 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, const vector<u
       RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{
       data_out[i].resize(cnt);
-      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &(RecvRequest[i]));
     }
 
   }
@@ -496,7 +495,7 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, const vector<u
     if((i==MyRank)||(cnt==0)){
       SendRequest[i] =  MPI_REQUEST_NULL;
     }else{
-      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &(SendRequest[i]));
     }
   }
 
@@ -529,7 +528,7 @@ void Mesh::halo_update(const vector< vector<samfloat_t> >& data_in, vector< vect
       RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{    
       data_out[i].resize( cnt );
-      MPI_Irecv(&(data_out[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
+      MPI_Irecv(&(data_out[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &(RecvRequest[i]));
     }
   }
   
@@ -542,7 +541,7 @@ void Mesh::halo_update(const vector< vector<samfloat_t> >& data_in, vector< vect
       SendRequest[i] =  MPI_REQUEST_NULL;
       continue;
     }else{
-      MPI_Isend(&(data_in[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
+      MPI_Isend(&(data_in[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &(SendRequest[i]));
     }
   }
 

--- a/libadaptivity/load_balance/src/Mesh.cpp
+++ b/libadaptivity/load_balance/src/Mesh.cpp
@@ -54,10 +54,12 @@ Mesh::Mesh(){
   __num_elements_surface  = 0;
 
   dimension = -1;
-  
-  if(MPI::Is_initialized()){
-    MyRank = MPI::COMM_WORLD.Get_rank();
-    NProcs = MPI::COMM_WORLD.Get_size();
+ 
+  int init_flag; 
+  MPI_Initialized(&init_flag);
+  if(init_flag){
+    MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   }else{
     MyRank = 0;
     NProcs = 1;
@@ -284,11 +286,13 @@ unsigned Mesh::num_nodes_halo(const unsigned proc){
 }
 
 void Mesh::find_nodes_per_rank(const unsigned lcnt){
-  if( MPI::Is_initialized() ){
+  int init_flag;
+
+  if(init_flag){
     nodes_per_rank.resize( NProcs );
     
     for(int i = 0; i<NProcs; i++)
-      MPI::COMM_WORLD.Gather(&lcnt, 1, MPI::INT, &(nodes_per_rank[0]), 1, MPI::INT, i);
+      MPI_Gather(&lcnt, 1, MPI_INT, &(nodes_per_rank[0]), 1, MPI_INT, i, MPI_COMM_WORLD);
     
   }else{ // Not running MPI.
     nodes_per_rank.resize(1);
@@ -377,32 +381,33 @@ void Mesh::halo_update(const vector< vector<int> >& data_in, vector< vector<int>
   }
   
   // setup non-blocking receives
-  vector<MPI::Request> RecvRequest(NProcs);
+  vector<MPI_Request> RecvRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_halo(i);
     
     if((i==MyRank)||(cnt==0)){
-      RecvRequest[i] =  MPI::REQUEST_NULL;
+      RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{
       data_out[i].resize(cnt);
-      RecvRequest[i] = MPI::COMM_WORLD.Irecv(&(data_out[i][0]), cnt, MPI::INT, i, 13);
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
+      //RecvRequest[i] = recieve
     }
   }
   
   // setup non-blocking sends
-  vector<MPI::Request> SendRequest(NProcs);
+  vector<MPI_Request> SendRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_shared(i);
 
     if((i==MyRank)||(cnt==0)){
-      SendRequest[i] =  MPI::REQUEST_NULL;
+      SendRequest[i] =  MPI_REQUEST_NULL;
     }else{    
-      SendRequest[i] = MPI::COMM_WORLD.Isend(&(data_in[i][0]), cnt, MPI::INT, i, 13);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_INT, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
     }
   }
   
-  MPI::Request::Waitall(NProcs, &(RecvRequest[0]));
-  MPI::Request::Waitall(NProcs, &(SendRequest[0]));
+  MPI_Waitall(NProcs, &(RecvRequest[0]),MPI_STATUSES_IGNORE);
+  MPI_Waitall(NProcs, &(SendRequest[0]),MPI_STATUSES_IGNORE);
   
 }
 // Updata all halo values stored in data_in
@@ -423,32 +428,32 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, vector< vector
   }
   
   // setup non-blocking receives
-  vector<MPI::Request> RecvRequest(NProcs);
+  vector<MPI_Request> RecvRequest(NProcs);
   for(int i=0;i<NProcs;i++){
     int cnt = stride*num_nodes_halo(i);
 
     if((i==MyRank)||(cnt==0)){
-      RecvRequest[i] =  MPI::REQUEST_NULL;
+      RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{    
       data_out[i].resize( cnt );
-      RecvRequest[i] = MPI::COMM_WORLD.Irecv(&(data_out[i][0]), cnt, MPI::UNSIGNED, i, 13);
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
     }
   }
   
   // setup non-blocking sends
-  vector<MPI::Request> SendRequest(NProcs);
+  vector<MPI_Request> SendRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_shared(i);
 
     if((i==MyRank)||(cnt==0)){
-      SendRequest[i] =  MPI::REQUEST_NULL;
+      SendRequest[i] =  MPI_REQUEST_NULL;
     }else{    
-      SendRequest[i] = MPI::COMM_WORLD.Isend(&(data_in[i][0]), cnt, MPI::UNSIGNED, i, 13);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
     }
   }
   
-  MPI::Request::Waitall(NProcs, &(RecvRequest[0]));
-  MPI::Request::Waitall(NProcs, &(SendRequest[0]));
+  MPI_Waitall(NProcs, &(RecvRequest[0]), MPI_STATUSES_IGNORE);
+  MPI_Waitall(NProcs, &(SendRequest[0]), MPI_STATUSES_IGNORE);
   
 }
 // Updata all halo values stored in data_in
@@ -470,33 +475,33 @@ void Mesh::halo_update(const vector< vector<unsigned> >& data_in, const vector<u
   }
     
   // setup non-blocking receives
-  vector<MPI::Request> RecvRequest(NProcs);
+  vector<MPI_Request> RecvRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*data_cnt[i];
     
     if((i==MyRank)||(cnt==0)){
-      RecvRequest[i] =  MPI::REQUEST_NULL;
+      RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{
       data_out[i].resize(cnt);
-      RecvRequest[i] = MPI::COMM_WORLD.Irecv(&(data_out[i][0]), cnt, MPI::UNSIGNED, i, 13);
+      MPI_Irecv(&(data_out[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
     }
 
   }
   
   // setup non-blocking sends
-  vector<MPI::Request> SendRequest(NProcs);
+  vector<MPI_Request> SendRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_shared(i);
     
     if((i==MyRank)||(cnt==0)){
-      SendRequest[i] =  MPI::REQUEST_NULL;
+      SendRequest[i] =  MPI_REQUEST_NULL;
     }else{
-      SendRequest[i] = MPI::COMM_WORLD.Isend(&(data_in[i][0]), cnt, MPI::UNSIGNED, i, 13);
+      MPI_Isend(&(data_in[i][0]), cnt, MPI_UNSIGNED, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
     }
   }
-  
-  MPI::Request::Waitall(NProcs, &(RecvRequest[0]));
-  MPI::Request::Waitall(NProcs, &(SendRequest[0]));
+
+  MPI_Waitall(NProcs, &(RecvRequest[0]), MPI_STATUSES_IGNORE);
+  MPI_Waitall(NProcs, &(SendRequest[0]), MPI_STATUSES_IGNORE);  
   
 }
 void Mesh::halo_update(const vector< vector<samfloat_t> >& data_in, vector< vector<samfloat_t> >& data_out){
@@ -516,33 +521,33 @@ void Mesh::halo_update(const vector< vector<samfloat_t> >& data_in, vector< vect
   }
   
   // setup non-blocking receives
-  vector<MPI::Request> RecvRequest(NProcs);
+  vector<MPI_Request> RecvRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_halo(i);
     
     if((cnt==0)||(i==MyRank)){
-      RecvRequest[i] =  MPI::REQUEST_NULL;
+      RecvRequest[i] =  MPI_REQUEST_NULL;
     }else{    
       data_out[i].resize( cnt );
-      RecvRequest[i] = MPI::COMM_WORLD.Irecv(&(data_out[i][0]), cnt, MPI::SAMFLOAT, i, 13);
+      MPI_Irecv(&(data_out[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &RecvRequest[i]);
     }
   }
   
   // setup non-blocking sends
-  vector<MPI::Request> SendRequest(NProcs);
+  vector<MPI_Request> SendRequest(NProcs);
   for(int i = 0; i<NProcs; i++){
     int cnt = stride*num_nodes_shared(i);
     
     if((cnt==0)||(i==MyRank)){
-      SendRequest[i] =  MPI::REQUEST_NULL;
+      SendRequest[i] =  MPI_REQUEST_NULL;
       continue;
     }else{
-      SendRequest[i] = MPI::COMM_WORLD.Isend(&(data_in[i][0]), cnt, MPI::SAMFLOAT, i, 13);
+      MPI_Isend(&(data_in[i][0]), cnt, SAMFLOAT, i, 13, MPI_COMM_WORLD, &SendRequest[i]);
     }
   }
-  
-  MPI::Request::Waitall(NProcs, &(RecvRequest[0]));
-  MPI::Request::Waitall(NProcs, &(SendRequest[0]));
+
+  MPI_Waitall(NProcs, &(RecvRequest[0]), MPI_STATUSES_IGNORE);
+  MPI_Waitall(NProcs, &(SendRequest[0]), MPI_STATUSES_IGNORE);  
   
 }
 

--- a/libadaptivity/load_balance/src/Mesh.cpp
+++ b/libadaptivity/load_balance/src/Mesh.cpp
@@ -287,7 +287,7 @@ unsigned Mesh::num_nodes_halo(const unsigned proc){
 
 void Mesh::find_nodes_per_rank(const unsigned lcnt){
   int init_flag;
-
+  MPI_Initialized(&init_flag);
   if(init_flag){
     nodes_per_rank.resize( NProcs );
     

--- a/libadaptivity/load_balance/src/Node.cpp
+++ b/libadaptivity/load_balance/src/Node.cpp
@@ -314,80 +314,81 @@ unsigned                     Node::get_size_metric() const{
 }
 
 void Node::pack(char *buffer, int& bsize, int& offset) const{
-  MPI::UNN_T.Pack(&unn, 1, buffer, bsize, offset, MPI::COMM_WORLD);
-  MPI::GNN_T.Pack(&gnn, 1, buffer, bsize, offset, MPI::COMM_WORLD);
-  MPI::UNSIGNED_CHAR.Pack(&flags,  1, buffer, bsize, offset, MPI::COMM_WORLD);
-  MPI::UNSIGNED_SHORT.Pack(owner,  2, buffer, bsize, offset, MPI::COMM_WORLD);
+  MPI_Pack(&unn, 1, UNN_T, buffer, bsize, &offset, MPI_COMM_WORLD);
+  MPI_Pack(&gnn, 1, GNN_T, buffer, bsize, &offset, MPI_COMM_WORLD);
+  MPI_Pack(&flags,  1, MPI_UNSIGNED_CHAR, buffer, bsize, &offset, MPI_COMM_WORLD);
+  MPI_Pack(&owner,  2, MPI_UNSIGNED_SHORT, buffer, bsize, &offset, MPI_COMM_WORLD);
   
   { // Pack ifields.
     unsigned nifields = ifields.size();      
-    MPI::UNSIGNED.Pack(&nifields, 1, buffer, bsize, offset, MPI::COMM_WORLD);
+    MPI_Pack(&nifields, 1, MPI_UNSIGNED, buffer, bsize, &offset, MPI_COMM_WORLD);
     if(nifields>0)
-      MPI::INT.Pack(&(ifields[0]), nifields, buffer, bsize, offset, MPI::COMM_WORLD);
+      MPI_Pack(&(ifields[0]), nifields,MPI_INT, buffer, bsize, &offset, MPI_COMM_WORLD);
+
   }
 
   { // Pack fields.
     unsigned nfields = fields.size();      
-    MPI::UNSIGNED.Pack(&nfields,       1,       buffer, bsize, offset, MPI::COMM_WORLD);
+    MPI_Pack(&nfields, 1, MPI_UNSIGNED, buffer, bsize, &offset, MPI_COMM_WORLD);
     if(nfields>0)
-      MPI::SAMFLOAT.Pack(&(fields[0]), nfields, buffer, bsize, offset, MPI::COMM_WORLD);
+      MPI_Pack(&(fields[0]), nfields, SAMFLOAT, buffer, bsize, &offset, MPI_COMM_WORLD);
   }
   
   { // Pack coordinates.
     unsigned ndim = x.size();
-    MPI::UNSIGNED.Pack(&ndim, 1, buffer, bsize, offset, MPI::COMM_WORLD);
+    MPI_Pack(&ndim, 1, MPI_UNSIGNED, buffer, bsize, &offset, MPI_COMM_WORLD);
     if(ndim>0)
-      MPI::SAMFLOAT.Pack(&(x[0]), ndim, buffer, bsize, offset, MPI::COMM_WORLD);
+      MPI_Pack(&(x[0]), ndim,SAMFLOAT, buffer, bsize, &offset, MPI_COMM_WORLD);
   }
 
   { // Pack metric.
     unsigned len = metric.size();
-    MPI::UNSIGNED.Pack(&len, 1, buffer, bsize, offset, MPI::COMM_WORLD);
+    MPI_Pack(&len, 1, MPI_UNSIGNED, buffer, bsize, &offset, MPI_COMM_WORLD);
     if(len>0)
-      MPI::SAMFLOAT.Pack(&(metric[0]), len, buffer, bsize, offset, MPI::COMM_WORLD);
+      MPI_Pack(&(metric[0]), len, SAMFLOAT, buffer, bsize, &offset, MPI_COMM_WORLD);
   }
 
 }
 
 void Node::unpack(char *buffer, int& bsize, int& offset){
-  MPI::UNN_T.Unpack(buffer, bsize, &unn, 1, offset, MPI::COMM_WORLD);
-  MPI::GNN_T.Unpack(buffer, bsize, &gnn, 1, offset, MPI::COMM_WORLD );
-  MPI::UNSIGNED_CHAR.Unpack(buffer,  bsize, &flags, 1, offset, MPI::COMM_WORLD );
-  MPI::UNSIGNED_SHORT.Unpack(buffer, bsize, owner,  2, offset, MPI::COMM_WORLD );
+  MPI_Unpack(buffer, bsize, &offset, &unn, 1, UNN_T, MPI_COMM_WORLD);
+  MPI_Unpack(buffer, bsize, &offset, &gnn, 1, GNN_T, MPI_COMM_WORLD );
+  MPI_Unpack(buffer, bsize, &offset, &flags, 1, MPI_UNSIGNED, MPI_COMM_WORLD );
+  MPI_Unpack(buffer, bsize, &offset, owner, 2, MPI_UNSIGNED_SHORT, MPI_COMM_WORLD );
   
   { // Unpack ifields.
     unsigned nifields;
-    MPI::UNSIGNED.Unpack(buffer, bsize, &nifields, 1, offset, MPI::COMM_WORLD);
+    MPI_Unpack(buffer, bsize, &offset, &nifields, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
     if(nifields>0){
       ifields.resize(nifields);  
-      MPI::INT.Unpack(buffer, bsize, &(ifields[0]), nifields, offset, MPI::COMM_WORLD);
+      MPI_Unpack(buffer, bsize, &offset, &(ifields[0]), nifields, MPI_INT, MPI_COMM_WORLD);
     }
   }
 
   { // Unpack fields.
     unsigned nfields;
-    MPI::UNSIGNED.Unpack(buffer, bsize, &nfields, 1, offset, MPI::COMM_WORLD);
+    MPI_Unpack(buffer, bsize, &offset, &nfields, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
     if(nfields>0){
       fields.resize( nfields );  
-      MPI::SAMFLOAT.Unpack(buffer, bsize, &(fields[0]), nfields, offset, MPI::COMM_WORLD);
+      MPI_Unpack(buffer, bsize, &offset, &(fields[0]), nfields, SAMFLOAT, MPI_COMM_WORLD);
     }
   }
 
   { // Unpack coordinates.
     unsigned ndim;
-    MPI::UNSIGNED.Unpack(buffer, bsize, &ndim, 1, offset, MPI::COMM_WORLD);
+    MPI_Unpack(buffer, bsize, &offset, &ndim, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
     if(ndim>0){
       x.resize(ndim);
-      MPI::SAMFLOAT.Unpack(buffer, bsize, &(x[0]), ndim, offset, MPI::COMM_WORLD);
+      MPI_Unpack(buffer, bsize, &offset, &(x[0]), ndim, SAMFLOAT, MPI_COMM_WORLD);
     }
   }
 
   { // Unpack metric.
     unsigned len;
-    MPI::UNSIGNED.Unpack(buffer, bsize, &len, 1, offset, MPI::COMM_WORLD);
+    MPI_Unpack(buffer, bsize, &offset, &len, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
     if(len>0){
       metric.resize(len);
-      MPI::SAMFLOAT.Unpack(buffer, bsize, &(metric[0]), len, offset, MPI::COMM_WORLD);
+      MPI_Unpack(buffer, bsize, &offset, &(metric[0]), len, SAMFLOAT, MPI_COMM_WORLD);
     }
   }
      
@@ -395,31 +396,36 @@ void Node::unpack(char *buffer, int& bsize, int& offset){
 
 // Return an estimate of the number of bytes required to pack this guy.
 unsigned Node::pack_size() const{
-  int total=0;
+  int total=0,s1,s2,s3,s4;
   
-  total  = MPI::UNN_T.Pack_size(1, MPI::COMM_WORLD);
-  total += MPI::GNN_T.Pack_size(1, MPI::COMM_WORLD);         
-  total += MPI::UNSIGNED_CHAR.Pack_size(1, MPI::COMM_WORLD); 
-  total += MPI::UNSIGNED_SHORT.Pack_size(2, MPI::COMM_WORLD);
+  MPI_Pack_size(1, UNN_T, MPI_COMM_WORLD, &s1);
+  MPI_Pack_size(1, GNN_T, MPI_COMM_WORLD, &s2);         
+  MPI_Pack_size(1, MPI_UNSIGNED_CHAR, MPI_COMM_WORLD, &s3); 
+  MPI_Pack_size(2, MPI_UNSIGNED_SHORT, MPI_COMM_WORLD, &s4);
+  total = s1 + s2 + s3 + s4;
   {
     unsigned nifields = ifields.size();      
-    total += MPI::UNSIGNED.Pack_size(1, MPI::COMM_WORLD);      
-    total += MPI::INT.Pack_size(nifields, MPI::COMM_WORLD); 
+    MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &s1);      
+    MPI_Pack_size(nifields, MPI_INT, MPI_COMM_WORLD, &s2); 
+    total += (s1 + s2);
   }
   {
     unsigned nfields = fields.size();      
-    total += MPI::UNSIGNED.Pack_size(1, MPI::COMM_WORLD);      
-    total += MPI::SAMFLOAT.Pack_size(nfields, MPI::COMM_WORLD); 
+    total += MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &s1);      
+    total += MPI_Pack_size(nfields, SAMFLOAT, MPI_COMM_WORLD, &s2);
+    total += (s1 + s2); 
   }
   {
     unsigned ndim = x.size();
-    total += MPI::UNSIGNED.Pack_size(1, MPI::COMM_WORLD);      
-    total += MPI::SAMFLOAT.Pack_size(ndim, MPI::COMM_WORLD);       
+    MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &s1);      
+    MPI_Pack_size(ndim, SAMFLOAT, MPI_COMM_WORLD, &s2);       
+    total += (s1 + s2);
   }
   {
     unsigned len = metric.size();
-    total += MPI::UNSIGNED.Pack_size(1, MPI::COMM_WORLD);      
-    total += MPI::SAMFLOAT.Pack_size(len, MPI::COMM_WORLD);     
+    MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &s1);      
+    MPI_Pack_size(len, SAMFLOAT, MPI_COMM_WORLD, &s2);
+    total += (s1 + s2);    
   }
 
   return total;

--- a/libadaptivity/load_balance/src/ParMetis.cpp
+++ b/libadaptivity/load_balance/src/ParMetis.cpp
@@ -46,7 +46,8 @@ using namespace csr;
 
 void Graph::RepartRemap(vector<int>& vtxdist, vector<int>& noddom){
   MPI_Comm comm_world = MPI_COMM_WORLD;
-  int nparts = MPI::COMM_WORLD.Get_size();
+  int nparts;
+  MPI_Comm_size(MPI_COMM_WORLD, &nparts);
 
   int *vwgt   = NULL;
   int *adjwgt = NULL;
@@ -91,13 +92,14 @@ void Graph::Repart(vector<int>& vtxdist, vector<int>& noddom, int nparts){
   int options[4];
   int numflag = 0;
   
-  int nprocs = MPI::COMM_WORLD.Get_size();
-  int MyRank = MPI::COMM_WORLD.Get_rank();
+  int MyRank, nprocs;
+  MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
   vector<int> nnodes(nprocs, 0);
   nnodes[MyRank] = noddom.size();
   
-  MPI::COMM_WORLD.Allgather(&(nnodes[MyRank]), 1, MPI_INT, &(nnodes[0]), 1, MPI_INT);
+  MPI_Allgather(&(nnodes[MyRank]), 1, MPI_INT, &(nnodes[0]), 1, MPI_INT, MPI_COMM_WORLD);
   
   vector<int> ranks;
   for(int i=0;i<nprocs;i++){

--- a/libadaptivity/load_balance/src/c++debuglog.cpp
+++ b/libadaptivity/load_balance/src/c++debuglog.cpp
@@ -40,10 +40,13 @@ void openlog(const bool all2null){
   int MyRank;
   char filename[20];
 
+  int init_flag;
+  MPI_Initialized(&init_flag);
+
   if(all2null){
     strcpy(filename, "/dev/null");
   }else{
-    if( MPI::Is_initialized() ){
+    if(init_flag){
       MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
       sprintf(filename, "c++debuglog%06d\n", MyRank);
     }else{

--- a/libadaptivity/load_balance/src/errorHandling.cpp
+++ b/libadaptivity/load_balance/src/errorHandling.cpp
@@ -31,7 +31,7 @@
 std::string mpiErrorMessage(const int err){
   char *msg = new char [MPI_MAX_ERROR_STRING];
   int len;
-  MPI::Get_error_string(err, msg, len);
+  MPI_Error_string(err, msg, &len);
   std::string mesg(msg);
   delete [] msg;
   return mesg;

--- a/libadaptivity/load_balance/src/fixate.cpp
+++ b/libadaptivity/load_balance/src/fixate.cpp
@@ -96,7 +96,7 @@ void Mesh::fixate_elements(const unsigned paranoid_element,
 	  ECHO("Two Elements have been found to be equal! See below:");
 	  ECHO(*i);
 	  ECHO(*j);
-	  MPI::COMM_WORLD.Abort(-1);
+	  MPI_Abort(MPI_COMM_WORLD,-1);
 	} 
   }
 #endif

--- a/libadaptivity/load_balance/src/fluidity_sam.cpp
+++ b/libadaptivity/load_balance/src/fluidity_sam.cpp
@@ -218,7 +218,8 @@ extern "C"{
       }
     }
 
-    int MyRank = MPI::COMM_WORLD.Get_rank();
+    int MyRank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
 
     { // Compress volume element-node lists
       int i = 0;

--- a/libadaptivity/load_balance/src/formHalo2.cpp
+++ b/libadaptivity/load_balance/src/formHalo2.cpp
@@ -167,7 +167,8 @@ void Mesh::formHalo2(){
     unsigned max_node_size      = max_nodepack_size();
     unsigned max_pnode_size     = max_pressurepack_size();
     unsigned max_element_size   = max_elementpack_size();
-    unsigned space_for_unsigned = MPI::UNSIGNED.Pack_size(1, MPI::COMM_WORLD);
+    int space_for_unsigned;
+    MPI_Pack_size(1, MPI_UNSIGNED, MPI_COMM_WORLD, &space_for_unsigned);
     
     for(int i=0; i<NProcs; i++){
       unsigned nbytes = space_for_unsigned          +
@@ -196,8 +197,8 @@ void Mesh::formHalo2(){
     
     // Elements
     unsigned cnt = halo2Elements[i].size();
-    MPI::UNSIGNED.Pack(&cnt, 1, buff, len, offsets[i], MPI::COMM_WORLD);
-    
+    MPI_Pack(&cnt, 1, MPI_UNSIGNED, buff, len, &offsets[i], MPI_COMM_WORLD);
+
     ECHO("Packing "<<cnt<<" halo2 elements for "<<i<<".");
     for(unsigned j=0; j<cnt; j++){
 
@@ -205,15 +206,14 @@ void Mesh::formHalo2(){
       unsigned danger = 0;
       if( dangerElements.find( halo2Elements[i][j] ) != dangerElements.end() )
 	danger = 1;
-      MPI::UNSIGNED.Pack(&danger, 1, buff, len, offsets[i], MPI::COMM_WORLD);
+      MPI_Pack(&danger, 1, MPI_UNSIGNED, buff, len, &offsets[i], MPI_COMM_WORLD);
 
       // Pack element
       element_list[ halo2Elements[i][j] ].pack(buff, len, offsets[i]);
     }
     // Nodes
     cnt = sendhalo2nodes[i].size();
-    MPI::UNSIGNED.Pack(&cnt, 1, buff, len, offsets[i], MPI::COMM_WORLD);
-
+    MPI_Pack(&cnt, 1, MPI_UNSIGNED, buff, len, &offsets[i], MPI_COMM_WORLD);
     ECHO("Packing "<<cnt<<" halo2 nodes for "<<i<<".");    
     for(set<unsigned>::const_iterator it=sendhalo2nodes[i].begin(); it!=sendhalo2nodes[i].end(); ++it){
       const Node& node = node_list.unn( *it );
@@ -222,7 +222,7 @@ void Mesh::formHalo2(){
     
     // Pressure nodes
     cnt = sendhalo2pnodes[i].size();
-    MPI::UNSIGNED.Pack(&cnt, 1, buff, len, offsets[i], MPI::COMM_WORLD);
+    MPI_Pack(&cnt, 1, MPI_UNSIGNED, buff, len, &offsets[i], MPI_COMM_WORLD);
     ECHO("Packing "<<cnt<<" halo2 pressure nodes for "<<i<<".");
 
     for(set<unsigned>::const_iterator it=sendhalo2pnodes[i].begin(); it!=sendhalo2pnodes[i].end(); ++it){
@@ -273,7 +273,7 @@ void Mesh::formHalo2(){
       char *buffer = &(SendRecvBuffer[p][0]);
       { // elements
 	unsigned cnt;
-	MPI::UNSIGNED.Unpack(buffer, nbytes, &cnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &cnt, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
 	
 	ECHO("Unpacking "<<cnt<<" elements from "<<p<<".");
 	
@@ -284,7 +284,7 @@ void Mesh::formHalo2(){
 	  
 	  // Unpack danger flag.
 	  unsigned danger;
-	  MPI::UNSIGNED.Unpack(buffer, nbytes, &danger, 1, offsets[p], MPI::COMM_WORLD);
+      MPI_Unpack(buffer, nbytes, &offsets[p], &danger, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
 	  CHECK(danger);
 	  
 	  // Unpack element...      
@@ -302,7 +302,7 @@ void Mesh::formHalo2(){
       
       { // nodes
 	unsigned cnt;
-	MPI::UNSIGNED.Unpack(buffer, nbytes, &cnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &cnt, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
 	ECHO("Unpacking "<<cnt<<" nodes from "<<p<<".");
 	
 	for(unsigned j=0; j<cnt; j++){
@@ -323,7 +323,7 @@ void Mesh::formHalo2(){
       
       { // pressure nodes
 	unsigned cnt;
-	MPI::UNSIGNED.Unpack(buffer, nbytes, &cnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &cnt, 1, MPI_UNSIGNED, MPI_COMM_WORLD);
 	ECHO("Unpacking "<<cnt<<" pressure nodes from "<<p<<".");
 	
 	for(unsigned j=0; j<cnt; j++){

--- a/libadaptivity/load_balance/src/graph_partitioning.cpp
+++ b/libadaptivity/load_balance/src/graph_partitioning.cpp
@@ -106,7 +106,7 @@ std::vector<int> Mesh::decomp(const vector<int>& options){
       break;
     default:
       ERROR("Unknown option " << options[3] << " for node weights passed down into Sam. Giving up!");
-      MPI::COMM_WORLD.Abort( MPI_ERR_OP );
+      MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OP);
       break;
     }
     ECHO("Got node weights.");    
@@ -155,7 +155,7 @@ std::vector<int> Mesh::decomp(const vector<int>& options){
       break;
     default:
       ERROR("Unknown option " << options[4] << " for edge weights passed down into Sam. Giving up!");
-      MPI::COMM_WORLD.Abort( MPI_ERR_OP );
+      MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OP);
     }
     ECHO("Got edge weights.");
   }

--- a/libadaptivity/load_balance/src/packing.cpp
+++ b/libadaptivity/load_balance/src/packing.cpp
@@ -42,7 +42,6 @@ static int packing_ncalls = 0;
 
 packing::packing(const MI5& intelligance_report, const Mesh& mesh){
   
-  int MyRank, NProcs;
   MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
   MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   __nnodes = intelligance_report.nnodes();

--- a/libadaptivity/load_balance/src/packing.cpp
+++ b/libadaptivity/load_balance/src/packing.cpp
@@ -42,8 +42,9 @@ static int packing_ncalls = 0;
 
 packing::packing(const MI5& intelligance_report, const Mesh& mesh){
   
-  NProcs   = MPI::COMM_WORLD.Get_size();
-  MyRank   = MPI::COMM_WORLD.Get_rank();
+  int MyRank, NProcs;
+  MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   __nnodes = intelligance_report.nnodes();
   __nelems = intelligance_report.nelems();
   
@@ -61,7 +62,8 @@ packing::packing(const MI5& intelligance_report, const Mesh& mesh){
 
   // allocate space for the send buffers.
   size_t nbytes;
-  int _space_for_ints = MPI::INT.Pack_size(3, MPI::COMM_WORLD);
+  int _space_for_ints;
+  MPI_Pack_size(3, MPI_INT, MPI_COMM_WORLD, &_space_for_ints);
 
   for(unsigned p=0; p<NProcs; p++){
 
@@ -114,7 +116,7 @@ void packing::pack(const MI5& intelligance_report, Mesh& mesh){
 
     ECHO("Packing "<<cnt<<" nodes for "<<p);
     
-    MPI::INT.Pack(&cnt, 1, buff, len, offsets[p], MPI::COMM_WORLD);
+    MPI_Pack(&cnt, 1, MPI_INT, buff, len, &offsets[p], MPI_COMM_WORLD);
   }
   pack_nodes(intelligance_report, mesh);
   
@@ -128,7 +130,7 @@ void packing::pack(const MI5& intelligance_report, Mesh& mesh){
 
     ECHO("Packing "<<cnt<<" elements for "<<p);
     
-    MPI::INT.Pack(&cnt, 1, buff, len, offsets[p], MPI::COMM_WORLD);
+    MPI_Pack(&cnt, 1, MPI_INT, buff, len, &offsets[p], MPI_COMM_WORLD);
   }
   pack_elems(intelligance_report, mesh);
   
@@ -142,7 +144,7 @@ void packing::pack(const MI5& intelligance_report, Mesh& mesh){
     
     ECHO("Pressure "<<cnt<<" nodes for "<<p<<" buff len="<<len<<", offsets[p]="<<offsets[p]);
     
-    MPI::INT.Pack(&cnt, 1, buff, len, offsets[p], MPI::COMM_WORLD);
+    MPI_Pack(&cnt, 1, MPI_INT, buff, len, &offsets[p], MPI_COMM_WORLD);
   }
   pack_pnodes(intelligance_report, mesh);
   
@@ -250,7 +252,7 @@ void packing::unpack_nodes( MI5& intelligance_report, Mesh& mesh){
     buffer     = &(SendRecvBuffer[p][0]);
 
     // How many new nodes.
-    MPI::INT.Unpack(buffer, nbytes, &ncnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &ncnt, 1, MPI_INT, MPI_COMM_WORLD);
     
     ECHO("Unpacking " << ncnt << " nodes from " << p);
     
@@ -288,7 +290,7 @@ void packing::unpack_elems(MI5& intelligance_report, Mesh& mesh){
     buffer     = &(SendRecvBuffer[p][0]);
     
     // How many new elements.
-    MPI::INT.Unpack(buffer, nbytes, &ecnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &ecnt, 1, MPI_INT, MPI_COMM_WORLD);
 
     ECHO("Unpacking " << ecnt << " elements from " << p);
 
@@ -318,7 +320,7 @@ void packing::unpack_pnodes( MI5& intelligance_report, Mesh& mesh){
     char *buffer     = &(SendRecvBuffer[p][0]);
     
     // How many new pressure nodes.
-    MPI::INT.Unpack(buffer, nbytes, &ncnt, 1, offsets[p], MPI::COMM_WORLD);
+    MPI_Unpack(buffer, nbytes, &offsets[p], &ncnt, 1, MPI_INT, MPI_COMM_WORLD);
     
     ECHO("Unpacking " << ncnt << " pressure nodes from " << p);
     

--- a/libspud/src/tests/test_main.cpp
+++ b/libspud/src/tests/test_main.cpp
@@ -38,12 +38,12 @@ extern "C"{
 
 int main(int argc, char **argv) {
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   chdir(getenv("PWD"));
 #endif
   TESTNAME();
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -738,8 +738,18 @@ extern "C" {
     // Set to true binary format (not encoded as base 64)
     writer->SetDataModeToAppended();
     writer->EncodeAppendedDataOff();
+#ifdef VTK_USES_MPI
+    // From version 6.3 VTK uses parallel communication to decide
+    // which files have been written
+    if (!writer->GetController()) {
+      vtkMPIController *cont = vtkMPIController::New();
+      cont->SetCommunicator(vtkMPICommunicator::GetWorldCommunicator());
+      writer->SetController(cont);
+    }
+    writer->SetWriteSummaryFile(true);
+#else
     writer->SetWriteSummaryFile((*rank)==0);
-
+#endif
     
     writer->Write();
     writer->Delete();

--- a/libvtkfortran/vtkfortran.cpp
+++ b/libvtkfortran/vtkfortran.cpp
@@ -37,10 +37,6 @@
 
 #include <vtk.h>
 
-#if VTK_MAJOR_VERSION>6 || (VTK_MAJOR_VERSION ==6 && VTK_MINOR_VERSION >2)
-#define VTK_USES_MPI 1
-#endif
-
 #include <vector>
 #include <string>
 
@@ -738,18 +734,8 @@ extern "C" {
     // Set to true binary format (not encoded as base 64)
     writer->SetDataModeToAppended();
     writer->EncodeAppendedDataOff();
-#ifdef VTK_USES_MPI
-    // From version 6.3 VTK uses parallel communication to decide
-    // which files have been written
-    if (!writer->GetController()) {
-      vtkMPIController *cont = vtkMPIController::New();
-      cont->SetCommunicator(vtkMPICommunicator::GetWorldCommunicator());
-      writer->SetController(cont);
-    }
-    writer->SetWriteSummaryFile(true);
-#else
     writer->SetWriteSummaryFile((*rank)==0);
-#endif
+
     
     writer->Write();
     writer->Delete();
@@ -784,7 +770,7 @@ extern "C" {
         if((*rank)%nwrites==lrank){
           _vtkpclose_nointerleave(rank, npartitions);
         }
-        MPI::COMM_WORLD.Barrier();
+        MPI_Barrier(MPI_COMM_WORLD);
       }
     }else{
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv){
   
 #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc,&argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -109,7 +109,7 @@ int main(int argc, char **argv){
   }
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/main/Usage.cpp
+++ b/main/Usage.cpp
@@ -287,9 +287,11 @@ void ParseArguments(int argc, char** argv){
   // Verbose?
   {    
     int MyRank = 0;
-#ifdef HAVE_MPI
-    if(MPI::Is_initialized()){
-      MyRank = MPI::COMM_WORLD.Get_rank();
+#ifdef HAVE_MPI  
+    int init_flag;
+    MPI_Initialized(&init_flag);
+    if(init_flag){
+      MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
     }
 #endif
  
@@ -310,8 +312,11 @@ void ParseArguments(int argc, char** argv){
     debug_file << "fluidity.log";
     err_file << "fluidity.err";
 #ifdef HAVE_MPI
-    if(MPI::Is_initialized()){
-      int MyRank = MPI::COMM_WORLD.Get_rank();
+    int init_flag;
+    MPI_Initialized(&init_flag);
+    if(init_flag){
+      int MyRank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
       debug_file << "-" << MyRank;
       err_file << "-" << MyRank;
     }

--- a/ocean_forcing/FluxesReader.cpp
+++ b/ocean_forcing/FluxesReader.cpp
@@ -43,9 +43,12 @@ FluxesReader::FluxesReader(){
   MyRank = 0;
   NProcs = 1;
 #ifdef HAVE_MPI
-  if(MPI::Is_initialized()){
-    MyRank = MPI::COMM_WORLD.Get_rank();
-    NProcs = MPI::COMM_WORLD.Get_size();
+  int init_flag;
+  MPI_Initialized(&init_flag);
+  if(init_flag){
+    int MyRank, NProcs;
+    MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   }
 #endif
   if(NProcs>1){

--- a/ocean_forcing/NEMOReader.cpp
+++ b/ocean_forcing/NEMOReader.cpp
@@ -43,9 +43,13 @@ NEMOReader::NEMOReader(){
   MyRank = 0;
   NProcs = 1;
 #ifdef HAVE_MPI
-  if(MPI::Is_initialized()){
-    MyRank = MPI::COMM_WORLD.Get_rank();
-    NProcs = MPI::COMM_WORLD.Get_size();
+
+  int init_flag;
+  MPI_Initialized(&init_flag);
+  if(init_flag){
+    int MyRank, NProcs;
+    MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &NProcs);
   }
 #endif
   if(NProcs>1){

--- a/ocean_forcing/tests/test_main.cpp
+++ b/ocean_forcing/tests/test_main.cpp
@@ -57,13 +57,14 @@ int main(int argc, char **argv)
   set_global_debug_level_fc(&val);
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   
@@ -81,7 +82,7 @@ int main(int argc, char **argv)
   PetscFinalize();
 #endif
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/ocean_forcing/tests/test_main.cpp
+++ b/ocean_forcing/tests/test_main.cpp
@@ -64,7 +64,6 @@ int main(int argc, char **argv)
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   PetscInitializeFortran();
 #endif
   

--- a/parameterisation/tests/test_main.cpp
+++ b/parameterisation/tests/test_main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
   set_global_debug_level_fc(&val);
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
   PetscFinalize();
 #endif
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/preprocessor/fluidity_check_options.cpp
+++ b/preprocessor/fluidity_check_options.cpp
@@ -48,14 +48,14 @@ int main(int argc, char **argv)
   set_global_debug_level_fc(&val);
   set_pseudo2d_domain_fc(&val);
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
 #endif
 #ifdef HAVE_PETSC  
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, PETSC_NULL);
 #endif
   check_options();
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/tools/Checkmesh_main.cpp
+++ b/tools/Checkmesh_main.cpp
@@ -55,7 +55,7 @@ void Usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -68,15 +68,19 @@ int main(int argc, char** argv){
   // Logging
   int nprocs = 1;
 #ifdef HAVE_MPI
-  if(MPI::Is_initialized()){
-    nprocs = MPI::COMM_WORLD.Get_size();
+  int init_flag;
+  MPI_Initialized(&init_flag);
+  if(init_flag){
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
   }
 #endif
 if(nprocs > 1){
   int rank = 0;
 #ifdef HAVE_MPI
-  if (MPI::Is_initialized()){
-    rank = MPI::COMM_WORLD.Get_rank();
+  int init_flag;
+  MPI_Initialized(&init_flag);
+  if (init_flag){
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   }
 #endif
   ostringstream buffer;
@@ -105,7 +109,7 @@ if(nprocs > 1){
   checkmesh(basename.c_str(), basename_len);
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/Differentiate_Vtu_main.cpp
+++ b/tools/Differentiate_Vtu_main.cpp
@@ -64,7 +64,7 @@ void differentiate_vtu_usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -135,7 +135,7 @@ int main(int argc, char **argv){
 #endif
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/Fladapt_main.cpp
+++ b/tools/Fladapt_main.cpp
@@ -62,7 +62,7 @@ void Usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -138,7 +138,7 @@ int main(int argc, char** argv){
 #endif
   
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/Flredecomp_main.cpp
+++ b/tools/Flredecomp_main.cpp
@@ -65,7 +65,7 @@ void Usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -98,8 +98,10 @@ int main(int argc, char** argv){
   if(args.count('l')){
     int rank = 0;
 #ifdef HAVE_MPI
-    if(MPI::Is_initialized()){
-      rank = MPI::COMM_WORLD.Get_rank();
+    int init_flag;
+    MPI_Initialized(&init_flag);
+    if(init_flag){
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     }
 #endif
     ostringstream buffer;
@@ -163,7 +165,7 @@ int main(int argc, char** argv){
              input_nprocs, target_nprocs);
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/Meshconv_main.cpp
+++ b/tools/Meshconv_main.cpp
@@ -72,7 +72,7 @@ void Usage(){
 int main(int argc, char** argv){
 
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -106,8 +106,10 @@ int main(int argc, char** argv){
     int rank = 0;
 
 #ifdef HAVE_MPI
-    if(MPI::Is_initialized()){
-      rank = MPI::COMM_WORLD.Get_rank();
+    int init_flag;
+    MPI_Initialized(&init_flag);
+    if(init_flag){
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     }
 #endif
 
@@ -177,7 +179,7 @@ int main(int argc, char** argv){
 
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
 
   return 0;

--- a/tools/Probe_Vtu_main.cpp
+++ b/tools/Probe_Vtu_main.cpp
@@ -63,7 +63,7 @@ void project_vtu_usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -139,7 +139,7 @@ int main(int argc, char **argv){
 #endif
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/Project_Vtu_main.cpp
+++ b/tools/Project_Vtu_main.cpp
@@ -64,7 +64,7 @@ void project_vtu_usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -143,7 +143,7 @@ int main(int argc, char **argv){
 #endif
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/Streamfunction_2D_main.cpp
+++ b/tools/Streamfunction_2D_main.cpp
@@ -62,7 +62,7 @@ void Usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -138,7 +138,7 @@ int main(int argc, char** argv){
 #endif
   
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/Supermesh_Difference_main.cpp
+++ b/tools/Supermesh_Difference_main.cpp
@@ -62,7 +62,7 @@ void project_vtu_usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -128,7 +128,7 @@ int main(int argc, char **argv){
 #endif
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/Vertical_Integration_main.cpp
+++ b/tools/Vertical_Integration_main.cpp
@@ -72,7 +72,7 @@ void Usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -178,7 +178,7 @@ int main(int argc, char** argv){
 #endif
   
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/Vtu_Bins_main.cpp
+++ b/tools/Vtu_Bins_main.cpp
@@ -63,7 +63,7 @@ void vtu_bins_usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -133,7 +133,7 @@ int main(int argc, char **argv){
 #endif
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/fldiagnostics_main.cpp
+++ b/tools/fldiagnostics_main.cpp
@@ -206,7 +206,8 @@ void FatalError(const char* message){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -306,7 +307,7 @@ int main(int argc, char** argv){
   }
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/gmsh2vtu_main.cpp
+++ b/tools/gmsh2vtu_main.cpp
@@ -50,7 +50,7 @@ void usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -66,7 +66,7 @@ int main(int argc, char** argv){
   gmsh2vtu(filename.c_str(), filename_len);
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/petsc_readnsolve_main.cpp
+++ b/tools/petsc_readnsolve_main.cpp
@@ -89,8 +89,10 @@ void usage(int argc, char **argv){
   if (flg) {
     int rank = 0;
 #ifdef HAVE_MPI
-    if(MPI::Is_initialized()){
-      rank = MPI::COMM_WORLD.Get_rank();
+    int init_flag;
+    MPI_Initialized(&init_flag);
+    if(init_flag){
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     }
 #endif
     ostringstream buffer;
@@ -113,7 +115,7 @@ int main(int argc, char **argv){
 
 #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc,&argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -123,6 +125,7 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   usage(argc, argv);
@@ -141,7 +144,7 @@ int main(int argc, char **argv){
 
   PetscFinalize();
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
  
   return 0;

--- a/tools/petsc_readnsolve_main.cpp
+++ b/tools/petsc_readnsolve_main.cpp
@@ -125,7 +125,6 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   usage(argc, argv);

--- a/tools/project_to_continuous_main.cpp
+++ b/tools/project_to_continuous_main.cpp
@@ -64,7 +64,7 @@ void usage(char *binary){
 int main(int argc, char **argv){
  #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -124,7 +124,7 @@ int main(int argc, char **argv){
   project_to_continuous(vtufile.c_str(),vtulen,meshfile.c_str(),meshlen);
   
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return(0);
 }

--- a/tools/test_pressure_solve_main.cpp
+++ b/tools/test_pressure_solve_main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv){
 
 #ifdef HAVE_MPI
   // This must be called before we process any arguments
-  MPI::Init(argc,argv);
+  MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
@@ -43,6 +43,7 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
+  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   test_pressure_solve_();

--- a/tools/test_pressure_solve_main.cpp
+++ b/tools/test_pressure_solve_main.cpp
@@ -43,7 +43,6 @@ int main(int argc, char **argv){
   static char help[] = "Use -help to see the help.\n\n";
   PetscErrorCode ierr = PetscInitialize(&argc, &argv, NULL, help);
   // PetscInitializeFortran needs to be called when initialising PETSc from C, but calling it from Fortran
-  // This sets all kinds of objects such as PETSC_NULL_OBJECT, PETSC_COMM_WORLD, etc., etc.
   ierr = PetscInitializeFortran();
   
   test_pressure_solve_();

--- a/tools/triangle2vtu_main.cpp
+++ b/tools/triangle2vtu_main.cpp
@@ -50,7 +50,7 @@ void usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -66,7 +66,7 @@ int main(int argc, char** argv){
   triangle2vtu(filename.c_str(), filename_len);
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/unifiedmesh_main.cpp
+++ b/tools/unifiedmesh_main.cpp
@@ -56,7 +56,7 @@ void usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -78,7 +78,7 @@ int main(int argc, char** argv){
               outputfilename.c_str(), output_file_name_len);
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/vtu2gmsh_main.cpp
+++ b/tools/vtu2gmsh_main.cpp
@@ -50,7 +50,7 @@ void usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -67,7 +67,7 @@ int main(int argc, char** argv){
 
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }

--- a/tools/vtu2triangle_main.cpp
+++ b/tools/vtu2triangle_main.cpp
@@ -49,7 +49,7 @@ void usage(){
 
 int main(int argc, char** argv){
 #ifdef HAVE_MPI
-  MPI::Init(argc, argv);
+  MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
   chdir(getenv("PWD"));
 #endif
@@ -66,7 +66,7 @@ int main(int argc, char** argv){
 
 
 #ifdef HAVE_MPI
-  MPI::Finalize();
+  MPI_Finalize();
 #endif
   return 0;
 }


### PR DESCRIPTION
Changes to address issue #175. 

This appears to compile and run fine for me, but could do with a sanity check (and there may be more elegant ways of implementing some of the changes!).

In most cases it's just a straight swap for C++ to C MPI bindings, in a few cases things had to be shuffled around to make sure variables were declared/assigned correctly - these are probably the bits where there might be some room for improvement.