### PR TITLE
Build spring clean

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -428,10 +428,10 @@ AC_MSG_NOTICE([Using PETSC_DIR=$PETSC_DIR])
 PETSC_LINK_LIBS=`make -s -f petsc_makefile_old getlinklibs 2> /dev/null || make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
-# need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
+# need to add -I$PWD/include/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
 PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null || make -s -f petsc_makefile getincludedirs`
-CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
-FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
+CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -I$PWD/include/"
+FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -I$PWD/include/"
 
 # first check we have the right petsc version
 AC_COMPUTE_INT(PETSC_VERSION_MAJOR, "PETSC_VERSION_MAJOR", [#include "petscversion.h"], 

--- a/assemble/Free_Surface.F90
+++ b/assemble/Free_Surface.F90
@@ -195,7 +195,7 @@ contains
     type(scalar_field) :: original_bottomdist, original_bottomdist_remap
 
     if (.not. has_scalar_field(state, "OriginalDistanceToBottom")) then
-       ewrite(2, *), "Inserting OriginalDistanceToBottom field into state."   
+       ewrite(2, *) "Inserting OriginalDistanceToBottom field into state."   
        bottomdist => extract_scalar_field(state, "DistanceToBottom")
        call allocate(original_bottomdist, bottomdist%mesh, "OriginalDistanceToBottom")
        call zero(original_bottomdist)
@@ -204,7 +204,7 @@ contains
        call deallocate(original_bottomdist)
 
        ! We also cache  the OriginalDistanceToBottom on the pressure mesh
-       ewrite(2, *), "Inserting OriginalDistanceToBottomPressureMesh field into state."   
+       ewrite(2, *) "Inserting OriginalDistanceToBottomPressureMesh field into state."   
        p_mesh => extract_pressure_mesh(state)
        call allocate(original_bottomdist_remap, p_mesh, "OriginalDistanceToBottomPressureMesh")
        call remap_field(original_bottomdist, original_bottomdist_remap)

--- a/assemble/Geostrophic_Pressure.F90
+++ b/assemble/Geostrophic_Pressure.F90
@@ -1986,7 +1986,7 @@ contains
     
     call clear_boundary_conditions(ps)
     
-    ewrite(2, *), "Adding strong Dirichlet bc for field " // trim(ps(1)%name)
+    ewrite(2, *) "Adding strong Dirichlet bc for field " // trim(ps(1)%name)
     do i = 1, size(surface_eles)
       surface_eles(i) = i
     end do
@@ -1999,7 +1999,7 @@ contains
     call insert_surface_field(ps(1), 1, b_ps(1))
     call deallocate(b_ps(1))
     do i = 2, size(ps)
-      ewrite(2, *), "Adding strong Dirichlet bc for field " // trim(ps(i)%name) 
+      ewrite(2, *) "Adding strong Dirichlet bc for field " // trim(ps(i)%name) 
       call add_boundary_condition_surface_elements(ps(i), "InterpolatedBoundary", "dirichlet", surface_eles) 
       ewrite_minmax(b_ps(i))
       call insert_surface_field(ps(i), 1, b_ps(i))
@@ -2165,7 +2165,7 @@ contains
       end do
       do i = 1, size(bc_ps, 1)
         call clear_boundary_conditions(bc_ps(i))
-        ewrite(2, *), "Adding strong Dirichlet bc for field " // trim(bc_ps(i)%name)
+        ewrite(2, *) "Adding strong Dirichlet bc for field " // trim(bc_ps(i)%name)
         call add_boundary_condition_surface_elements(bc_ps(i), "ConstantBoundary", "dirichlet", surface_eles) 
         call get_boundary_condition(bc_ps(i), 1, surface_mesh = bc_mesh, &
           & surface_element_list = bc_surface_element_list) 
@@ -2373,7 +2373,7 @@ contains
       end do
       do i = 1, size(bc_ps, 1)
         call clear_boundary_conditions(bc_ps(i))
-        ewrite(2, *), "Adding strong Dirichlet bc for field " // trim(bc_ps(i)%name)
+        ewrite(2, *) "Adding strong Dirichlet bc for field " // trim(bc_ps(i)%name)
         call add_boundary_condition_surface_elements(bc_ps(i), "ConstantBoundary", "dirichlet", surface_eles) 
         call get_boundary_condition(bc_ps(i), 1, surface_mesh = bc_mesh, &
           & surface_element_list = bc_surface_element_list) 

--- a/assemble/tests/test_main.cpp
+++ b/assemble/tests/test_main.cpp
@@ -59,7 +59,11 @@ int main(int argc, char **argv)
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/climatology/create_climatology_atlas.cpp
+++ b/climatology/create_climatology_atlas.cpp
@@ -461,7 +461,8 @@ int main(){
       // cout<<"Reading level "<<k<<endl;
       for(size_t j=0; j<(size_t)jdim0; j++)
   for(size_t i=0; i<(size_t)idim0; i++){
-    fscanf(fp, "%f", &(dat[m][k][j*idim0+i]));
+    int ierr = fscanf(fp, "%f", &(dat[m][k][j*idim0+i]));
+    if (ierr<1) cerr<<"File read error";
   }
     }
     fclose(fp);
@@ -490,7 +491,8 @@ int main(){
       // cout<<"Reading level "<<k<<endl;
       for(size_t j=0; j<(size_t)jdim0; j++)
   for(size_t i=0; i<(size_t)idim0; i++){
-    fscanf(fp, "%f", &(dat[m][k][j*idim0+i]));
+    int ierr = fscanf(fp, "%f", &(dat[m][k][j*idim0+i]));
+    if (ierr<1) cerr<<"File read error";
   }
     }
     fclose(fp);
@@ -528,7 +530,8 @@ int main(){
       for(size_t j=0; j<(size_t)jdim0; j++)
   for(size_t i=0; i<(size_t)idim0; i++){
     float v;
-    fscanf(fp, "%f", &v);
+    int ierr = fscanf(fp, "%f", &v);
+    if (ierr<1) cerr<<"File read error";
     if(k>=24){
       dat[m][k-24][j*idim0+i] = v;
     }
@@ -560,7 +563,8 @@ int main(){
       for(size_t j=0; j<(size_t)jdim0; j++)
   for(size_t i=0; i<(size_t)idim0; i++){
     float v;
-    fscanf(fp, "%f", &v);
+    int ierr = fscanf(fp, "%f", &v);
+    if (ierr<1) cerr<<"File read error";
     if(k>=24){
       dat[m][k-24][j*idim0+i] = v;
     }

--- a/configure
+++ b/configure
@@ -12641,10 +12641,10 @@ $as_echo "$as_me: Using PETSC_DIR=$PETSC_DIR" >&6;}
 PETSC_LINK_LIBS=`make -s -f petsc_makefile_old getlinklibs 2> /dev/null || make -s -f petsc_makefile getlinklibs`
 LIBS="$PETSC_LINK_LIBS $LIBS"
 
-# need to add -Iinclude/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
+# need to add -I$PWD/include/ to what we get from petsc, so we can use our own petsc_legacy.h wrapper
 PETSC_INCLUDE_FLAGS=`make -s -f petsc_makefile_old getincludedirs 2> /dev/null || make -s -f petsc_makefile getincludedirs`
-CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
-FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -Iinclude/"
+CPPFLAGS="$CPPFLAGS $PETSC_INCLUDE_FLAGS -I$PWD/include/"
+FCFLAGS="$FCFLAGS $PETSC_INCLUDE_FLAGS -I$PWD/include/"
 
 # first check we have the right petsc version
 if ac_fn_c_compute_int "$LINENO" ""PETSC_VERSION_MAJOR"" "PETSC_VERSION_MAJOR"        "#include \"petscversion.h\""; then :

--- a/diagnostics/Tidal_Diagnostics.F90
+++ b/diagnostics/Tidal_Diagnostics.F90
@@ -103,7 +103,7 @@ subroutine calculate_free_surface_history(state, s_field)
     real :: spin_up_time, current_time, timestep
     real, dimension(:), allocatable :: saved_snapshots_times
 
-    ewrite(3,*),'in free_surface_history_diagnostics'
+    ewrite(3,*) 'in free_surface_history_diagnostics'
 
     fs_field => extract_scalar_field(state,"FreeSurface",stat)
     call halo_update(fs_field)
@@ -158,13 +158,13 @@ subroutine calculate_free_surface_history(state, s_field)
    ! Note this is after the options check above as we add options to the tree if
    ! they aren't there and they are needed in tidal_harmonics diagnostics
    if(current_time+timestep<spin_up_time) then
-       ewrite(4,*), "Still spinning up."
+       ewrite(4,*) "Still spinning up."
        return
    endif
    
    ! check if we want to save the current timestep at all
    if (mod(timestep_counter,stride)/=0) then
-       ewrite(4,*), "Ignoring this timestep"
+       ewrite(4,*) "Ignoring this timestep"
        return
    end if
 
@@ -181,7 +181,7 @@ subroutine calculate_free_surface_history(state, s_field)
   saved_snapshots_times(new_snapshot_index)=current_time+timestep
   call set_option(trim(base_path) // "saved_snapshots_times", saved_snapshots_times, stat)
   assert(any(stat == (/SPUD_NO_ERROR, SPUD_NEW_KEY_WARNING/)))
-  ewrite(4,*), 'Filling history level: ', min(timestep_counter/stride+1,levels), '/', levels
+  ewrite(4,*) 'Filling history level: ', min(timestep_counter/stride+1,levels), '/', levels
  
   ! lets copy a snapshot of freesurface to s_field(new_snapshot_index)
   hist_fs_field => extract_scalar_field(state,'harmonic'//int2str(new_snapshot_index))
@@ -220,7 +220,7 @@ subroutine calculate_tidal_harmonics(state, s_field)
 
    ! Only if Harmonics weren't already calculated in this timestep
    if (last_update/=timestep) then 
-      ewrite(3,*), "In tidal_harmonics"
+      ewrite(3,*) "In tidal_harmonics"
       allocate(harmonic_fields(get_number_of_harmonic_fields(state)))
       allocate(sigma(nLevels_))
 
@@ -229,9 +229,9 @@ subroutine calculate_tidal_harmonics(state, s_field)
       if (.not. ignoretimestep) then
          ! Initialize the harmonic fields and frequencies if not already done.
          call getHarmonicFields(state, harmonic_fields, nohfs, sigma, M)
-         ewrite(4,*), 'Frequencies to analyse:'
+         ewrite(4,*) 'Frequencies to analyse:'
          do i=1,M
-            ewrite(4,*), sigma(i)
+            ewrite(4,*) sigma(i)
          end do
          ! Calculate harmonics and update (all!) harmonic fields
          call update_harmonic_fields(state, saved_snapshots_times, size(saved_snapshots_times), current_snapshot_index, sigma, M, harmonic_fields, nohfs)
@@ -268,12 +268,12 @@ subroutine getFreeSurfaceHistoryData(state, ignoretimestep, saved_snapshots_time
    call get_option(trim(free_surface_history_path) // "levels", levels)
 
    if( mod(timestep_counter,stride)/=0) then
-        ewrite(4,*),'Do nothing in this timestep.'
+        ewrite(4,*) 'Do nothing in this timestep.'
         ignoretimestep=.true.
         return
    end if
    if(timestep_counter/stride+1 .lt. levels) then
-        ewrite(4,*), 'Do nothing until levels are filled up.'
+        ewrite(4,*) 'Do nothing until levels are filled up.'
         ignoretimestep=.true.
         return
    end if
@@ -350,8 +350,8 @@ subroutine getHarmonicFields(state, harmonic_fields, nohfs, sigma, M)
            end if
        end if
     end do s_field_loop
-    ewrite(4,*), 'Found ',  nohfs, ' constituents to analyse.' 
-    ewrite(4,*), 'Found ', M, ' frequencies to analyse.'
+    ewrite(4,*) 'Found ',  nohfs, ' constituents to analyse.' 
+    ewrite(4,*) 'Found ', M, ' frequencies to analyse.'
 
    if ( M .le. 0 ) then
       FLExit("Internal error in calculate_tidal_harmonics(). No harmonic constituents were found in option tree.")

--- a/error_measures/tests/test_main.cpp
+++ b/error_measures/tests/test_main.cpp
@@ -53,7 +53,11 @@ int main(int argc, char **argv) {
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/femtools/Coordinates.F90
+++ b/femtools/Coordinates.F90
@@ -1004,7 +1004,7 @@ contains
     type(scalar_field):: radius, s_radius
     real, dimension(positions%dim):: xyz
 
-    ewrite(1,*), 'In higher_order_sphere_projection'
+    ewrite(1,*) 'In higher_order_sphere_projection'
     
     call allocate(s_radius, s_positions%mesh, "HigherOrderRadius")
     radius=magnitude(positions)

--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -592,13 +592,13 @@ contains
         if(stat_mesh(mesh)) then
           column = column + 1
           buffer = field_tag(name = mesh%name, column = column, statistic = "nodes")
-          write(default_stat%diag_unit, "(a)"), trim(buffer)
+          write(default_stat%diag_unit, "(a)") trim(buffer)
           column = column + 1
           buffer = field_tag(name = mesh%name, column = column, statistic = "elements")
-          write(default_stat%diag_unit, "(a)"), trim(buffer)
+          write(default_stat%diag_unit, "(a)") trim(buffer)
           column = column + 1
           buffer = field_tag(name = mesh%name, column = column, statistic = "surface_elements")
-          write(default_stat%diag_unit, "(a)"), trim(buffer)
+          write(default_stat%diag_unit, "(a)") trim(buffer)
         end if
       end do
 

--- a/femtools/Exodusii_C_Interface.c
+++ b/femtools/Exodusii_C_Interface.c
@@ -8,6 +8,8 @@
 #include "exodusII.h"
 #endif
 
+void FLExit(const char*);
+
 /* Open ExodusII File for reading */
 int c_read_ex_open(const char *path, int mode, int *comp_ws, int *io_ws, float *version)
 {

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -387,7 +387,7 @@ contains
 
     ! Skip newline character when in binary mode
     if( gmshFormat == binaryFormat ) then
-       read(fd), newlineChar
+       read(fd) newlineChar
        call ascii_formatting(fd, filename, "read")
     end if
 
@@ -477,7 +477,7 @@ contains
 
     ! Skip newline character when in binary mode
     if( gmshFormat == binaryFormat ) then
-      read(fd), newlineChar
+      read(fd) newlineChar
       call ascii_formatting(fd, filename, "read")
     end if
 

--- a/femtools/embed_python.c
+++ b/femtools/embed_python.c
@@ -33,6 +33,7 @@ USA
 #include "Python.h"
 #endif
 #ifdef HAVE_NUMPY
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 #endif
 
@@ -526,7 +527,7 @@ void set_tensor_field_from_python(char *function, int *function_len, int *dim,
     }
     
     pArray = (PyArrayObject *)
-      PyArray_ContiguousFromObject(pResult, PyArray_DOUBLE, 2, 2);
+      PyArray_ContiguousFromObject(pResult, NPY_DOUBLE, 2, 2);
 
     if (PyErr_Occurred()){
       PyErr_Print();
@@ -534,10 +535,10 @@ void set_tensor_field_from_python(char *function, int *function_len, int *dim,
       return;
     }
 
-    if (pArray->dimensions[0] != result_dim[0] || pArray->dimensions[1] != result_dim[1])
+    if (PyArray_DIMS(pArray)[0] != result_dim[0] || PyArray_DIMS(pArray)[1] != result_dim[1])
     {
       fprintf(stderr, "Error: dimensions of array returned from python ([%d, %d]) do not match allocated dimensions of the tensor_field ([%d, %d])).\n", 
-             (int) pArray->dimensions[0], (int) pArray->dimensions[1], result_dim[0], result_dim[1]);
+             (int) PyArray_DIMS(pArray)[0], (int) PyArray_DIMS(pArray)[1], result_dim[0], result_dim[1]);
       *stat=1;
       return;
     }
@@ -547,7 +548,7 @@ void set_tensor_field_from_python(char *function, int *function_len, int *dim,
         
         // Note the transpose for fortran.
         double tmp;
-        tmp = *(double*)(pArray->data + ii * pArray->strides[0] + jj * pArray->strides[1]);
+        tmp = *(double*)(PyArray_DATA(pArray) + ii * PyArray_STRIDES(pArray)[0] + jj * PyArray_STRIDES(pArray)[1]);
         result[i*(result_dim[0] * result_dim[1]) + jj * result_dim[0] + ii] = tmp;
       }
     }

--- a/femtools/python_statec.c
+++ b/femtools/python_statec.c
@@ -514,7 +514,7 @@ void python_add_array_double_1d(double *arr, int *size, char *name){
   //  the actual data as a byte array(char*)
 
   // Set the array
-  PyObject *a = PyArray_SimpleNewFromData(1, (npy_intp[]){*size}, PyArray_DOUBLE, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(1, (npy_intp[]){*size}, NPY_DOUBLE, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   Py_DECREF(a);
 #endif
@@ -528,7 +528,7 @@ void python_add_array_double_2d(double *arr, int *sizex, int *sizey, char *name)
 
   // Set the array
   npy_intp dims[] = {*sizey,*sizex};
-  PyObject *a = PyArray_SimpleNewFromData(2, dims, PyArray_DOUBLE, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(2, dims, NPY_DOUBLE, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   char c[200];
   snprintf(c, 200, "%s = numpy.transpose(%s,(1,0))",name,name);
@@ -545,7 +545,7 @@ void python_add_array_double_3d(double *arr, int *sizex, int *sizey, int *sizez,
 
   // Set the array
   npy_intp dims[] = {*sizez,*sizey,*sizex};
-  PyObject *a = PyArray_SimpleNewFromData(3, dims, PyArray_DOUBLE, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(3, dims, NPY_DOUBLE, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   char c[200];
   snprintf(c, 200, "%s = numpy.transpose(%s,(2,1,0))",name,name);
@@ -561,7 +561,7 @@ void python_add_array_integer_1d(int *arr, int *size, char *name){
   PyObject *pDict = PyModule_GetDict(pMain);
 
   // Set the array
-  PyObject *a = PyArray_SimpleNewFromData(1, (npy_intp[]){*size}, PyArray_INT, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(1, (npy_intp[]){*size}, NPY_INT, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   Py_DECREF(a);
 #endif
@@ -575,7 +575,7 @@ void python_add_array_integer_2d(int *arr, int *sizex, int *sizey, char *name){
 
   // Set the array
   npy_intp dims[] = {*sizey,*sizex};
-  PyObject *a = PyArray_SimpleNewFromData(2, dims, PyArray_INT, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(2, dims, NPY_INT, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   char c[200];
   snprintf(c, 200, "%s = numpy.transpose(%s,(1,0))",name,name);
@@ -592,7 +592,7 @@ void python_add_array_integer_3d(int *arr, int *sizex, int *sizey, int *sizez, c
 
   // Set the array
   npy_intp dims[] = {*sizez,*sizey,*sizex};
-  PyObject *a = PyArray_SimpleNewFromData(3, dims, PyArray_INT, (char*)arr);
+  PyObject *a = PyArray_SimpleNewFromData(3, dims, NPY_INT, (char*)arr);
   PyDict_SetItemString(pDict,name,a);
   char c[200];
   snprintf(c, 200, "%s = numpy.transpose(%s,(2,1,0))",name,name);

--- a/femtools/tests/test_main.cpp
+++ b/femtools/tests/test_main.cpp
@@ -59,7 +59,11 @@ int main(int argc, char **argv)
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/horizontal_adaptivity/tests/test_main.cpp
+++ b/horizontal_adaptivity/tests/test_main.cpp
@@ -53,7 +53,11 @@ int main(int argc, char **argv) {
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/include/python_statec.h
+++ b/include/python_statec.h
@@ -10,6 +10,7 @@
 #ifndef ALLOW_IMPORT_ARRAY
 #define NO_IMPORT_ARRAY
 #endif
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 #endif
 

--- a/libmba2d/isnan.c
+++ b/libmba2d/isnan.c
@@ -1,3 +1,5 @@
+#include "math.h"
+
 //to call floating-point check from the Fortran routine
 void fpcheck_c_( double *a, int *flag ) 
 { 

--- a/libwm/Wm4System.cpp
+++ b/libwm/Wm4System.cpp
@@ -250,7 +250,8 @@ int System::Write1 (char* acBuffer, int iQuantity, const void* pvData)
 int System::Read1 (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,1,iQuantity,pkFile);
+    int iRead = fread(pvData,1,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
     return iQuantity;
 }
 //----------------------------------------------------------------------------
@@ -336,7 +337,8 @@ int System::Write8le (char* acBuffer, int iQuantity, const void* pvData)
 int System::Read2le (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,2,iQuantity,pkFile);
+    int iRead = fread(pvData,2,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifdef WM4_BIG_ENDIAN
     SwapBytes(2,iQuantity,pvData);
 #endif
@@ -346,7 +348,8 @@ int System::Read2le (FILE* pkFile, int iQuantity, void* pvData)
 int System::Read4le (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,4,iQuantity,pkFile);
+    int iRead = fread(pvData,4,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifdef WM4_BIG_ENDIAN
     SwapBytes(4,iQuantity,pvData);
 #endif
@@ -356,7 +359,8 @@ int System::Read4le (FILE* pkFile, int iQuantity, void* pvData)
 int System::Read8le (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,8,iQuantity,pkFile);
+    int iRead = fread(pvData,8,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifdef WM4_BIG_ENDIAN
     SwapBytes(8,iQuantity,pvData);
 #endif
@@ -489,7 +493,8 @@ int System::Write8be (char* acBuffer, int iQuantity, const void* pvData)
 int System::Read2be (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,2,iQuantity,pkFile);
+    int iRead = fread(pvData,2,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifndef WM4_BIG_ENDIAN
     SwapBytes(2,iQuantity,pvData);
 #endif
@@ -499,7 +504,8 @@ int System::Read2be (FILE* pkFile, int iQuantity, void* pvData)
 int System::Read4be (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,4,iQuantity,pkFile);
+    int iRead = fread(pvData,4,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifndef WM4_BIG_ENDIAN
     SwapBytes(4,iQuantity,pvData);
 #endif
@@ -509,7 +515,8 @@ int System::Read4be (FILE* pkFile, int iQuantity, void* pvData)
 int System::Read8be (FILE* pkFile, int iQuantity, void* pvData)
 {
     assert(pkFile && iQuantity > 0 && pvData);
-    fread(pvData,8,iQuantity,pkFile);
+    int iRead = fread(pvData,8,iQuantity,pkFile);
+    if (iRead != iQuantity) assert(false);
 #ifndef WM4_BIG_ENDIAN
     SwapBytes(8,iQuantity,pvData);
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -60,7 +60,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc,&argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+	std::cerr << "Unable to switch to directory " << getenv("PWD");
+	abort();
+  }
   
 #endif
 

--- a/ocean_forcing/FluxesReader.cpp
+++ b/ocean_forcing/FluxesReader.cpp
@@ -438,11 +438,11 @@ int FluxesReader::Read(int time_index){
     
     short fill_value;
     err = nc_get_att_short(ncid, id, "_FillValue", &fill_value);
-    if (err != NC_NOERR) fill_value = std::numeric_limits<double>::quiet_NaN();
+    if (err != NC_NOERR) fill_value = std::numeric_limits<short>::quiet_NaN();
     
     short missing_value;
     err = nc_get_att_short(ncid, id, "missing_value", &missing_value);
-    if (err != NC_NOERR) missing_value = std::numeric_limits<double>::quiet_NaN();
+    if (err != NC_NOERR) missing_value = std::numeric_limits<short>::quiet_NaN();
     
     if(verbose){
       cout<<*ifield<<" scale_factor = "<<scale_factor<<endl

--- a/ocean_forcing/tests/test_main.cpp
+++ b/ocean_forcing/tests/test_main.cpp
@@ -59,7 +59,11 @@ int main(int argc, char **argv)
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/parameterisation/tests/test_main.cpp
+++ b/parameterisation/tests/test_main.cpp
@@ -59,7 +59,11 @@ int main(int argc, char **argv)
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 #ifdef HAVE_PETSC  
   PetscInitialize(&argc, &argv, NULL, PETSC_NULL);

--- a/spatialindex-1.8.0/src/rtree/RTree.cc
+++ b/spatialindex-1.8.0/src/rtree/RTree.cc
@@ -207,7 +207,7 @@ SpatialIndex::ISpatialIndex* SpatialIndex::RTree::createAndBulkLoadNewRTree(
 	switch (m)
 	{
 	case BLM_STR:
-		bl.bulkLoadUsingSTR(static_cast<RTree*>(tree), stream, bindex, bleaf, 10000, 100);
+                bl.bulkLoadUsingSTR(static_cast<RTree*>(tree), stream, bindex, bleaf, std::numeric_limits<uint32_t>::max(), 1);
 		break;
 	default:
 		throw Tools::IllegalArgumentException("createAndBulkLoadNewRTree: Unknown bulk load method.");

--- a/spatialindex-1.8.0/src/tools/Tools.cc
+++ b/spatialindex-1.8.0/src/tools/Tools.cc
@@ -33,6 +33,7 @@
 #include <spatialindex/tools/rand48.h>
 #endif
 
+#include <unistd.h>
 #include <cstring>
 
 #if HAVE_PTHREAD_H
@@ -1096,9 +1097,13 @@ Tools::TemporaryFile::TemporaryFile()
 		m_sFile = std::string(tmpName);
 
 #else
-	char tmpName[7] = "XXXXXX";
-	if (mktemp(tmpName) == 0)
+	char tmpName[] = "spatialindex.XXXXXX";
+        int fd;
+	fd = mkstemp(tmpName);
+        if (fd == -1)
 		throw std::ios_base::failure("Tools::TemporaryFile: Cannot create temporary file name.");
+        close(fd);
+
 	m_sFile = tmpName;
 #endif
 

--- a/tools/Checkmesh_main.cpp
+++ b/tools/Checkmesh_main.cpp
@@ -57,7 +57,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
     
   if(argc < 2){

--- a/tools/Differentiate_Vtu_main.cpp
+++ b/tools/Differentiate_Vtu_main.cpp
@@ -67,7 +67,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   
   // Initialise PETSc (this also parses PETSc command line arguments)

--- a/tools/Fladapt_main.cpp
+++ b/tools/Fladapt_main.cpp
@@ -64,7 +64,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   PetscInit(argc, argv);
 #ifdef HAVE_PYTHON

--- a/tools/Flredecomp_main.cpp
+++ b/tools/Flredecomp_main.cpp
@@ -67,7 +67,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
   // Modified version of fldecomp argument parsing

--- a/tools/Meshconv_main.cpp
+++ b/tools/Meshconv_main.cpp
@@ -74,7 +74,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
   // Modified version of fldecomp argument parsing

--- a/tools/Probe_Vtu_main.cpp
+++ b/tools/Probe_Vtu_main.cpp
@@ -66,7 +66,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   
   // Initialise PETSc (this also parses PETSc command line arguments)

--- a/tools/Project_Vtu_main.cpp
+++ b/tools/Project_Vtu_main.cpp
@@ -67,7 +67,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   
   // Initialise PETSc (this also parses PETSc command line arguments)

--- a/tools/Streamfunction_2D_main.cpp
+++ b/tools/Streamfunction_2D_main.cpp
@@ -64,7 +64,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   PetscInit(argc, argv);
 #ifdef HAVE_PYTHON

--- a/tools/Supermesh_Difference_main.cpp
+++ b/tools/Supermesh_Difference_main.cpp
@@ -65,7 +65,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   
   // Initialise PETSc (this also parses PETSc command line arguments)

--- a/tools/Vertical_Integration_main.cpp
+++ b/tools/Vertical_Integration_main.cpp
@@ -74,7 +74,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   PetscInit(argc, argv);
 #ifdef HAVE_PYTHON

--- a/tools/Vtu_Bins_main.cpp
+++ b/tools/Vtu_Bins_main.cpp
@@ -66,7 +66,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
   
   // Initialise PETSc (this also parses PETSc command line arguments)

--- a/tools/fldiagnostics_main.cpp
+++ b/tools/fldiagnostics_main.cpp
@@ -209,7 +209,11 @@ int main(int argc, char** argv){
 
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        std::cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
   if(argc == 1){

--- a/tools/gmsh2vtu_main.cpp
+++ b/tools/gmsh2vtu_main.cpp
@@ -52,7 +52,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
     
   if(argc<2){

--- a/tools/petsc_readnsolve_main.cpp
+++ b/tools/petsc_readnsolve_main.cpp
@@ -118,7 +118,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc,&argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int cderr = chdir(getenv("PWD"));
+  if (cderr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
 #ifdef HAVE_PETSC

--- a/tools/project_to_continuous_main.cpp
+++ b/tools/project_to_continuous_main.cpp
@@ -67,7 +67,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
  
   // Get any command line arguments

--- a/tools/test_pressure_solve_main.cpp
+++ b/tools/test_pressure_solve_main.cpp
@@ -31,7 +31,11 @@ int main(int argc, char **argv){
   MPI_Init(&argc, &argv);
 
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int cderr = chdir(getenv("PWD"));
+  if (cderr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
 #ifdef HAVE_PYTHON

--- a/tools/triangle2vtu_main.cpp
+++ b/tools/triangle2vtu_main.cpp
@@ -52,7 +52,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
     
   if(argc<2){

--- a/tools/unifiedmesh_main.cpp
+++ b/tools/unifiedmesh_main.cpp
@@ -58,7 +58,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
     
   if(argc<3){

--- a/tools/vtu2gmsh_main.cpp
+++ b/tools/vtu2gmsh_main.cpp
@@ -52,7 +52,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
 
   if(argc<2){

--- a/tools/vtu2triangle_main.cpp
+++ b/tools/vtu2triangle_main.cpp
@@ -51,7 +51,11 @@ int main(int argc, char** argv){
 #ifdef HAVE_MPI
   MPI_Init(&argc, &argv);
   // Undo some MPI init shenanigans
-  chdir(getenv("PWD"));
+  int ierr = chdir(getenv("PWD"));
+  if (ierr == -1) {
+        cerr << "Unable to switch to directory " << getenv("PWD");
+        abort();
+  }
 #endif
     
   if(argc<2){


### PR DESCRIPTION
This changeset attempts to silence some of the superfluous warnings that fluidity currently spits out during building. The biggest things it doesn't deal with are an upstream warning from spud, and an issue caused by two different files in population_balance both producing a module with the same name. It also implements jrmaddison's suggestion in #119 to stop spatialindex from making temporary files.