### PR TITLE
Statplot as a standalone

### DIFF
--- a/tools/statplot.py
+++ b/tools/statplot.py
@@ -320,7 +320,7 @@ class StatplotWindow(Gtk.Window):
             values = numpy.fromfile(self.statfile[0] + '.dat',
                                     dtype=numpy.float64)
             ncols = entries.size
-            nrows = int(values.size // ncols)
+            nrows = values.size // ncols
             values = values[:nrows * ncols].reshape(nrows, ncols)
         return list(entries), values
 


### PR DESCRIPTION
I had already proposed this idea in this now-closed [issue](https://github.com/FluidityProject/fluidity/issues/236) where I tried to show that many files in the Fluidity tree are currently involved in the file-reading process of statplot.

I believe that the current situation is too complex for what it should be and therefore I hereby propose a standalone version of statplot.

Changes compared to the master branch are summarized in the two commit messages. Instructions relative to the implemented keyboard shortcuts are available through `statplot.py --help`.

I am happy to modify further and implement new features if requested.