### PR TITLE
Prevent unallocated/unassociated actual arguments

### DIFF
--- a/assemble/Momentum_CG.F90
+++ b/assemble/Momentum_CG.F90
@@ -1614,7 +1614,7 @@
       type(scalar_field), intent(in) :: nvfrac
       real, dimension(ele_loc(u, ele), ele_ngi(u, ele), u%dim), intent(in) :: du_t
       real, dimension(ele_loc(u, ele), ele_ngi(u, ele), u%dim), intent(in) :: dug_t
-      real, dimension(:, :, :), intent(in) :: dnvfrac_t
+      real, dimension(:, :, :), allocatable, intent(in) :: dnvfrac_t
       real, dimension(ele_ngi(u, ele)), intent(in) :: detwei
       real, dimension(u%dim, u%dim, ele_ngi(u,ele)) :: J_mat, diff_q
       real, dimension(u%dim, u%dim, ele_loc(u, ele), ele_loc(u, ele)), intent(inout) :: big_m_tensor_addto

--- a/assemble/Multiphase.F90
+++ b/assemble/Multiphase.F90
@@ -485,7 +485,7 @@
                     
                type(scalar_field), intent(in) :: vfrac_fluid, vfrac_particle
                type(scalar_field), intent(in) :: density_fluid, density_particle
-               type(scalar_field), intent(in) :: d_field ! Scalar field representing particle diameter
+               type(scalar_field), pointer, intent(in) :: d_field ! Scalar field representing particle diameter
                type(vector_field), intent(in) :: nu_fluid, nu_particle
                type(vector_field), intent(in) :: oldu_fluid, oldu_particle
                type(tensor_field), intent(in) :: viscosity_fluid    
@@ -900,7 +900,7 @@
                     
                type(scalar_field), intent(in) :: vfrac_fluid, vfrac_particle
                type(scalar_field), intent(in) :: density_fluid, density_particle
-               type(scalar_field), intent(in) :: d_field ! Scalar field representing particle diameter
+               type(scalar_field), pointer, intent(in) :: d_field ! Scalar field representing particle diameter
                type(vector_field), intent(in) :: nu_fluid, nu_particle
                type(scalar_field), intent(in) :: internal_energy_fluid, internal_energy_particle
                type(scalar_field), intent(in) :: old_internal_energy_fluid, old_internal_energy_particle

--- a/horizontal_adaptivity/Extrude.F90
+++ b/horizontal_adaptivity/Extrude.F90
@@ -360,7 +360,7 @@ module hadapt_extrude
     real, intent(in) :: map_depth, min_depth
     real, intent(in) :: depth, constant_sizing
     character(len=*), intent(in) :: depth_function, sizing_function
-    real, dimension(:), intent(in) :: sizing_vector
+    real, dimension(:), allocatable, intent(in) :: sizing_vector
     integer, intent(in) :: number_sigma_layers
     logical, intent(in) :: radial_extrusion
 
@@ -569,7 +569,7 @@ module hadapt_extrude
     integer, intent(in) :: column
     logical, intent(in) :: apply_region_ids
     logical, intent(inout) :: column_visited
-    integer, dimension(:), intent(in) :: region_ids
+    integer, dimension(:), allocatable, intent(in) :: region_ids
     integer, intent(inout), optional :: visited_count
     
     integer, dimension(:), pointer :: eles

--- a/parameterisation/k_epsilon.F90
+++ b/parameterisation/k_epsilon.F90
@@ -450,7 +450,7 @@ subroutine assemble_rhs_ele(src_abs_terms, k, eps, scalar_eddy_visc, u, density,
   integer :: term, ngi, dim, gi, i
 
   type(vector_field), intent(in) :: bc_value	
-  integer, dimension(:,:), intent(in) :: bc_type    
+  integer, dimension(:,:), allocatable, intent(in) :: bc_type
 
   real, dimension(:, :, :), allocatable :: dshape_u
 

--- a/population_balance/DQMOM.F90
+++ b/population_balance/DQMOM.F90
@@ -716,8 +716,8 @@ contains
                  &X, singular_option, perturb_val, cond, ele)
 
     type(scalar_field), dimension(:), intent(in) :: abscissa, weight
-    type(scalar_field), intent(in) :: turbulent_dissipation
-    type(tensor_field), intent(in) :: viscosity_continuous
+    type(scalar_field), pointer, intent(in) :: turbulent_dissipation
+    type(tensor_field), pointer, intent(in) :: viscosity_continuous
     type(scalar_field_pointer), dimension(:), intent(inout) :: s_weighted_abscissa, s_weight
     type(tensor_field), pointer, intent(in) :: D
     type(vector_field), pointer, intent(in) :: X


### PR DESCRIPTION
In a few places, an array will be allocated or a pointer associated depending on a logical flag. These subroutines then call another subroutine, passing the array/pointer and the flag. However, the dummy argument to this second subroutine doesn't have the `allocatable` or `pointer` attributes. Depending on the flag, we may be passing an unallocated array or unassociated pointer to a bare dummy argument, which is not allowed. To be compliant, we should specify these attributes, even for `intent(in)` dummy arguments, where the allocated/associated status is not allowed to change (this is a Fortran 2003-ism in the case of pointers).

For an example of the pattern:

```fortran
subroutine construct_momentum_element_cg(...)
  real, dimension(:,:,:), allocatable :: dnvfrac_t

  if (multiphase) then
    allocate(dnvfrac_t(...))
  end if

  call add_advection_element_cg(..., dnvfrac_t, ...)
end subroutine construct_momentum_element_cg

subroutine add_advection_element_cg(..., dnvfrac_t, ...)
  real, dimension(:,:,:), intent(in) :: dnvfrac_t
  !                                     ^--- we might pass an unallocated array to this!
  
  if (multiphase) then
    ! do something with dnvfrac_t
  end if
  ...
```

These are just the cases I had to fix to get the short/medium tests to run with the Intel compiler with checking enabled, so I'm not sure if it's exhaustive. Ideally this'd be statically analysed somehow