### PR TITLE
Update create_makefile for Python 3

### DIFF
--- a/tools/create_makefile.py
+++ b/tools/create_makefile.py
@@ -188,9 +188,8 @@ def generate_dependencies(fortran):
     
     # Sort the output by filename.
     files=dependencies.keys()
-    files.sort()
 
-    for f in files:       
+    for f in sorted(files):
         dep_strings+=dependencies[f].as_strings()
     
     return dep_strings


### PR DESCRIPTION
One of the few things not caught by the test suite! We can't call `.sort()` on an iterator, so use `sorted()` instead.

Closes #240 