### PR TITLE
Add in 'make makefiles' test in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,8 @@ pipeline {
             steps { 
                 sh 'make -j' ;
                 sh 'make -j fltools' ;
+                sh 'make makefiles' ;
+                sh 'test -z "$(git status --porcelain */Makefile.dependencies)"' ;
                 sh 'make manual'
             }
         }


### PR DESCRIPTION
Jenkins is missing a make makefiles - add one to the testing suite.