### PR TITLE
Update testharness.py

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@ pipeline {
     agent { 
         docker {
             image "fluidity/baseimages:${PROJECT_NAME}"
-            label 'azure-linux'
+            label 'azure-linux-8core'
         } 
     }
     environment {
         MPLBACKEND = 'PS'
-	OMPI_MCA_btl = '^openib'
+        OMPI_MCA_btl = '^openib'
     }
     stages {
         stage('Configuring') {   
@@ -27,8 +27,8 @@ pipeline {
         stage('Testing') {       
             steps { 
                 sh 'make unittest' ;
-                sh 'make THREADS=2 test' ;
-                sh 'make THREADS=2 mediumtest'
+                sh 'make THREADS=8 test' ;
+                sh 'make THREADS=8 mediumtest'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     }
     environment {
         MPLBACKEND = 'PS'
+	OMPI_MCA_btl = '^openib'
     }
     stages {
         stage('Configuring') {   
@@ -25,9 +26,9 @@ pipeline {
         }
         stage('Testing') {       
             steps { 
-                sh 'make -j 8 unittest' ;
-                sh 'make -j 8 test' ;
-                sh 'make -j 8 mediumtest'
+                sh 'make unittest' ;
+                sh 'make THREADS=2 test' ;
+                sh 'make THREADS=2 mediumtest'
             }
         }
     }

--- a/python/fluidity/regressiontest.py
+++ b/python/fluidity/regressiontest.py
@@ -9,6 +9,7 @@ import time
 import glob
 import threading
 import traceback
+import StringIO as io
 
 try:
     from junit_xml import TestCase
@@ -206,6 +207,9 @@ class TestProblem:
             self.log("Running failure tests: ")
             for test in self.pass_tests:
                 self.log("Running %s:" % test.name)
+                log = io.StringIO()
+                _ = sys.stdout
+                sys.stdout = log
                 status = test.run(varsdict)
                 tc=TestCase(test.name,
                             '%s.%s'%(self.length,
@@ -222,6 +226,10 @@ class TestProblem:
                     self.pass_status.append('F')
                     tc.add_failure_info(  "Failure", status )
                 self.xml_reports.append(tc)
+                sys.stdout = _
+                log.seek(0)
+                tc.stdout = log.read()
+                print tc.stdout
 
         if len(self.warn_tests) != 0:
             self.log("Running warning tests: ")

--- a/python/fluidity/regressiontest.py
+++ b/python/fluidity/regressiontest.py
@@ -9,7 +9,12 @@ import time
 import glob
 import threading
 import traceback
-import StringIO as io
+try:
+  #python2
+  from StringIO import StringIO
+except ImportError:
+  #python3
+  from io import StringIO
 
 try:
     from junit_xml import TestCase
@@ -207,8 +212,8 @@ class TestProblem:
             self.log("Running failure tests: ")
             for test in self.pass_tests:
                 self.log("Running %s:" % test.name)
-                log = io.StringIO()
-                _ = sys.stdout
+                log = StringIO()
+                original_stdout = sys.stdout
                 sys.stdout = log
                 status = test.run(varsdict)
                 tc=TestCase(test.name,
@@ -226,10 +231,10 @@ class TestProblem:
                     self.pass_status.append('F')
                     tc.add_failure_info(  "Failure", status )
                 self.xml_reports.append(tc)
-                sys.stdout = _
+                sys.stdout = original_stdout
                 log.seek(0)
                 tc.stdout = log.read()
-                print tc.stdout
+                print(tc.stdout)
 
         if len(self.warn_tests) != 0:
             self.log("Running warning tests: ")

--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -425,6 +425,11 @@ if __name__ == "__main__":
       os.environ["LD_LIBRARY_PATH"] = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "..", "lib")) + ":" + os.environ["LD_LIBRARY_PATH"]
     except KeyError:
       os.putenv("LD_LIBRARY_PATH", os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "..", "lib")))
+      
+    try:
+      os.environ["OMPI_MCA_rmaps_base_oversubscribe"] = "1"
+    except KeyError:
+      os.putenv("OMPI_MCA_rmaps_base_oversubscribe", "1")
 
     try:
         os.mkdir(os.environ["HOME"] + os.sep + "lock")


### PR DESCRIPTION
Apply the change proposed in #182 to allow oversubscription of MPI slots in openmpi 3.0 and above.