### PR TITLE
GMSH v4 support

### DIFF
--- a/femtools/Makefile.dependencies
+++ b/femtools/Makefile.dependencies
@@ -996,10 +996,11 @@ Read_Exodusii.o ../include/read_exodusii.mod: Read_Exodusii.F90 \
 ../include/read_gmsh.mod: Read_GMSH.o
 	@true
 
-Read_GMSH.o ../include/read_gmsh.mod: Read_GMSH.F90 ../include/elements.mod \
-   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
-   ../include/futils.mod ../include/global_parameters.mod \
-   ../include/gmsh_common.mod ../include/parallel_tools.mod \
+Read_GMSH.o ../include/read_gmsh.mod: Read_GMSH.F90 \
+   ../include/data_structures.mod ../include/elements.mod ../include/fdebug.h \
+   ../include/fields.mod ../include/fldebug.mod ../include/futils.mod \
+   ../include/global_parameters.mod ../include/gmsh_common.mod \
+   ../include/linked_lists.mod ../include/parallel_tools.mod \
    ../include/quadrature.mod ../include/state_module.mod
 
 ../include/read_triangle.mod: Read_Triangle.o

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -840,8 +840,6 @@ subroutine read_nodes_coords_v4_binary( fd, filename, versionNumber, nodes )
     integer :: entityDim, entityTag, tag_index
     integer :: numentityelements
 
-    integer, allocatable :: ltags(:)
-
     read(fd,*) charBuf
     if( trim(charBuf)/="$Elements" ) then
        FLExit("Error: cannot find '$Elements' in GMSH mesh file")
@@ -877,11 +875,6 @@ subroutine read_nodes_coords_v4_binary( fd, filename, versionNumber, nodes )
        tag_index = fetch(entityMap(entityDim+1), entityTag)
        numTags = entityTags(tag_index)
 
-       allocate(ltags(numTags))
-       do i=1, numTags
-          ltags(i) = entityTags(tag_index+i)
-       end do
-
        do k=1, numEntityElements
           e = e + 1
           ! Read in whole line into a string buffer
@@ -896,12 +889,9 @@ subroutine read_nodes_coords_v4_binary( fd, filename, versionNumber, nodes )
           
           ! Now read in tags and node IDs
           read(charBuf, *) allElements(e)%elementID, allElements(e)%nodeIDs
-          allElements(e)%tags(:) = ltags
+          allElements(e)%tags = entityTags(tag_index+1:tag_index+numTags)
 
        end do
-
-       deallocate(ltags)
-
     end do
 
     ! Check for $EndElements tag
@@ -939,7 +929,6 @@ subroutine read_nodes_coords_v4_binary( fd, filename, versionNumber, nodes )
     integer :: entityDim, entityTag, tag_index
     integer(kind=c_long) ::  ltmp, numentityelements
 
-    integer, allocatable :: ltags(:)
     integer(kind=c_long), allocatable :: vltmp(:)
 
     read(fd,*) charBuf

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -138,14 +138,14 @@ contains
     ! Read in the nodes
     if (versionNumber%major .eq. 4) then
        if( gmshFormat == asciiFormat ) then
