### PR TITLE
Remove erronous scaling of extruded partioning weights

### DIFF
--- a/assemble/Zoltan_callbacks.F90
+++ b/assemble/Zoltan_callbacks.F90
@@ -82,14 +82,8 @@ contains
     
     if(zoltan_global_migrate_extruded_mesh) then
        ! weight the nodes according to the number of nodes in the column beneath it
-       max_obj_wgt = 1.0
        do i = 1, count
           obj_wgts(i) = float(row_length(zoltan_global_columns_sparsity, i))
-          max_obj_wgt = max(max_obj_wgt, obj_wgts(i))
-       end do
-       ! normalise according to the most nodes in a column
-       do i = 1, count
-          obj_wgts(i) = obj_wgts(i)/max_obj_wgt
        end do
     else
        do i = 1, count


### PR DESCRIPTION
This is in the partioning of the horizontal mesh. The weight for each
column is determined by the number of layers in that column. This weight
was then divided by the maximum number of layers, however the maximum
was not computed globally, so this scaling causes an imbalance between
partititions with many layers and those with few layers. Establishing
the global maximum (allmax) would probably cause a hang as this is inside a zoltan callback. Therefore just remove the scaling. This might give a different weighting of nodal vs. edge weights - but it's unclear what is the right answer.

Fixed #114.