### PR TITLE
Test harness bug fix plus Jenkins slack integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     stages {
         stage('Configuring') {   
             steps { 
+                slackSend "Build started - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
                 sh './configure --enable-2d-adaptivity' 
             }
         }    
@@ -29,12 +30,29 @@ pipeline {
                 sh 'make unittest' ;
                 sh 'make THREADS=8 test' ;
                 sh 'make THREADS=8 mediumtest'
+                junit 'tests/test_result*xml'
             }
         }
     }
     post {
-        always {
-            junit 'tests/test_result*xml'
+        aborted {
+            slackSend(color: '#DEADED',
+	              message: "Build aborted - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+        }
+	success {
+	    slackSend (color: 'good',
+	     message: "Build completed successfully - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+        }
+	unstable {
+	    slackSend(color: 'warning',
+	              message: "Build completed with test failures - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            script {
+                currentBuild.result = "FAILURE"
+            }
+        }
+	failure {
+	    slackSend(color: 'danger',
+	              message: "Build failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
         }
     }
 }

--- a/python/fluidity/regressiontest.py
+++ b/python/fluidity/regressiontest.py
@@ -203,6 +203,11 @@ class TestProblem:
             except:
               self.log("failure.")
               self.pass_status.append('F')
+              tc=TestCase(self.name,
+                          '%s.%s'%(self.length,
+                                   self.filename[:-4]))
+              tc.add_failure_info("Failure" )
+              self.xml_reports.append(tc)
               return self.pass_status
 
             varsdict[var.name] = tmpdict[var.name]

--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -338,9 +338,9 @@ class TestHarness:
                 except Queue.Empty:
                     break
             for e, lines in exceptions:
-                tc=TestCase(e.name,
-                            '%s.%s'%(e.length,
-                                     e.filename[:-4]))
+                tc=TestCase(e[1].name,
+                            '%s.%s'%(e[1].length,
+                                     e[1].filename[:-4]))
                 tc.add_failure_info("Failure", lines)
                 self.xml_parser.test_cases+= [tc]
                 self.tests.remove(e)

--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -28,13 +28,18 @@ import xml.parsers.expat
 import string
 
 try:
-  from junit_xml import TestSuite
+  from junit_xml import TestSuite, TestCase
 except ImportError:
   class TestSuite(object):
      def __init__(self, name, test_cases):
          self.test_cases=test_cases
      def to_file(self,*args):
          print "cannot generate xml report without junit_xml module."
+  class TestCase(object):
+        def __init__(self,*args,**kwargs):
+            pass
+        def add_failure_info(self,*args,**kwargs):
+            pass
 
 # make sure we use the correct version of regressiontest
 sys.path.insert(0, os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]), os.pardir, "python"))
@@ -328,11 +333,16 @@ class TestHarness:
             exceptions = []
             while True:
                 try:
-                    test_id = self.test_exception_ids.get(timeout=0.1)
-                    exceptions.append(self.tests[test_id])
+                    test_id, lines = self.test_exception_ids.get(timeout=0.1)
+                    exceptions.append((self.tests[test_id], lines))
                 except Queue.Empty:
                     break
-            for e in exceptions:
+            for e, lines in exceptions:
+                tc=TestCase(e.name,
+                            '%s.%s'%(e.length,
+                                     e.filename[:-4]))
+                tc.add_failure_info("Failure", lines)
+                self.xml_parser.test_cases+= [tc]
                 self.tests.remove(e)
                 self.completed_tests += [e[1]]
 
@@ -440,7 +450,7 @@ class TestHarness:
                 for line in lines:
                     self.log(line)
                 test.pass_status = ['F']
-                self.test_exception_ids.put(test_id)
+                self.test_exception_ids.put((test_id, lines))
             finally:
                 sys.stdout = main_stdout
                 buf.seek(0)


### PR DESCRIPTION
These changes fix an important oversight in the testharness junit support, which meant two test failures on the Jenkins Centos7 build weren't being picked up. Further, it adds Slack notifications to the Jenkinsfile, as well as marking unstable builds as failed on Jenkins, in a method that could be extended if we want e.g email notifications of master build failures.

For the record, the 2 centos failures are `vtu2ensight`, due to missing files in the vtk support and `gls-ocean-param`, apparently due to `matplotlib` issues.