### PR TITLE
Correct types in call to PETSc (3.8+) VecScatterCreate()

### DIFF
--- a/include/petsc_legacy.h
+++ b/include/petsc_legacy.h
@@ -65,6 +65,7 @@
 #define PETSC_NULL_MAT PETSC_NULL_OBJECT
 #define PETSC_NULL_VECSCATTER PETSC_NULL_OBJECT
 #define PETSC_NULL_VIEWER PETSC_NULL_OBJECT
+#define PETSC_NULL_IS PETSC_NULL_OBJECT
 #endif
 #if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<8)
 #define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x, ierr)

--- a/tools/petsc_readnsolve.F90
+++ b/tools/petsc_readnsolve.F90
@@ -727,7 +727,7 @@ contains
     ! create a Vec according to the proper partioning:
     call VecCreateMPI(MPI_COMM_FEMTOOLS, n*ncomponents, m, new_x, ierr)
     ! fill it with values from the read x by asking for its row numbers
-    call VecScatterCreate(x, row_indexset, new_x, PETSC_NULL_VECSCATTER, &
+    call VecScatterCreate(x, row_indexset, new_x, PETSC_NULL_IS, &
        scatter, ierr)
     call VecScatterBegin(scatter, x, new_x, INSERT_VALUES, &
        SCATTER_FORWARD, ierr)


### PR DESCRIPTION
I can't figure out why this compiles in its current state, although not on my configuration. Currently, a null `VecScatter` object is passed through to an `IS` parameter. This should affect PETSc versions 3.8 and up, where typed null objects were introduced.