### PR TITLE
Support PETSc 3.9

### DIFF
--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -1860,7 +1860,7 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
     PC:: subpc
     MatNullSpace:: nullsp
     PCType:: pctype, hypretype
-    MatSolverPackage:: matsolverpackage
+    MatSolverType:: matsolvertype
     PetscErrorCode:: ierr
     
     call get_option(trim(option_path)//'/name', pctype)
@@ -1973,8 +1973,8 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
        call PCSetType(pc, pctype, ierr)
 
        if (pctype==PCLU) then
-          call get_option(trim(option_path)//'/factorization_package/name', matsolverpackage)
-          call PCFactorSetMatSolverPackage(pc, matsolverpackage, ierr)
+          call get_option(trim(option_path)//'/factorization_package/name', matsolvertype)
+          call PCFactorSetMatSolverType(pc, matsolvertype, ierr)
        end if
 
       if (pctype==PCGAMG) then

--- a/include/petsc_legacy.h
+++ b/include/petsc_legacy.h
@@ -74,3 +74,7 @@
 #if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<8)
 #define MatCreateSubMatrix MatGetSubMatrix
 #endif
+#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<9)
+#define MatSolverType MatSolverPackage
+#define PCFactorSetMatSolverType PCFactorSetMatSolverPackage
+#endif


### PR DESCRIPTION
PETSc saw `MatSolverPackage` renamed to `MatSolverType`, this has been reflected in the petsc_legacy.h overrides. Hopefully this doesn't step on the toes of #218 which first raised the issue.