### PR TITLE
Fix wrong Jacobian dimensions in transform_cvsurf_to_physical.

### DIFF
--- a/femtools/Transform_elements.F90
+++ b/femtools/Transform_elements.F90
@@ -2285,7 +2285,7 @@ contains
     type(cv_faces_type), intent(in) :: cvfaces
 
     ! Jacobian matrix
-    real, dimension(size(X,1),x_shape%numbering%dimension) :: J
+    real, dimension(size(X,1), size(x_shape%dn, 3)) :: J
 
     ! Determinant of J
     real :: detJ

--- a/femtools/Transform_elements.F90
+++ b/femtools/Transform_elements.F90
@@ -1664,7 +1664,7 @@ contains
 
 
     ! Jacobian matrix and its inverse.
-    real, dimension(X%dim,X%dim-1) :: J
+    real, dimension(X%dim, mesh_dim(X)-1) :: J
     ! Determinant of J
     real :: detJ
     ! Whether the cache can be used


### PR DESCRIPTION
The second dimension of J should be the surface dimension (i.e. dim-1),
otherwise the matmul in line 2326 does not match. This is copying a
smaller array into a larger, so should be safe - and I can't actually
get my compiler to complain (even with debugging) - but this should
hopefully fix #206.