### PR TITLE
Correct bug in make_mesh_periodic

### DIFF
--- a/femtools/Fields_Allocates.F90
+++ b/femtools/Fields_Allocates.F90
@@ -2165,7 +2165,7 @@ contains
     x => positions%val(1,:)
     if (positions%dim>1) then
        y => positions%val(2,:)
-       if(positions%dim>1) then
+       if(positions%dim>2) then
           z => positions%val(3,:)
        end if
     end if


### PR DESCRIPTION
I discovered this while trying to make an Intel-compiled executable run. This bug fix isn't specific to that, so I've broken it into its own PR.