### PR TITLE
Fix netcdf_read_free_surface with modern matplotlib

### DIFF
--- a/tests/netcdf_read_free_surface/height.py
+++ b/tests/netcdf_read_free_surface/height.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-from matplotlib.mlab import bivariate_normal
+from scipy.stats import multivariate_normal
 
 def function(position):
   xg = 3.0 * position[0]
   yg = 3.0 * position[1]
-  h1 = bivariate_normal(xg, yg, 1.0, 1.0, 0.0, 0.0)
-  h2 = bivariate_normal(xg, yg, 1.5, 0.5, 1, 1)
+  h1 = multivariate_normal.pdf([xg, yg], cov=[[1, 0], [0, 1]])
+  h2 = multivariate_normal.pdf([xg, yg], mean=[1, 1], cov=[[1.5**2, 0], [0, 0.5**2]])
   h = 10.0 * (h1 - h2)
   return h
 


### PR DESCRIPTION
The `bivariate_normal` function was removed from matplotlib's mlab modules [in 3.1.0](https://matplotlib.org/api/prev_api_changes/api_changes_3.1.0.html?highlight=bivariate_normal#matplotlib-mlab-removals). Using `multivariate_normal` from scipy (as of 0.14.0) can replicate the same behaviour: the maximum absolute difference is about 5e-16 (matplotlib 2.1.1, scipy 0.19.1, Python 2.7.15).

Making this change fixes the *netcdf_read_free_surface* test case with recent matplotlib versions.