-          call read_nodes_coords_version_four_ascii( fd, lfilename, &
+          call read_nodes_coords_v4_ascii( fd, lfilename, &
                versionNumber, nodes )
        else
-          call read_nodes_coords_version_four_binary( fd, lfilename, &
+          call read_nodes_coords_v4_binary( fd, lfilename, &
                versionNumber, nodes )
        end if
     else
-       call read_nodes_coords_version_two( fd, lfilename, gmshFormat, nodes )
+       call read_nodes_coords_v2( fd, lfilename, gmshFormat, nodes )
     end if
 
     ! Read in elements
@@ -158,7 +158,7 @@ contains
                versionNumber, elements, faces, dim, entityMap, entityTags)
        end if
     else
-       call read_faces_and_elements_version_two( fd, lfilename, gmshFormat, &
+       call read_faces_and_elements_v2( fd, lfilename, gmshFormat, &
          elements, faces, dim)
     end if
 
@@ -536,7 +536,7 @@ contains
   ! -----------------------------------------------------------------
   ! read in GMSH mesh nodes' coords into temporary arrays
 
-  subroutine read_nodes_coords_version_two( fd, filename, gmshFormat, nodes )
+  subroutine read_nodes_coords_v2( fd, filename, gmshFormat, nodes )
     integer :: fd, gmshFormat
 
     character(len=*) :: filename
@@ -591,9 +591,9 @@ contains
     if(gmshFormat == binaryFormat) read(fd, *) charBuf
 #endif
 
-  end subroutine read_nodes_coords_version_two
+  end subroutine read_nodes_coords_v2
 
-  subroutine read_nodes_coords_version_four_ascii( fd, filename, versionNumber, nodes )
+  subroutine read_nodes_coords_v4_ascii( fd, filename, versionNumber, nodes )
     integer :: fd
     type(version), intent(in) :: versionNumber
 
@@ -649,9 +649,9 @@ contains
        FLExit("Error: can't find '$EndNodes' in GMSH file '"//trim(filename)//"'")
     end if
 
-  end subroutine read_nodes_coords_version_four_ascii
+  end subroutine read_nodes_coords_v4_ascii
 
-subroutine read_nodes_coords_version_four_binary( fd, filename, versionNumber, nodes )
+subroutine read_nodes_coords_v4_binary( fd, filename, versionNumber, nodes )
     integer :: fd
     type(version)    :: versionNumber
 
@@ -721,7 +721,7 @@ subroutine read_nodes_coords_version_four_binary( fd, filename, versionNumber, n
     read(fd, *) charBuf
 #endif
 
-  end subroutine read_nodes_coords_version_four_binary
+  end subroutine read_nodes_coords_v4_binary
 
 
   ! -----------------------------------------------------------------
@@ -1022,7 +1022,7 @@ subroutine read_nodes_coords_version_four_binary( fd, filename, versionNumber, n
 
   end subroutine read_faces_and_elements_v4_binary
 
-  subroutine read_faces_and_elements_version_two( fd, filename, gmshFormat, &
+  subroutine read_faces_and_elements_v2( fd, filename, gmshFormat, &
        elements, faces, dim)
 
     integer, intent(in) :: fd, gmshFormat
@@ -1134,7 +1134,7 @@ subroutine read_nodes_coords_version_four_binary( fd, filename, versionNumber, n
     ! We no longer need this
     call deallocateElementList( allElements )
 
-  end subroutine read_faces_and_elements_version_two
+  end subroutine read_faces_and_elements_v2
 
   subroutine process_gmsh_elements(numAllElements, allElements, elements, faces, dim)
 

--- a/femtools/Read_GMSH.F90
+++ b/femtools/Read_GMSH.F90
@@ -59,7 +59,8 @@ module read_gmsh
 
   type version
 
-     integer :: major, minor
+    integer :: major = 0
+    integer :: minor = 0
 
   end type version
 
@@ -344,7 +345,8 @@ contains
     character(len=*) :: lfilename
     character(len=longStringLen) :: charBuf
     character :: newlineChar
-    integer gmshFileType, gmshDataSize, one, i
+    integer :: gmshFileType, gmshDataSize, one, i
+    logical :: decimalVersion = .false.
     type(version) versionNumber
 
 
@@ -358,10 +360,18 @@ contains
     read(fd, *) charBuf, gmshFileType, gmshDataSize
 
     do i=1, len_trim(charbuf)
-       if (charbuf(i:i) == '.') charbuf(i:i) = ' '
+      if (charbuf(i:i) == '.') then
+        charbuf(i:i) = ' '
+        decimalVersion = .true.
+      end if
     end do
 
-    read(charBuf,*, pad='yes') versionNumber%major, versionNumber%minor
+    if (decimalVersion) then
+      read(charBuf,*, pad='yes') versionNumber%major, versionNumber%minor
+    else
+      read(charBuf,*, pad='yes') versionNumber%major
+    end if
+
     if( versionNumber%major .lt. 2 .or. &
          versionNumber%major == 3 .or. &
          (versionNumber%major == 4 .and. versionNumber%minor .gt. 1) .or. &

--- a/python/fluidity/diagnostics/gmshtools.py
+++ b/python/fluidity/diagnostics/gmshtools.py
@@ -4,12 +4,12 @@
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
-# 
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -41,42 +41,42 @@ GMSH_TETRAHEDRON = 4
 GMSH_QUAD = 3
 GMSH_HEXAHEDRON = 5
 GMSH_POINT = 15
- 
+
 gmshElementTypeIds = ( \
     GMSH_UNKNOWN, \
     GMSH_LINE, GMSH_TRIANGLE, GMSH_QUAD, \
     GMSH_TETRAHEDRON, GMSH_HEXAHEDRON, \
     GMSH_POINT \
   )
-  
+
 def FromGmshNodeOrder(nodes, type):
   """
   Permute Gmsh node ordering into default node ordering
   """
-  
+
   newNodes = nodes
-  
+
   if type.GetElementTypeId() == elements.ELEMENT_QUAD:
     newNodes = copy.deepcopy(nodes)
     newNodes[3] = nodes[2]
     newNodes[2] = nodes[3]
-      
+
   return newNodes
-  
+
 def ToGmshNodeOrder(nodes, type):
   """
   Permute Gmsh node ordering into default node ordering
   """
 
   newNodes = nodes
-  
+
   if type.GetElementTypeId() == elements.ELEMENT_QUAD:
     newNodes = copy.deepcopy(nodes)
     newNodes[2] = nodes[3]
     newNodes[3] = nodes[2]
-      
+
   return newNodes
- 
+
 class GmshElementType(elements.ElementType):
   """
   Class defining a Gmsh element type
@@ -90,113 +90,243 @@ class GmshElementType(elements.ElementType):
       GMSH_POINT:elements.ELEMENT_VERTEX
     }
   _elementTypeIdToGmshElementTypeId = utils.DictInverse(_gmshElementTypeIdToElementTypeId)
-  
+
   def __init__(self, dim = None, nodeCount = None, gmshElementTypeId = None):
     if gmshElementTypeId is None:
       elements.ElementType.__init__(self, dim = dim, nodeCount = nodeCount)
     else:
       elements.ElementType.__init__(self, elementTypeId = self._gmshElementTypeIdToElementTypeId[gmshElementTypeId])
-      
+
     self._UpdateGmshElementTypeId()
     self.RegisterEventHandler("elementTypeIdChange", self._UpdateGmshElementTypeId)
-        
+
     return
-    
+
   def _UpdateGmshElementTypeId(self):
     """
     Update the Gmsh type ID to reflect the element type ID
     """
-    
+
     self._gmshElementTypeId = self._elementTypeIdToGmshElementTypeId[self._elementTypeId]
-    
+
     return
-    
+
   def GetGmshElementTypeId(self):
     return self._gmshElementTypeId
-    
+
   def SetGmshElementTypeId(self, gmshElementTypeId):
     self.SetElementTypeId(self._gmshElementTypeIdToElementTypeId[gmshElementTypeId])
-  
+
     return
-    
 
-def ReadMsh(filename):
+def ByteSwap(fileHandle):
   """
-  Read a Gmsh msh file
+  Given a file handle, read a single 32-bit int, which should have the value 1.
+  Determine whether this matches the endianness of the current architecture, or a swap is required.
   """
-      
-  def ReadNonCommentLine(fileHandle):
-    line = fileHandle.readline().decode("utf8")
-    while len(line) > 0:
-      line = line.strip()
-      if len(line) > 0:
-        return line
-      line = fileHandle.readline().decode("utf8")
-      
-    return line
-  
-  fileHandle = open(filename, "rb")
 
-  basename = filename.split(".")[0]
-  hasHalo = filehandling.FileExists(basename + ".halo")
-  
-  # Read the MeshFormat section
-  
-  line = ReadNonCommentLine(fileHandle)
-  assert(line == "$MeshFormat")
-  
-  line = ReadNonCommentLine(fileHandle)
-  lineSplit = line.split()
-  assert(len(lineSplit) == 3)
-  version = float(lineSplit[0])
-  fileType = int(lineSplit[1])
-  dataSize = int(lineSplit[2])  
-  if fileType == 1:
-    # Binary format
-    
-    if dataSize == 4:
-      realFormat = "f"
-    elif dataSize == 8:
-      realFormat = "d"
-    else:
-      raise Exception("Unrecognised real size " + str(dataSize))
-      
-    iArr = array.array("i")    
-    iArr.fromfile(fileHandle, 1)
+  iArr = array.array("i")
+  iArr.fromfile(fileHandle, 1)
+  if iArr[0] == 1:
+    swap = False
+  else:
+    iArr.byteswap()
     if iArr[0] == 1:
-      swap = False
+      swap = True
     else:
+      raise Exception("Invalid one byte")
+
+  return swap
+
+
+def ReadNonCommentLine(fileHandle):
+  line = fileHandle.readline().decode("utf8")
+  while len(line) > 0:
+    line = line.strip()
+    if len(line) > 0:
+      return line
+    line = fileHandle.readline().decode("utf8")
+
+  return line
+
+
+def ReadBinaryMshV2(fileHandle, dataSize):
+  if dataSize == 4:
+    realFormat = "f"
+  elif dataSize == 8:
+    realFormat = "d"
+  else:
+    raise Exception("Unrecognised real size " + str(dataSize))
+
+  swap = ByteSwap(fileHandle)
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndMeshFormat")
+
+  # Read the Nodes section (no PhysicalNames section in binary)
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Nodes")
+
+  # number-of-nodes
+  # node-number x-coord y-coord z-coord
+  # ...
+
+  line = ReadNonCommentLine(fileHandle)
+  nNodes = int(line)
+  # Assume dense node IDs, but not necessarily ordered
+  seenNode = [False for i in range(nNodes)]
+  nodeIds = []
+  nodes = []
+  lbound = [calc.Inf() for i in range(3)]
+  ubound = [-calc.Inf() for i in range(3)]
+  for i in range(nNodes):
+    iArr = array.array("i")
+    rArr = array.array(realFormat)
+    iArr.fromfile(fileHandle, 1)
+    rArr.fromfile(fileHandle, 3)
+    if swap:
       iArr.byteswap()
-      if iArr[0] == 1:
-        swap = True
-      else:
-        raise Exception("Invalid one byte")
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$EndMeshFormat")
-    
-    # Read the Nodes section
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$Nodes")    
-    
-    line = ReadNonCommentLine(fileHandle)
-    nNodes = int(line)
-    # Assume dense node IDs, but not necessarily ordered
-    seenNode = [False for i in range(nNodes)]
-    nodeIds = []
-    nodes = []
-    lbound = [calc.Inf() for i in range(3)]
-    ubound = [-calc.Inf() for i in range(3)]
-    for i in range(nNodes):
+      rArr.byteswap()
+    nodeId = iArr[0]
+    coord = rArr
+    assert(nodeId > 0)
+    assert(not seenNode[nodeId - 1])
+    seenNode[nodeId - 1] = True
+    nodeIds.append(nodeId)
+    nodes.append(coord)
+    for j in range(3):
+      lbound[j] = min(lbound[j], coord[j])
+      ubound[j] = max(ubound[j], coord[j])
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndNodes")
+
+  nodes = utils.KeyedSort(nodeIds, nodes)
+  bound = bounds.BoundingBox(lbound, ubound)
+  indices = bound.UsedDimIndices()
+  dim = len(indices)
+  if dim < 3:
+    nodes = [[coord[index] for index in indices] for coord in nodes]
+
+  mesh = meshes.Mesh(dim)
+  mesh.AddNodeCoords(nodes)
+
+  # Read the Elements section
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Elements")
+
+  # number-of-elements
+  # element-header-binary
+  # element-binary
+  # ...
+
+  # where element-header-binary is: elm-type num-elm num-tags
+  # where element-binary is:
+  #   num-elm * (4 + num-tags*4 + node-num*4)
+  # node-num physical-tag elementary-tag node-nums ...
+
+  line = ReadNonCommentLine(fileHandle)
+  nEles = int(line)
+  i = 0
+  while i < nEles:
+    iArr = array.array("i")
+    iArr.fromfile(fileHandle, 3)
+    if swap:
+      iArr.byteswap()
+    typeId = iArr[0]
+    nSubEles = iArr[1]
+    nIds = iArr[2]
+
+    type = GmshElementType(gmshElementTypeId = typeId)
+
+    for j in range(nSubEles):
       iArr = array.array("i")
-      rArr = array.array(realFormat)
-      iArr.fromfile(fileHandle, 1)
-      rArr.fromfile(fileHandle, 3)
+      iArr.fromfile(fileHandle, 1 + nIds + type.GetNodeCount())
       if swap:
         iArr.byteswap()
+      eleId = iArr[0]
+      assert(eleId > 0)
+      ids = iArr[1:1 + nIds]
+      nodes = FromGmshNodeOrder(utils.OffsetList(iArr[-type.GetNodeCount():], -1), type)
+
+      element = elements.Element(nodes, ids)
+
+      if type.GetDim() == dim - 1:
+        mesh.AddSurfaceElement(element)
+      elif type.GetDim() == dim:
+        mesh.AddVolumeElement(element)
+      else:
+        debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
+
+    i += nSubEles
+    assert(i == nEles)
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndElements")
+
+  return mesh
+
+
+def ReadBinaryMshV4(fileHandle, dataSize):
+  if dataSize == 4:
+    sizeFormat = "i"
+  elif dataSize == 8:
+    sizeFormat = "l"
+  else:
+    raise Exception("Unrecognised size_t size " + str(dataSize))
+
+  swap = ByteSwap(fileHandle)
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndMeshFormat")
+
+  # skip ahead to Nodes section (possibly bypassing Entities)
+  while line != "$Nodes":
+    line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Nodes")
+
+  # numEntityBlock(size_t) numNodes(size_t)
+  #   minNodeTag(size_t) maxNodeTag(size_t)
+  #
+  # entityDim(int) entityTag(int) parametric(int) numNodes(size_t)
+  #
+  #  nodeTag(size_t) ...
+  #  x(double) y(double) z(double) ...
+  # ...
+  sArr = array.array(sizeFormat)
+  sArr.fromfile(fileHandle, 4)
+  if swap:
+    sArr.byteswap()
+  numBlocks = sArr[0]
+  numNodes = sArr[1]
+  # assume dense nodes (we can check using the min/max id fields)
+  seenNode = [False] * numNodes
+  nodeIds = []
+  nodes = []
+  lbound = [calc.Inf() for i in range(3)]
+  ubound = [-calc.Inf() for i in range(3)]
+  for b in range(numBlocks):
+    iArr = array.array("i")
+    sArr = array.array(sizeFormat)
+    iArr.fromfile(fileHandle, 3)
+    sArr.fromfile(fileHandle, 1)
+    if swap:
+      iArr.byteswap()
+      sArr.byteswap()
+
+    subNodes = sArr[0]
+    tagArr = array.array(sizeFormat)
+    tagArr.fromfile(fileHandle, subNodes)
+    if swap:
+      tagArr.byteswap()
+
+    for i in range(subNodes):
+      rArr = array.array("d")
+      rArr.fromfile(fileHandle, 3)
+      if swap:
         rArr.byteswap()
-      nodeId = iArr[0]
+
+      nodeId = tagArr[i]
       coord = rArr
       assert(nodeId > 0)
       assert(not seenNode[nodeId - 1])
@@ -206,144 +336,292 @@ def ReadMsh(filename):
       for j in range(3):
         lbound[j] = min(lbound[j], coord[j])
         ubound[j] = max(ubound[j], coord[j])
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$EndNodes")
-      
-    nodes = utils.KeyedSort(nodeIds, nodes)
-    bound = bounds.BoundingBox(lbound, ubound)
-    indices = bound.UsedDimIndices()
-    dim = len(indices)
-    if dim < 3:
-      nodes = [[coord[index] for index in indices] for coord in nodes]
-    
-    mesh = meshes.Mesh(dim)
-    mesh.AddNodeCoords(nodes)
-      
-    # Read the Elements section
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$Elements")  
-    
-    line = ReadNonCommentLine(fileHandle)
-    nEles = int(line)
-    i = 0
-    while i < nEles:
-      iArr = array.array("i")
-      iArr.fromfile(fileHandle, 3)
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndNodes")
+
+  nodes = utils.KeyedSort(nodeIds, nodes)
+  bound = bounds.BoundingBox(lbound, ubound)
+  indices = bound.UsedDimIndices()
+  dim = len(indices)
+  if dim < 3:
+    nodes = [[coord[index] for index in indices] for coord in nodes]
+
+  mesh = meshes.Mesh(dim)
+  mesh.AddNodeCoords(nodes)
+
+  # read the Elements section
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Elements")
+
+  # numEntityBlocks(size_t) numElements(size_t)
+  #   minElementTag(size_t) maxElementTag(size_t)
+  #
+  # entityDim(int) entityTag(int) elementType(int) numElems(size_t)
+  #   elementTag(size_t) nodeTag(size_t) ...
+  #   ...
+  # ...
+  sArr = array.array(sizeFormat)
+  sArr.fromfile(fileHandle, 4)
+  if swap:
+    sArr.byteswap()
+  numEntities = sArr[0]
+  numElems = sArr[1]
+  for i in range(numEntities):
+    iArr = array.array("i")
+    sArr = array.array(sizeFormat)
+    iArr.fromfile(fileHandle, 3)
+    sArr.fromfile(fileHandle, 1)
+
+    if swap:
+      iArr.byteswap()
+      sArr.byteswap()
+
+    entityDim = iArr[0]
+    entityTag = iArr[1]
+    elementType = iArr[2]
+    elemsInBlock = sArr[0]
+
+    type = GmshElementType(gmshElementTypeId=elementType)
+
+    for j in range(elemsInBlock):
+      sArr = array.array(sizeFormat)
+      sArr.fromfile(1 + type.GetNodeCount())
       if swap:
-        iArr.byteswap()
-      typeId = iArr[0]
-      nSubEles = iArr[1]
-      nIds = iArr[2]
-      
-      type = GmshElementType(gmshElementTypeId = typeId)
-      
-      for j in range(nSubEles):
-        iArr = array.array("i")
-        iArr.fromfile(fileHandle, 1 + nIds + type.GetNodeCount())
-        if swap:
-          iArr.byteswap()
-        eleId = iArr[0]
-        assert(eleId > 0)
-        ids = iArr[1:1 + nIds]
-        nodes = FromGmshNodeOrder(utils.OffsetList(iArr[-type.GetNodeCount():], -1), type)
-        
-        element = elements.Element(nodes, ids)
-        
-        if type.GetDim() == dim - 1:
-          mesh.AddSurfaceElement(element)
-        elif type.GetDim() == dim:
-          mesh.AddVolumeElement(element)
-        else:
-          debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
-          
-      i += nSubEles
-    assert(i == nEles)
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$EndElements")
-  elif fileType == 0:
-    # ASCII format
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$EndMeshFormat")
-    
-    # Read the Nodes section
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$Nodes")
-    
-    line = ReadNonCommentLine(fileHandle)
-    nNodes = int(line)
-    # Assume dense node IDs, but not necessarily ordered
-    seenNode = [False for i in range(nNodes)]
-    nodeIds = []
-    nodes = []
-    lbound = [calc.Inf() for i in range(3)]
-    ubound = [-calc.Inf() for i in range(3)]
-    for i in range(nNodes):
-      line = ReadNonCommentLine(fileHandle)
-      lineSplit = line.split()
-      assert(len(lineSplit) == 4)
-      nodeId = int(lineSplit[0])
-      coord = [float(comp) for comp in lineSplit[1:]]
-      assert(nodeId > 0)
-      assert(not seenNode[nodeId - 1])
-      seenNode[nodeId - 1] = True
-      nodeIds.append(nodeId)
-      nodes.append(coord)
-      for j in range(3):
-        lbound[j] = min(lbound[j], coord[j])
-        ubound[j] = max(ubound[j], coord[j])
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$EndNodes")
-      
-    nodes = utils.KeyedSort(nodeIds, nodes)
-    bound = bounds.BoundingBox(lbound, ubound)
-    indices = bound.UsedDimIndices()
-    dim = len(indices)
-    if dim < 3:
-      nodes = [[coord[index] for index in indices] for coord in nodes]
-    
-    mesh = meshes.Mesh(dim)
-    mesh.AddNodeCoords(nodes)
-    
-    # Read the Elements section
-    
-    line = ReadNonCommentLine(fileHandle)
-    assert(line == "$Elements")  
-    
-    line = ReadNonCommentLine(fileHandle)
-    nEles = int(line)
-    for i in range(nEles):
-      line = ReadNonCommentLine(fileHandle)
-      lineSplit = line.split()
-      assert(len(lineSplit) > 3)
-      eleId = int(lineSplit[0])
-      assert(eleId > 0)
-      typeId = int(lineSplit[1])
-      nIds = int(lineSplit[2])
-      
-      type = GmshElementType(gmshElementTypeId = typeId)
-      ids = [int(id) for id in lineSplit[3:3 + nIds]]
-      nodes = FromGmshNodeOrder([int(node) - 1 for node in lineSplit[-type.GetNodeCount():]], type)
+        sArr.byteswap()
+
+      ids = [entityTag, sArr[0]]
+      nodes = FromGmshNodeOrder(utils.OffsetList(sArr[1:], -1), type)
       element = elements.Element(nodes, ids)
+
       if type.GetDim() == dim - 1:
         mesh.AddSurfaceElement(element)
       elif type.GetDim() == dim:
         mesh.AddVolumeElement(element)
       else:
         debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
-    
+
     line = ReadNonCommentLine(fileHandle)
     assert(line == "$EndElements")
-    
-    # Ignore all remaining sections
+
+    return mesh
+
+def ReadAsciiMshV2(fileHandle):
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndMeshFormat")
+
+  # Read the Nodes section
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Nodes")
+
+  line = ReadNonCommentLine(fileHandle)
+  nNodes = int(line)
+  # Assume dense node IDs, but not necessarily ordered
+  seenNode = [False for i in range(nNodes)]
+  nodeIds = []
+  nodes = []
+  lbound = [calc.Inf() for i in range(3)]
+  ubound = [-calc.Inf() for i in range(3)]
+  for i in range(nNodes):
+    line = ReadNonCommentLine(fileHandle)
+    lineSplit = line.split()
+    assert(len(lineSplit) == 4)
+    nodeId = int(lineSplit[0])
+    coord = [float(comp) for comp in lineSplit[1:]]
+    assert(nodeId > 0)
+    assert(not seenNode[nodeId - 1])
+    seenNode[nodeId - 1] = True
+    nodeIds.append(nodeId)
+    nodes.append(coord)
+    for j in range(3):
+      lbound[j] = min(lbound[j], coord[j])
+      ubound[j] = max(ubound[j], coord[j])
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndNodes")
+
+  nodes = utils.KeyedSort(nodeIds, nodes)
+  bound = bounds.BoundingBox(lbound, ubound)
+  indices = bound.UsedDimIndices()
+  dim = len(indices)
+  if dim < 3:
+    nodes = [[coord[index] for index in indices] for coord in nodes]
+
+  mesh = meshes.Mesh(dim)
+  mesh.AddNodeCoords(nodes)
+
+  # Read the Elements section
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Elements")
+
+  line = ReadNonCommentLine(fileHandle)
+  nEles = int(line)
+  for i in range(nEles):
+    line = ReadNonCommentLine(fileHandle)
+    lineSplit = line.split()
+    assert(len(lineSplit) > 3)
+    eleId = int(lineSplit[0])
+    assert(eleId > 0)
+    typeId = int(lineSplit[1])
+    nIds = int(lineSplit[2])
+
+    type = GmshElementType(gmshElementTypeId = typeId)
+    ids = [int(id) for id in lineSplit[3:3 + nIds]]
+    nodes = FromGmshNodeOrder([int(node) - 1 for node in lineSplit[-type.GetNodeCount():]], type)
+    element = elements.Element(nodes, ids)
+    if type.GetDim() == dim - 1:
+      mesh.AddSurfaceElement(element)
+    elif type.GetDim() == dim:
+      mesh.AddVolumeElement(element)
+    else:
+      debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndElements")
+
+  return mesh
+
+
+def ReadAsciiMshV4(fileHandle):
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndMeshFormat")
+
+  # skip to the Nodes section
+  while line != "$Nodes":
+    line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Nodes")
+
+  line = ReadNonCommentLine(fileHandle)
+  lineSplit = line.split()
+  numBlocks = int(lineSplit[0])
+  numNodes = int(lineSplit[1])
+  seenNode = [False] * numNodes
+  nodeIds = []
+  nodes = []
+  lbound = [calc.Inf() for i in range(3)]
+  ubound = [-calc.Inf() for i in range(3)]
+  for b in range(numBlocks):
+    line = ReadNonCommentLine(fileHandle)
+    lineSplit = line.split()
+    subNodes = int(lineSplit[3])
+    tagArr = [int(ReadNonCommentLine(fileHandle)) for i in range(subNodes)]
+    for i in range(subNodes):
+      line = ReadNonCommentLine(fileHandle)
+      lineSplit = line.split()
+      assert(len(lineSplit) == 3)
+
+      nodeId = tagArr[i]
+      coord = [float(comp) for comp in lineSplit]
+      assert(nodeId > 0)
+      assert(not seenNode[nodeId - 1])
+
+      seenNode[nodeId - 1] = True
+      nodeIds.append(nodeId)
+      nodes.append(coord)
+
+      for j in range(3):
+        lbound[j] = min(lbound[j], coord[j])
+        ubound[j] = max(ubound[j], coord[j])
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndNodes")
+
+  nodes = utils.KeyedSort(nodeIds, nodes)
+  bound = bounds.BoundingBox(lbound, ubound)
+  indices = bound.UsedDimIndices()
+  dim = len(indices)
+  if dim < 3:
+    nodes = [[coord[index] for index in indices] for coord in nodes]
+
+  mesh = meshes.Mesh(dim)
+  mesh.AddNodeCoords(nodes)
+
+  # read the Elements section
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$Elements")
+
+  line = ReadNonCommentLine(fileHandle)
+  lineSplit = line.split()
+  numEntities = int(lineSplit[0])
+  numElems = int(lineSplit[1])
+  for i in range(numEntities):
+    line = ReadNonCommentLine(fileHandle)
+    lineSplit = line.split()
+
+    entityDim = int(lineSplit[0])
+    entityTag = int(lineSplit[1])
+    elementType = int(lineSplit[2])
+    elemsInBlock = int(lineSplit[3])
+
+    type = GmshElementType(gmshElementTypeId=elementType)
+
+    for j in range(elemsInBlock):
+      line = ReadNonCommentLine(fileHandle)
+      lineSplit = line.split()
+      assert(len(lineSplit) == 1 + type.GetNodeCount())
+
+      ids = [entityTag, int(lineSplit[0])]
+      nodes = FromGmshNodeOrder([int(node) - 1 for node in lineSplit[1:]], type)
+      element = elements.Element(nodes, ids)
+
+      if type.GetDim() == dim - 1:
+        mesh.AddSurfaceElement(element)
+      elif type.GetDim() == dim:
+        mesh.AddVolumeElement(element)
+      else:
+        debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$EndElements")
+
+  return mesh
+
+
+def ReadMsh(filename):
+  """
+  Read a Gmsh msh file
+  """
+
+  fileHandle = open(filename, "rb")
+
+  basename = filename.split(".")[0]
+  hasHalo = filehandling.FileExists(basename + ".halo")
+
+  # Read the MeshFormat section
+
+  line = ReadNonCommentLine(fileHandle)
+  assert(line == "$MeshFormat")
+
+  line = ReadNonCommentLine(fileHandle)
+  lineSplit = line.split()
+  assert(len(lineSplit) == 3)
+  version = lineSplit[0]
+  fileType = int(lineSplit[1])
+  dataSize = int(lineSplit[2])
+
+  if version[0] == "4" and version < "4.1":
+    raise Exception("gmshtools doesn't handle msh4 with minor version 0")
+
+  if fileType == 1:
+    # Binary format
+    if version[0] == "4":
+      mesh = ReadBinaryMshV4(fileHandle, dataSize)
+    elif version[0] == "2":
+      mesh = ReadBinaryMshV2(fileHandle, dataSize)
+    else:
+      raise Exception("Unknown gmsh major version")
+  elif fileType == 0:
+    # ASCII format
+    if version[0] == "4":
+      mesh = ReadAsciiMshV4(fileHandle)
+    elif version[0] == "2":
+      mesh = ReadAsciiMshV2(fileHandle)
+    else:
+      raise Exception("Unknown gmsh major version")
   else:
     raise Exception("File type " + str(fileType) + " not recognised")
-  
+
   fileHandle.close()
 
   if hasHalo:
@@ -355,67 +633,67 @@ def ReadMsh(filename):
       mesh.SetHalos(halos)
     else:
       debug.deprint("Warning: No .halo I/O support")
-  
+
   return mesh
-  
+
 def WriteMsh(mesh, filename, binary = True):
   """
   Write a Gmsh msh file
   """
-  
+
   if binary:
     # Binary format
-    
+
     fileHandle = open(filename, "wb")
-    
-    # Write the MeshFormat section    
+
+    # Write the MeshFormat section
     fileHandle.write("$MeshFormat\n".encode("utf8"))
     version = 2.1
     fileType = 1
     dataSize = ctypes.sizeof(ctypes.c_double)
     fileHandle.write(utils.FormLine([version, fileType, dataSize]).encode("utf8"))
-    
+
     iArr = array.array("i", [1])
     iArr.tofile(fileHandle)
     fileHandle.write("\n".encode("utf8"))
-    
+
     fileHandle.write("$EndMeshFormat\n".encode("utf8"))
-    
+
     # Write the Nodes section
-    
+
     fileHandle.write("$Nodes\n".encode("utf8"))
     fileHandle.write(utils.FormLine([mesh.NodeCoordsCount()]).encode("utf8"))
-    
+
     for i, nodeCoord in enumerate(mesh.GetNodeCoords()):
       nodeCoord = list(nodeCoord)
       while len(nodeCoord) < 3:
         nodeCoord.append(0.0)
       assert(len(nodeCoord) == 3)
-      
+
       iArr = array.array("i", [i + 1])
       rArr = array.array("d", nodeCoord)
       iArr.tofile(fileHandle)
-      rArr.tofile(fileHandle) 
-    fileHandle.write("\n".encode("utf8"))     
-    
+      rArr.tofile(fileHandle)
+    fileHandle.write("\n".encode("utf8"))
+
     fileHandle.write("$EndNodes\n".encode("utf8"))
-    
+
     # Write the Elements section
-        
+
     fileHandle.write("$Elements\n".encode("utf8"))
     fileHandle.write(utils.FormLine([mesh.SurfaceElementCount() + mesh.VolumeElementCount()]).encode("utf8"))
-    
+
     eleSort = {}
     for ele in mesh.GetSurfaceElements() + mesh.GetVolumeElements():
       eleType = ele.GetType()
       gmshType = GmshElementType(dim = eleType.GetDim(), nodeCount = eleType.GetNodeCount())
-      
+
       key = (gmshType.GetGmshElementTypeId(), len(ele.GetIds()))
       if key in eleSort:
         eleSort[key].append(ele)
       else:
         eleSort[key] = [ele]
-    
+
     index = 1
     for gmshEleId, nIds in eleSort:
       eles = eleSort[(gmshEleId, nIds)]
@@ -427,23 +705,23 @@ def WriteMsh(mesh, filename, binary = True):
         index += 1
     assert(index == mesh.SurfaceElementCount() + mesh.VolumeElementCount() + 1)
     fileHandle.write("\n".encode("utf8"))
-    
+
     fileHandle.write("$EndElements\n".encode("utf8"))
   else:
     # ASCII format
-    
+
     fileHandle = open(filename, "w")
-    
-    # Write the MeshFormat section    
+
+    # Write the MeshFormat section
     fileHandle.write("$MeshFormat\n")
     version = 2.1
     fileType = 0
     dataSize = ctypes.sizeof(ctypes.c_double)
-    fileHandle.write(utils.FormLine([version, fileType, dataSize]))    
+    fileHandle.write(utils.FormLine([version, fileType, dataSize]))
     fileHandle.write("$EndMeshFormat\n")
-    
+
     # Write the Nodes section
-    
+
     fileHandle.write("$Nodes\n")
     fileHandle.write(utils.FormLine([mesh.NodeCoordsCount()]))
     for i, nodeCoord in enumerate(mesh.GetNodeCoords()):
@@ -453,9 +731,9 @@ def WriteMsh(mesh, filename, binary = True):
       assert(len(nodeCoord) == 3)
       fileHandle.write(utils.FormLine([i + 1, nodeCoord]))
     fileHandle.write("$EndNodes\n")
-    
+
     # Write the Elements section
-    
+
     fileHandle.write("$Elements\n")
     fileHandle.write(utils.FormLine([mesh.SurfaceElementCount() + mesh.VolumeElementCount()]))
     for i, ele in enumerate(mesh.GetSurfaceElements() + mesh.GetVolumeElements()):
@@ -464,10 +742,10 @@ def WriteMsh(mesh, filename, binary = True):
       ids = ele.GetIds()
       fileHandle.write(utils.FormLine([i + 1, gmshType.GetGmshElementTypeId(), len(ids), ids, utils.OffsetList(ToGmshNodeOrder(ele.GetNodes(), eleType), 1)]))
     fileHandle.write("$EndElements\n")
-  
+
   return
-    
-class gmshtoolsUnittests(unittest.TestCase):    
+
+class gmshtoolsUnittests(unittest.TestCase):
   def testGmshElementType(self):
     type = GmshElementType(dim = 2, nodeCount = 4)
     self.assertEquals(type.GetGmshElementTypeId(), GMSH_QUAD)
@@ -481,9 +759,9 @@ class gmshtoolsUnittests(unittest.TestCase):
     self.assertRaises(KeyError, type.SetGmshElementTypeId, GMSH_UNKNOWN)
     self.assertRaises(AssertionError, type.SetDim, -1)
     self.assertRaises(AssertionError, type.SetNodeCount, -1)
-    
+
     return
-    
+
   def testMshIo(self):
     tempDir = tempfile.mkdtemp()
     oldMesh = meshes.Mesh(2)
@@ -520,5 +798,5 @@ class gmshtoolsUnittests(unittest.TestCase):
     self.assertEquals(oldMesh.NodeCount(), newMesh.NodeCount())
     self.assertEquals(oldMesh.SurfaceElementCount(), newMesh.SurfaceElementCount())
     self.assertEquals(oldMesh.VolumeElementCount(), newMesh.VolumeElementCount())
-    
+
     return

--- a/python/fluidity/diagnostics/gmshtools.py
+++ b/python/fluidity/diagnostics/gmshtools.py
@@ -259,7 +259,7 @@ def ReadBinaryMshV2(fileHandle, dataSize):
         debug.deprint("Warning: Element of type " + str(type) + " encountered in " + str(dim) + " dimensions")
 
     i += nSubEles
-    assert(i == nEles)
+  assert(i == nEles)
 
   line = ReadNonCommentLine(fileHandle)
   assert(line == "$EndElements")

--- a/tests/channel-flow-dg/channel.py
+++ b/tests/channel-flow-dg/channel.py
@@ -41,7 +41,6 @@ def run_test(layers, binary):
     generate_meshfile("channel.geo",layers)
 
     os.system("gmsh -2 channel.geo")
-    os.system("../../bin/gmsh2triangle --2d channel.msh")
 
     os.system(binary+" channel.flml")
 

--- a/tests/channel-flow-dg/channel_viscous.py
+++ b/tests/channel-flow-dg/channel_viscous.py
@@ -31,7 +31,6 @@ def generate_meshfile(name,layers):
                  ).replace('<layers>',str(layers)))
 
     os.system("gmsh -2 "+name+".geo")
-    os.system("../../bin/gmsh2triangle --2d "+name+".msh")
 
 
 def run_test(layers, binary):

--- a/tests/diffusion-dg-stretched/makebox.py
+++ b/tests/diffusion-dg-stretched/makebox.py
@@ -25,6 +25,5 @@ def generate_meshfile(name,layers,width):
     open(name+".geo",'w').write(geo)
 
     os.system("gmsh -2 "+name+".geo")
-    os.system("../../bin/gmsh2triangle -2 "+name+".msh")
 
 

--- a/tests/mms_tracer_P1dg_cdg_diff_steady_3d_cjc/cdg3d.py
+++ b/tests/mms_tracer_P1dg_cdg_diff_steady_3d_cjc/cdg3d.py
@@ -24,7 +24,6 @@ def generate_meshfile(name,layers):
     open(name+".geo",'w').write(geo)
 
     os.system("gmsh -3 "+name+".geo")
-    os.system("../../bin/gmsh2triangle "+name+".msh")
 
 
 def run_test(layers, binary):

--- a/tests/mms_tracer_P1dg_cdg_diff_steady_3d_cjc_inhNmnnbc/cdg3d.py
+++ b/tests/mms_tracer_P1dg_cdg_diff_steady_3d_cjc_inhNmnnbc/cdg3d.py
@@ -36,7 +36,6 @@ def generate_meshfile(name,layers):
     open(name+".geo",'w').write(geo)
 
     os.system("gmsh -3 "+name+".geo")
-    os.system("../../bin/gmsh2triangle "+name+".msh")
 
 
 def run_test(layers, binary):

--- a/tests/spherical_patch/src/spherical_segment.geo
+++ b/tests/spherical_patch/src/spherical_segment.geo
@@ -72,8 +72,8 @@ lastPointOnParallel = IP + 60001;
 newParallelID = IL + 1000;
 Call DrawParallel;
 
-BSpline(IL + 1001) = {IP + 60001, IP + 60002};
-BSpline(IL + 1002) = {IP + 60000, IP + 60003};
+Line(IL + 1001) = {IP + 60001, IP + 60002};
+Line(IL + 1002) = {IP + 60000, IP + 60003};
 
 ////Draw North-most parallel of the Domain.
 pointsOnParallel = 200;            //Assign parameters to variables and then call function DrawParallel,

--- a/tests/wetting_and_drying_balzano1_cg/mesh/makemesh.sh
+++ b/tests/wetting_and_drying_balzano1_cg/mesh/makemesh.sh
@@ -1,4 +1,3 @@
 #/bin/sh
 gmsh mesh_connected.geo -2
-../../../bin/gmsh2triangle mesh_connected.msh -2
 

--- a/tests/wetting_and_drying_balzano2_cg/mesh/makemesh.sh
+++ b/tests/wetting_and_drying_balzano2_cg/mesh/makemesh.sh
@@ -1,4 +1,3 @@
 #/bin/sh
 gmsh mesh_connected.geo -2
-../../../bin/gmsh2triangle mesh_connected.msh -2
 

--- a/tests/wetting_and_drying_balzano3_cg_parallel/Makefile
+++ b/tests/wetting_and_drying_balzano3_cg_parallel/Makefile
@@ -2,7 +2,6 @@ all: input
 	fluidity  -v5 balzano1_2plus1.flml &> output.txt
 
 input: clean
-	cd mesh; ./makemesh.sh
 
 clean:
 	rm -f  *.ele *.edge *.node *.poly *vtu *.s *.d.1 *.stat *.msh *.detectors.h5part matrixdump* *.pdf *.png *.dat

--- a/tests/wind_stratification/Makefile
+++ b/tests/wind_stratification/Makefile
@@ -1,6 +1,6 @@
 input: clean
 	gmsh -2 src/square.geo -o square.msh
-	../../bin/transform_mesh '(x,0.001*y,z)' square
+	../../bin/transform_mesh '(x,0.001*y)' square
 
 clean:
 	rm -f  *.ele *.edge *.node *.msh *.vtu *.stat matrixdump* *.node.bak fluidity.*

--- a/tests/wind_stratification/Makefile
+++ b/tests/wind_stratification/Makefile
@@ -1,6 +1,6 @@
 input: clean
 	gmsh -2 src/square.geo -o square.msh
-	../../bin/transform_mesh '(x,0.001*y)' square
+	../../bin/transform_mesh '(x,0.001*y,z)' square
 
 clean:
 	rm -f  *.ele *.edge *.node *.msh *.vtu *.stat matrixdump* *.node.bak fluidity.*


### PR DESCRIPTION
This builds on the issue raised in #233 and https://github.com/FluidityProject/fluidity/commit/c41e5e54fc7e169c620b10d30058d7fd2918f788. On my local build, all tests pass except for one on `spherical_segment`, due to some changes in GMSH itself.

This support would introduce a new dependency on the Python [meshio](https://github.com/nschloe/meshio) library for the `gmsh_mesh_transform` and `transform_mesh` tools, which currently expect ASCII MSH files and modify them directly. I think it's probably a more robust solution to abstract these mesh modifications through some kind of library anyway.