### PR TITLE
Surface l2 norm

### DIFF
--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -714,6 +714,15 @@ contains
               buffer = field_tag(sfield%name, column, "surface_integral%" // trim(surface_integral_name), material_phase_name)
               write(default_stat%diag_unit, "(a)") trim(buffer)
            end do
+
+            ! Surface l2norms
+            do j = 0, option_count(trim(complete_field_path(sfield%option_path, stat = stat)) // "/stat/surface_l2norm") - 1
+              call get_option(trim(complete_field_path(sfield%option_path)) &
+              // "/stat/surface_l2norm[" // int2str(j) // "]/name", surface_integral_name)
+              column = column + 1
+              buffer = field_tag(sfield%name, column, "surface_l2norm%" // trim(surface_integral_name), material_phase_name)
+              write(default_stat%diag_unit, "(a)") trim(buffer)
+           end do
            
          end do
 
@@ -773,6 +782,15 @@ contains
              // "/stat/surface_integral[" // int2str(j) // "]/name", surface_integral_name)
              column = column + 1
              buffer = field_tag(vfield%name, column, "surface_integral%" // trim(surface_integral_name), material_phase_name)
+             write(default_stat%diag_unit, "(a)") trim(buffer)
+           end do
+
+           ! Surface l2norms
+           do j = 0, option_count(trim(complete_field_path(vfield%option_path, stat = stat)) // "/stat/surface_l2norm") - 1
+             call get_option(trim(complete_field_path(vfield%option_path)) &
+             // "/stat/surface_integral[" // int2str(j) // "]/name", surface_integral_name)
+             column = column + 1
+             buffer = field_tag(vfield%name, column, "surface_l2norm%" // trim(surface_integral_name), material_phase_name)
              write(default_stat%diag_unit, "(a)") trim(buffer)
            end do
 
@@ -1915,7 +1933,7 @@ contains
     logical, intent(in), optional :: not_to_move_det_yet 
 
     character(len = 2 + real_format_len(padding = 1) + 1) :: format, format2, format3, format4
-    character(len = OPTION_PATH_LEN) :: func
+    character(len = OPTION_PATH_LEN) :: func, option_path
     integer :: i, j, k, phase, stat
     integer, dimension(2) :: shape_option
     integer :: nodes, elements, surface_elements
@@ -2050,8 +2068,19 @@ contains
           end do
          
          ! Surface integrals
-         do j = 0, option_count(trim(complete_field_path(sfield%option_path, stat = stat)) // "/stat/surface_integral") - 1
-           surface_integral = calculate_surface_integral(sfield, xfield, j)
+         option_path = trim(complete_field_path(sfield%option_path, stat = stat)) // "/stat/surface_integral"
+         do j = 0, option_count(option_path) - 1
+           surface_integral = calculate_surface_integral(sfield, xfield, trim(option_path)//"["//int2str(j)//"]")
+           ! Only the first process should write statistics information
+           if(getprocno() == 1) then
+             write(default_stat%diag_unit, trim(format), advance = "no") surface_integral
+           end if
+         end do
+
+         ! Surface l2norms
+         option_path = trim(complete_field_path(sfield%option_path, stat = stat)) // "/stat/surface_l2norm"
+         do j = 0, option_count(option_path) - 1
+           surface_integral = calculate_surface_l2norm(sfield, xfield, trim(option_path)//"["//int2str(j)//"]")
            ! Only the first process should write statistics information
            if(getprocno() == 1) then
              write(default_stat%diag_unit, trim(format), advance = "no") surface_integral
@@ -2094,8 +2123,19 @@ contains
          end if
          
          ! Surface integrals
-         do j = 0, option_count(trim(complete_field_path(vfield%option_path, stat = stat)) // "/stat/surface_integral") - 1
-           surface_integral = calculate_surface_integral(vfield, xfield, j)
+         option_path = trim(complete_field_path(vfield%option_path, stat = stat)) // "/stat/surface_integral"
+         do j = 0, option_count(option_path) - 1
+           surface_integral = calculate_surface_integral(vfield, xfield, trim(option_path)//"["//int2str(j)//"]")
+           ! Only the first process should write statistics information
+           if(getprocno() == 1) then
+             write(default_stat%diag_unit, trim(format), advance = "no") surface_integral
+           end if
+         end do
+
+         ! Surface l2norms
+         option_path = trim(complete_field_path(vfield%option_path, stat = stat)) // "/stat/surface_l2norm"
+         do j = 0, option_count(option_path) - 1
+           surface_integral = calculate_surface_l2norm(vfield, xfield, trim(option_path)//"["//int2str(j)//"]")
            ! Only the first process should write statistics information
            if(getprocno() == 1) then
              write(default_stat%diag_unit, trim(format), advance = "no") surface_integral

--- a/femtools/Diagnostic_variables.F90
+++ b/femtools/Diagnostic_variables.F90
@@ -788,7 +788,7 @@ contains
            ! Surface l2norms
            do j = 0, option_count(trim(complete_field_path(vfield%option_path, stat = stat)) // "/stat/surface_l2norm") - 1
              call get_option(trim(complete_field_path(vfield%option_path)) &
-             // "/stat/surface_integral[" // int2str(j) // "]/name", surface_integral_name)
+             // "/stat/surface_l2norm[" // int2str(j) // "]/name", surface_integral_name)
              column = column + 1
              buffer = field_tag(vfield%name, column, "surface_l2norm%" // trim(surface_integral_name), material_phase_name)
              write(default_stat%diag_unit, "(a)") trim(buffer)

--- a/femtools/Surface_Integrals.F90
+++ b/femtools/Surface_Integrals.F90
@@ -870,7 +870,7 @@ contains
     real :: integral
     
     character(len = real_format_len() + 4) :: format_buffer
-    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
+    character(len = FIELD_NAME_LEN) :: integral_name
     integer, dimension(2) :: shape
     integer, dimension(:), allocatable :: surface_ids
     logical :: normalise
@@ -896,9 +896,9 @@ contains
     
     call get_option(trim(option_path) // "/name", integral_name)
     if(normalise) then
-      ewrite(2, *) "Normalised surface l2norm of type " // trim(integral_type) // " for field " // trim(s_field%name) // ":"
+      ewrite(2, *) "Normalised surface l2norm of field " // trim(s_field%name) // ":"
     else
-      ewrite(2, *) "Surface l2norm of type " // trim(integral_type) // " for field " // trim(s_field%name) // ":"
+      ewrite(2, *) "Surface l2norm of field " // trim(s_field%name) // ":"
     end if
     format_buffer = "(a," // real_format() // ")"
     ewrite(2, format_buffer) trim(integral_name) // " = ", integral
@@ -916,7 +916,7 @@ contains
     real :: integral
     
     character(len = real_format_len() + 4) :: format_buffer
-    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
+    character(len = FIELD_NAME_LEN) :: integral_name
     integer, dimension(2) :: shape
     integer, dimension(:), allocatable :: surface_ids
     logical :: normalise
@@ -942,9 +942,9 @@ contains
     
     call get_option(trim(option_path) // "/name", integral_name)
     if(normalise) then
-      ewrite(2, *) "Normalised surface integral of type " // trim(integral_type) // " for field " // trim(v_field%name) // ":"
+      ewrite(2, *) "Normalised surface integral of field " // trim(v_field%name) // ":"
     else
-      ewrite(2, *) "Surface integral of type " // trim(integral_type) // " for field " // trim(v_field%name) // ":"
+      ewrite(2, *) "Surface integral of field " // trim(v_field%name) // ":"
     end if
     format_buffer = "(a," // real_format() // ")"
     ewrite(2, format_buffer) trim(integral_name) // " = ", integral

--- a/femtools/Surface_Integrals.F90
+++ b/femtools/Surface_Integrals.F90
@@ -49,7 +49,7 @@ module surface_integrals
   
   public :: calculate_surface_integral, gradient_normal_surface_integral, &
     & normal_surface_integral, surface_integral, surface_gradient_normal, &
-    & surface_normal_distance_sele
+    & surface_normal_distance_sele, calculate_surface_l2norm, surface_l2norm
   public :: diagnostic_body_drag
   
   interface integrate_over_surface_element
@@ -62,6 +62,16 @@ module surface_integrals
   interface calculate_surface_integral
     module procedure calculate_surface_integral_scalar, &
       & calculate_surface_integral_vector
+  end interface
+
+  interface calculate_surface_l2norm
+    module procedure calculate_surface_l2norm_scalar, &
+      & calculate_surface_l2norm_vector
+  end interface
+
+  interface surface_l2norm
+    module procedure surface_l2norm_scalar, &
+      & surface_l2norm_vector
   end interface
 
 contains
@@ -89,11 +99,7 @@ contains
     integral = 0.0   
     
     do i = 1, surface_element_count(s_field)    
-      if(present(surface_ids)) then
-        integrate_over_element = integrate_over_surface_element(s_field, i, surface_ids)
-      else
-        integrate_over_element = integrate_over_surface_element(s_field, i)
-      end if
+      integrate_over_element = integrate_over_surface_element(s_field, i, surface_ids=surface_ids)
       
       if(integrate_over_element) then
         if(present_and_true(normalise)) then
@@ -160,11 +166,7 @@ contains
     end if
     integral = 0.0   
     do i = 1, surface_element_count(v_field)
-      if(present(surface_ids)) then
-        integrate_over_element = integrate_over_surface_element(v_field, i, surface_ids)
-      else
-        integrate_over_element = integrate_over_surface_element(v_field, i)
-      end if
+      integrate_over_element = integrate_over_surface_element(v_field, i, surface_ids=surface_ids)
       
       if(integrate_over_element) then
         if(present_and_true(normalise)) then
@@ -253,11 +255,7 @@ contains
     integral = 0.0   
     
     do i = 1, surface_element_count(s_field)
-      if(present(surface_ids)) then
-        integrate_over_element = integrate_over_surface_element(s_field, i, surface_ids)
-      else
-        integrate_over_element = integrate_over_surface_element(s_field, i)
-      end if
+      integrate_over_element = integrate_over_surface_element(s_field, i, surface_ids=surface_ids)
       
       if(integrate_over_element) then
         if(present_and_true(normalise)) then
@@ -373,7 +371,135 @@ contains
     end function include_face
     
   end subroutine surface_gradient_normal
-  
+
+  function surface_l2norm_scalar(s_field, positions, surface_ids, normalise) result(integral)
+    !!< Calculate the L2 norm over the surface of the mesh.
+    !!< surface elements integrated over are defined by
+    !!< integrate_over_surface_element(...). If normalise is present and true,
+    !!< the result is divided by the sqrt of the surface area
+
+    type(scalar_field), intent(in) :: s_field
+    type(vector_field), target, intent(in) :: positions
+    integer, dimension(:), optional, intent(in) :: surface_ids
+    logical, optional, intent(in) :: normalise
+
+    real :: integral
+
+    integer :: i
+    real :: area, face_area, face_integral
+
+    if(present_and_true(normalise)) then
+      area = 0.0
+    end if
+    integral = 0.0
+
+    do i = 1, surface_element_count(s_field)
+      if (integrate_over_surface_element(s_field, i, surface_ids=surface_ids)) then
+        if(present_and_true(normalise)) then
+          call surface_l2norm_scalar_face(s_field, i, positions, face_integral, area = face_area)
+          area = area + face_area
+        else
+          call surface_l2norm_scalar_face(s_field, i, positions, face_integral)
+        end if
+        integral = integral + face_integral
+      end if
+    end do
+
+    call allsum(integral, communicator = halo_communicator(s_field))
+
+    if(present_and_true(normalise)) then
+      call allsum(area, communicator = halo_communicator(s_field))
+      integral = integral / area
+    end if
+
+    integral = sqrt(integral)
+
+  end function surface_l2norm_scalar
+
+  subroutine surface_l2norm_scalar_face(s_field, face, positions, integral, area)
+    type(scalar_field), intent(in) :: s_field
+    type(vector_field), intent(in) :: positions
+    integer, intent(in) :: face
+    real, intent(out) :: integral
+    real, optional, intent(out) :: area
+
+    real, dimension(face_ngi(s_field, face)) :: detwei
+
+    assert(face_ngi(s_field, face) == face_ngi(positions, face))
+
+    call transform_facet_to_physical(positions, face, detwei)
+
+    integral = dot_product(face_val_at_quad(s_field, face)**2, detwei)
+    if(present(area)) then
+      area = sum(detwei)
+    end if
+
+  end subroutine surface_l2norm_scalar_face
+
+  function surface_l2norm_vector(v_field, positions, surface_ids, normalise) result(integral)
+    !!< Calculate the L2 norm over the surface of the mesh.
+    !!< surface elements integrated over are defined by
+    !!< integrate_over_surface_element(...). If normalise is present and true,
+    !!< the result is divided by the sqrt of the surface area
+
+    type(vector_field), intent(in) :: v_field
+    type(vector_field), target, intent(in) :: positions
+    integer, dimension(:), optional, intent(in) :: surface_ids
+    logical, optional, intent(in) :: normalise
+
+    real :: integral
+
+    integer :: i
+    real :: area, face_area, face_integral
+
+    if(present_and_true(normalise)) then
+      area = 0.0
+    end if
+    integral = 0.0
+
+    do i = 1, surface_element_count(v_field)
+      if (integrate_over_surface_element(v_field, i, surface_ids=surface_ids)) then
+        if(present_and_true(normalise)) then
+          call surface_l2norm_vector_face(v_field, i, positions, face_integral, area = face_area)
+          area = area + face_area
+        else
+          call surface_l2norm_vector_face(v_field, i, positions, face_integral)
+        end if
+        integral = integral + face_integral
+      end if
+    end do
+
+    call allsum(integral, communicator = halo_communicator(v_field))
+
+    if(present_and_true(normalise)) then
+      call allsum(area, communicator = halo_communicator(v_field))
+      integral = integral / area
+    end if
+
+    integral = sqrt(integral)
+
+  end function surface_l2norm_vector
+
+  subroutine surface_l2norm_vector_face(v_field, face, positions, integral, area)
+    type(vector_field), intent(in) :: v_field
+    type(vector_field), intent(in) :: positions
+    integer, intent(in) :: face
+    real, intent(out) :: integral
+    real, optional, intent(out) :: area
+
+    real, dimension(face_ngi(v_field, face)) :: detwei
+
+    assert(face_ngi(v_field, face) == face_ngi(positions, face))
+
+    call transform_facet_to_physical(positions, face, detwei)
+
+    integral = sum(matmul(face_val_at_quad(v_field, face)**2, detwei))
+    if(present(area)) then
+      area = sum(detwei)
+    end if
+
+  end subroutine surface_l2norm_vector_face
+
   function surface_normal_distance_sele(positions, sele, ele) result(h)
     ! calculate wall-normal element size
     type(vector_field), intent(in) :: positions
@@ -443,11 +569,7 @@ contains
     
     logical :: integrate_over_element
 
-    if(present(surface_ids)) then
-      integrate_over_element = integrate_over_surface_element(s_field%mesh, face_number, surface_ids)
-    else
-      integrate_over_element = integrate_over_surface_element(s_field%mesh, face_number)
-    end if
+    integrate_over_element = integrate_over_surface_element(s_field%mesh, face_number, surface_ids=surface_ids)
     
   end function integrate_over_surface_element_scalar
   
@@ -461,11 +583,7 @@ contains
     
     logical :: integrate_over_element
     
-    if(present(surface_ids)) then
-      integrate_over_element = integrate_over_surface_element(v_field%mesh, face_number, surface_ids)
-    else
-      integrate_over_element = integrate_over_surface_element(v_field%mesh, face_number)
-    end if
+    integrate_over_element = integrate_over_surface_element(v_field%mesh, face_number, surface_ids=surface_ids)
     
   end function integrate_over_surface_element_vector
   
@@ -479,11 +597,7 @@ contains
     
     logical :: integrate_over_element
     
-    if(present(surface_ids)) then
-      integrate_over_element = integrate_over_surface_element(t_field%mesh, face_number, surface_ids)
-    else
-      integrate_over_element = integrate_over_surface_element(t_field%mesh, face_number)
-    end if
+    integrate_over_element = integrate_over_surface_element(t_field%mesh, face_number, surface_ids=surface_ids)
 
   end function integrate_over_surface_element_tensor
 
@@ -634,51 +748,33 @@ contains
     ewrite(1, *) "Exiting diagnostic_body_drag"
     
   end subroutine diagnostic_body_drag
-  
-  function calculate_surface_integral_scalar(s_field, positions, index) result(integral)
+
+  function calculate_surface_integral_scalar(s_field, positions, option_path) result(integral)
     !!< Calculates a surface integral for the specified scalar field based upon
     !!< options defined in the options tree
     
     type(scalar_field), intent(in) :: s_field
     type(vector_field), intent(in) :: positions
-    integer, optional, intent(in) :: index
+    character(len=*), intent(in) :: option_path
     
     real :: integral
     
     character(len = real_format_len() + 4) :: format_buffer
-    character(len = FIELD_NAME_LEN) :: integral_name
-    character(len = OPTION_PATH_LEN) :: path, integral_type
-    integer :: lindex, max_index
+    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
     integer, dimension(2) :: shape
     integer, dimension(:), allocatable :: surface_ids
     logical :: normalise
     
-    if(present(index)) then
-      lindex = index
-    else
-      lindex = 0
-    end if
-    
-    path = trim(complete_field_path(s_field%option_path)) // "/stat/surface_integral"
-    
-    max_index = option_count(trim(path)) - 1
-    if(lindex < 0 .or. lindex > max_index) then
-      ewrite(-1, "(a,i0,a,i0)") "Index: ", lindex, " - Max index: ", max_index
-      FLAbort("Invalid option path index when calculating surface integral")
-    end if
-    
-    path = trim(path) // "[" // int2str(lindex) // "]"
-    
-    if(have_option(trim(path) // "/surface_ids")) then
-      shape = option_shape(trim(path) // "/surface_ids")
+    if(have_option(trim(option_path) // "/surface_ids")) then
+      shape = option_shape(trim(option_path) // "/surface_ids")
       assert(shape(1) >= 0)
       allocate(surface_ids(shape(1)))
-      call get_option(trim(path) // "/surface_ids", surface_ids)
+      call get_option(trim(option_path) // "/surface_ids", surface_ids)
     end if
     
-    normalise = have_option(trim(path) // "/normalise")
+    normalise = have_option(trim(option_path) // "/normalise")
     
-    call get_option(trim(path) // "/type", integral_type)
+    call get_option(trim(option_path) // "/type", integral_type)
     select case(trim(integral_type))
       case("value")
         if(allocated(surface_ids)) then
@@ -700,7 +796,7 @@ contains
       deallocate(surface_ids)
     end if
     
-    call get_option(trim(path) // "/name", integral_name)
+    call get_option(trim(option_path) // "/name", integral_name)
     if(normalise) then
       ewrite(2, *) "Normalised surface integral of type " // trim(integral_type) // " for field " // trim(s_field%name) // ":"
     else
@@ -711,50 +807,32 @@ contains
     
   end function calculate_surface_integral_scalar
   
-  function calculate_surface_integral_vector(v_field, positions, index) result(integral)
+  function calculate_surface_integral_vector(v_field, positions, option_path) result(integral)
     !!< Calculates a surface integral for the specified vector field based upon
     !!< options defined in the options tree
     
     type(vector_field), intent(in) :: v_field
     type(vector_field), intent(in) :: positions
-    integer, optional, intent(in) :: index
+    character(len=*), intent(in) :: option_path
     
     real :: integral
     
     character(len = real_format_len() + 4) :: format_buffer
-    character(len = FIELD_NAME_LEN) :: integral_name
-    character(len = OPTION_PATH_LEN) :: path, integral_type
-    integer :: lindex, max_index
+    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
     integer, dimension(2) :: shape
     integer, dimension(:), allocatable :: surface_ids
     logical :: normalise
     
-    if(present(index)) then
-      lindex = index
-    else
-      lindex = 0
-    end if
-    
-    path = trim(complete_field_path(v_field%option_path)) // "/stat/surface_integral"
-    
-    max_index = option_count(trim(path)) - 1
-    if(lindex < 0 .or. lindex > max_index) then
-      ewrite(-1, "(a,i0,a,i0)") "Index: ", lindex, " - Max index: ", max_index
-      FLAbort("Invalid option path index when calculating surface integral")
-    end if
-    
-    path = trim(path) // "[" // int2str(lindex) // "]"
-    
-    if(have_option(trim(path) // "/surface_ids")) then
-      shape = option_shape(trim(path) // "/surface_ids")
+    if(have_option(trim(option_path) // "/surface_ids")) then
+      shape = option_shape(trim(option_path) // "/surface_ids")
       assert(shape(1) >= 0)
       allocate(surface_ids(shape(1)))
-      call get_option(trim(path) // "/surface_ids", surface_ids)
+      call get_option(trim(option_path) // "/surface_ids", surface_ids)
     end if
     
-    normalise = have_option(trim(path) // "/normalise")
+    normalise = have_option(trim(option_path) // "/normalise")
     
-    call get_option(trim(path) // "/type", integral_type)
+    call get_option(trim(option_path) // "/type", integral_type)
     select case(trim(integral_type))
       case("normal")
         if(allocated(surface_ids)) then
@@ -770,7 +848,7 @@ contains
       deallocate(surface_ids)
     end if
     
-    call get_option(trim(path) // "/name", integral_name)
+    call get_option(trim(option_path) // "/name", integral_name)
     if(normalise) then
       ewrite(2, *) "Normalised surface integral of type " // trim(integral_type) // " for field " // trim(v_field%name) // ":"
     else
@@ -780,5 +858,97 @@ contains
     ewrite(2, format_buffer) trim(integral_name) // " = ", integral
     
   end function calculate_surface_integral_vector
+
+  function calculate_surface_l2norm_scalar(s_field, positions, option_path) result(integral)
+    !!< Calculates a surface integral for the specified scalar field based upon
+    !!< options defined in the options tree
+    
+    type(scalar_field), intent(in) :: s_field
+    type(vector_field), intent(in) :: positions
+    character(len=*), intent(in) :: option_path
+    
+    real :: integral
+    
+    character(len = real_format_len() + 4) :: format_buffer
+    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
+    integer, dimension(2) :: shape
+    integer, dimension(:), allocatable :: surface_ids
+    logical :: normalise
+    
+    if(have_option(trim(option_path) // "/surface_ids")) then
+      shape = option_shape(trim(option_path) // "/surface_ids")
+      assert(shape(1) >= 0)
+      allocate(surface_ids(shape(1)))
+      call get_option(trim(option_path) // "/surface_ids", surface_ids)
+    end if
+    
+    normalise = have_option(trim(option_path) // "/normalise")
+    
+    if(allocated(surface_ids)) then
+      integral = surface_l2norm(s_field, positions, surface_ids = surface_ids, normalise = normalise)
+    else
+      integral = surface_l2norm(s_field, positions, normalise = normalise)
+    end if
+    
+    if(allocated(surface_ids)) then
+      deallocate(surface_ids)
+    end if
+    
+    call get_option(trim(option_path) // "/name", integral_name)
+    if(normalise) then
+      ewrite(2, *) "Normalised surface l2norm of type " // trim(integral_type) // " for field " // trim(s_field%name) // ":"
+    else
+      ewrite(2, *) "Surface l2norm of type " // trim(integral_type) // " for field " // trim(s_field%name) // ":"
+    end if
+    format_buffer = "(a," // real_format() // ")"
+    ewrite(2, format_buffer) trim(integral_name) // " = ", integral
+    
+  end function calculate_surface_l2norm_scalar
+  
+  function calculate_surface_l2norm_vector(v_field, positions, option_path) result(integral)
+    !!< Calculates a surface integral for the specified vector field based upon
+    !!< options defined in the options tree
+    
+    type(vector_field), intent(in) :: v_field
+    type(vector_field), intent(in) :: positions
+    character(len=*), intent(in) :: option_path
+    
+    real :: integral
+    
+    character(len = real_format_len() + 4) :: format_buffer
+    character(len = FIELD_NAME_LEN) :: integral_name, integral_type
+    integer, dimension(2) :: shape
+    integer, dimension(:), allocatable :: surface_ids
+    logical :: normalise
+    
+    if(have_option(trim(option_path) // "/surface_ids")) then
+      shape = option_shape(trim(option_path) // "/surface_ids")
+      assert(shape(1) >= 0)
+      allocate(surface_ids(shape(1)))
+      call get_option(trim(option_path) // "/surface_ids", surface_ids)
+    end if
+    
+    normalise = have_option(trim(option_path) // "/normalise")
+    
+    if(allocated(surface_ids)) then
+      integral = surface_l2norm(v_field, positions, surface_ids = surface_ids, normalise = normalise)
+    else
+      integral = surface_l2norm(v_field, positions, normalise = normalise)
+    end if
+    
+    if(allocated(surface_ids)) then
+      deallocate(surface_ids)
+    end if
+    
+    call get_option(trim(option_path) // "/name", integral_name)
+    if(normalise) then
+      ewrite(2, *) "Normalised surface integral of type " // trim(integral_type) // " for field " // trim(v_field%name) // ":"
+    else
+      ewrite(2, *) "Surface integral of type " // trim(integral_type) // " for field " // trim(v_field%name) // ":"
+    end if
+    format_buffer = "(a," // real_format() // ")"
+    ewrite(2, format_buffer) trim(integral_name) // " = ", integral
+    
+  end function calculate_surface_l2norm_vector
 
 end module surface_integrals

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -3392,6 +3392,7 @@ prognostic_scalar_stat_no_old_or_nonlinear_options.stat =
       exclude_stat?,
       cv_stats?,
       surface_integral_stats_scalar*,
+      surface_l2norm_stats*,
       mixing_stats*
    )   
    
@@ -3490,7 +3491,8 @@ prognostic_velocity_stat_options.stat &=
 prognostic_vector_stat_no_old_or_nonlinear_options.stat =
    (
       vector_field_stat_options_enabled_default,
-      surface_integral_stats_vector*
+      surface_integral_stats_vector*,
+      surface_l2norm_stats*
    )
 
 # Combining of stat elements for tensor fields
@@ -6408,6 +6410,13 @@ surface_integral_stats_vector.surface_integral &=
       attribute type { "normal" }
    )
 
+surface_l2norm_stats =
+   (
+      ## Calculate L2-norm of field over the specified surface
+      element surface_l2norm {
+         surface_integral_stats_base.surface_integral
+      }
+   )
 
 forcing =
   (

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -4435,6 +4435,9 @@ iteration in the .stat file.</a:documentation>
       <ref name="surface_integral_stats_scalar"/>
     </zeroOrMore>
     <zeroOrMore>
+      <ref name="surface_l2norm_stats"/>
+    </zeroOrMore>
+    <zeroOrMore>
       <ref name="mixing_stats"/>
     </zeroOrMore>
   </define>
@@ -4565,6 +4568,9 @@ IN PROGRESS - Does not include all terms!</a:documentation>
     <ref name="vector_field_stat_options_enabled_default"/>
     <zeroOrMore>
       <ref name="surface_integral_stats_vector"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <ref name="surface_l2norm_stats"/>
     </zeroOrMore>
   </define>
   <!-- Combining of stat elements for tensor fields -->
@@ -8006,6 +8012,12 @@ Defaults to zero at machine tolerance (epsilon(0.0)) if not selected.</a:documen
     <attribute name="type">
       <value>normal</value>
     </attribute>
+  </define>
+  <define name="surface_l2norm_stats">
+    <element name="surface_l2norm">
+      <a:documentation>Calculate L2-norm of field over the specified surface</a:documentation>
+      <ref name="surface_integral_stats_base.surface_integral"/>
+    </element>
   </define>
   <define name="forcing">
     <element name="ocean_forcing">

--- a/tests/viscous_fs_simpletopbottom/calculate_order_simpletopbottom.py
+++ b/tests/viscous_fs_simpletopbottom/calculate_order_simpletopbottom.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
@@ -31,7 +31,7 @@
         </stat>
       </from_mesh>
     </mesh>
-   <quadrature>
+    <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
       </degree>
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -293,7 +293,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -304,7 +304,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -333,12 +333,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -369,14 +369,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -395,12 +395,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -425,27 +425,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_E.flml
@@ -31,20 +31,7 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
-    <quadrature>
+   <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
       </degree>
@@ -443,54 +430,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -293,7 +293,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -304,7 +304,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -333,12 +333,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -369,14 +369,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -395,12 +395,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -425,27 +425,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -443,54 +430,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -293,7 +293,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -304,7 +304,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -333,12 +333,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -369,14 +369,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -395,12 +395,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -425,27 +425,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -443,54 +430,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -293,7 +293,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -304,7 +304,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -333,12 +333,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -369,14 +369,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -395,12 +395,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -425,27 +425,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -443,54 +430,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -293,7 +293,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -304,7 +304,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -333,12 +333,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -369,14 +369,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -395,12 +395,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -425,27 +425,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -443,54 +430,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/calculate_order_simpletopbottom_explicit.py
+++ b/tests/viscous_fs_simpletopbottom_explicit/calculate_order_simpletopbottom_explicit.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -447,54 +434,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_E.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -295,7 +295,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -308,7 +308,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -337,12 +337,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -373,14 +373,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -399,12 +399,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -429,27 +429,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -447,54 +434,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -295,7 +295,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -308,7 +308,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -337,12 +337,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -373,14 +373,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -399,12 +399,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -429,27 +429,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -447,54 +434,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -295,7 +295,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -308,7 +308,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -337,12 +337,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -373,14 +373,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -399,12 +399,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -429,27 +429,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -447,54 +434,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -295,7 +295,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -308,7 +308,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -337,12 +337,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -373,14 +373,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -399,12 +399,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -429,27 +429,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -447,54 +434,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -295,7 +295,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -308,7 +308,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -337,12 +337,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -373,14 +373,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -399,12 +399,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -429,27 +429,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/calculate_order_simpletopbottom_explicit.py
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/calculate_order_simpletopbottom_explicit.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -448,54 +435,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_E.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -309,7 +309,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -338,12 +338,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -374,14 +374,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -400,12 +400,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -430,27 +430,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -448,54 +435,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -309,7 +309,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -338,12 +338,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -374,14 +374,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -400,12 +400,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -430,27 +430,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -448,54 +435,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -309,7 +309,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -338,12 +338,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -374,14 +374,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -400,12 +400,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -430,27 +430,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -448,54 +435,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -309,7 +309,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -338,12 +338,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -374,14 +374,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -400,12 +400,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -430,27 +430,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -448,54 +435,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_testcv/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -309,7 +309,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -338,12 +338,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -374,14 +374,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -400,12 +400,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -430,27 +430,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/calculate_order_simpletopbottom_explicit_varrho.py
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/calculate_order_simpletopbottom_explicit_varrho.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -310,7 +310,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -339,12 +339,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -375,14 +375,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -401,12 +401,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -431,27 +431,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_E.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -449,54 +436,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -310,7 +310,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -339,12 +339,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -375,14 +375,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -401,12 +401,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -431,27 +431,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -449,54 +436,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -310,7 +310,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -339,12 +339,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -375,14 +375,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -401,12 +401,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -431,27 +431,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -449,54 +436,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -310,7 +310,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -339,12 +339,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -375,14 +375,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -401,12 +401,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -431,27 +431,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -449,54 +436,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress>
@@ -310,7 +310,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -339,12 +339,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -375,14 +375,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -401,12 +401,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -431,27 +431,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_explicit_varrho/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -449,54 +436,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/calculate_order_simpletopbottom.py
+++ b/tests/viscous_fs_simpletopbottom_testcv/calculate_order_simpletopbottom.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -187,7 +187,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -207,7 +207,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -243,7 +243,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -264,12 +264,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -283,7 +283,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -296,7 +296,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -307,7 +307,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -336,12 +336,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -372,14 +372,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -398,12 +398,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -428,27 +428,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_E.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -446,54 +433,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -444,54 +431,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -305,7 +305,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -334,12 +334,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -370,14 +370,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -396,12 +396,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -426,27 +426,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -444,54 +431,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -305,7 +305,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -334,12 +334,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -370,14 +370,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -396,12 +396,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -426,27 +426,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -444,54 +431,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -305,7 +305,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -334,12 +334,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -370,14 +370,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -396,12 +396,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -426,27 +426,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -444,54 +431,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_testcv/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -185,7 +185,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -205,7 +205,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -241,7 +241,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -262,12 +262,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -281,7 +281,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -305,7 +305,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -334,12 +334,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -370,14 +370,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -396,12 +396,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -426,27 +426,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/calculate_order_simpletopbottom_varrho.py
+++ b/tests/viscous_fs_simpletopbottom_varrho/calculate_order_simpletopbottom_varrho.py
@@ -12,24 +12,24 @@ def report_convergence(file1, file2):
 
   print(stat1["dt"]["value"][0], "->", stat2["dt"]["value"][0])
   
-  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errortop_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat1["dt"]["value"][1:]))
+  errortop_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][1:]**2*stat2["dt"]["value"][1:]))
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  errorbottom_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat1["dt"]["value"][1:]))
+  errorbottom_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][1:]**2*stat2["dt"]["value"][1:]))
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(sum(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat1["dt"]["value"][1:]))
-  error_l2_2 = sqrt(sum(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][1:]*stat2["dt"]["value"][1:]))
+  error_l2_1 = sqrt(sum(stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat1["dt"]["value"][1:]))
+  error_l2_2 = sqrt(sum(stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][1:]**2*stat2["dt"]["value"][1:]))
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -306,7 +306,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -335,12 +335,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -371,14 +371,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -397,12 +397,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -427,27 +427,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_E.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -445,54 +432,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -306,7 +306,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -335,12 +335,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -371,14 +371,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -397,12 +397,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -427,27 +427,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_F.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -445,54 +432,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -306,7 +306,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -335,12 +335,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -371,14 +371,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -397,12 +397,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -427,27 +427,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_G.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -445,54 +432,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -306,7 +306,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -335,12 +335,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -371,14 +371,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -397,12 +397,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -427,27 +427,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_H.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -445,54 +432,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
@@ -75,7 +75,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -100,7 +100,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -184,7 +184,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -204,7 +204,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -240,7 +240,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -261,12 +261,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -280,7 +280,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -294,7 +294,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -306,7 +306,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -335,12 +335,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -371,14 +371,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -397,12 +397,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global dx, F, G
 dx = solution.dx
 F = solution.nond_F
@@ -427,27 +427,27 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
         <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_l2norm type="value" name="Both">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="1">6 8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Top">
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_l2norm>
-          <surface_l2norm type="value" name="Bottom">
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_l2norm>
         </stat>

--- a/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
+++ b/tests/viscous_fs_simpletopbottom_varrho/viscous_fs_simpletopbottom_I.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -445,54 +432,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm type="value" name="Both">
             <surface_ids>
               <integer_value shape="1" rank="1">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Top">
             <surface_ids>
               <integer_value shape="1" rank="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm type="value" name="Bottom">
             <surface_ids>
               <integer_value shape="1" rank="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial/calculate_order_zhong_spatial.py
+++ b/tests/viscous_fs_zhong_spatial/calculate_order_zhong_spatial.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import solution
 from fluidity_tools import stat_parser as stat
-from math import log, sqrt
+from math import log
 
 def report_convergence(file1, file2):
   print(file1, "->", file2)
@@ -10,30 +10,30 @@ def report_convergence(file1, file2):
   stat1 = stat(file1)
   stat2 = stat(file2)
 
-  errortop_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
-  errortop_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
+  errortop_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
+  errortop_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
-  
-  errorbottom_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
-  errorbottom_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
+
+  errorbottom_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
+  errorbottom_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
-  
-  error_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
-  error_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
+
+  error_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
+  error_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)
   print('    error_l2_1 = ', error_l2_1)
   print('    error_l2_2 = ', error_l2_2)
-  
+
   error_linf_1 = stat1["Fluid"]["FreeSurfaceDifference"]["max"][-1]
   error_linf_2 = stat2["Fluid"]["FreeSurfaceDifference"]["max"][-1]
   convergence_linf = log((error_linf_1/error_linf_2), 2)
@@ -43,4 +43,3 @@ def report_convergence(file1, file2):
   print('    error_linf_2 = ', error_linf_2)
 
   return [convergencetop_l2, convergencebottom_l2, convergence_linf]
-  

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_A.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -94,7 +81,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -119,7 +106,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -203,7 +190,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -223,7 +210,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -259,7 +246,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -280,12 +267,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -299,7 +286,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -312,7 +299,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -320,13 +307,13 @@
         </boundary_conditions>
         <boundary_conditions name="Internal">
           <surface_ids>
-            <integer_value shape="1" rank="1">10</integer_value>
+            <integer_value rank="1" shape="1">10</integer_value>
           </surface_ids>
           <type name="flux">
             <align_bc_with_cartesian>
               <y_component>
                 <python>
-                  <string_value lines="20" type="code" language="python">def val(X,t):
+                  <string_value type="code" language="python" lines="20">def val(X,t):
    from math import pi, cos
    import solution
    k = solution.nond_wavenumber()
@@ -343,7 +330,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -372,12 +359,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global F, G
 F = solution.nond_F
 G = solution.nond_G
@@ -408,14 +395,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -434,12 +421,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global F, G
 F = solution.nond_F
 G = solution.nond_G
@@ -464,59 +451,29 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial/viscous_fs_zhong_B.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -94,7 +81,7 @@
           <mesh name="CoordinateMesh"/>
           <value name="WholeMesh">
             <constant>
-              <real_value shape="2" dim1="dim" rank="1">0.0 -1.0</real_value>
+              <real_value rank="1" dim1="dim" shape="2">0.0 -1.0</real_value>
             </constant>
           </value>
           <output/>
@@ -119,7 +106,7 @@
         </linear>
       </fluids>
     </equation_of_state>
-    <scalar_field name="Pressure" rank="0">
+    <scalar_field rank="0" name="Pressure">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <spatial_discretisation>
@@ -203,7 +190,7 @@
         <no_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="Density" rank="0">
+    <scalar_field rank="0" name="Density">
       <diagnostic>
         <algorithm name="Internal" material_phase_support="multiple"/>
         <mesh name="CoordinateMesh"/>
@@ -223,7 +210,7 @@
         </steady_state>
       </diagnostic>
     </scalar_field>
-    <vector_field name="Velocity" rank="1">
+    <vector_field rank="1" name="Velocity">
       <prognostic>
         <mesh name="VelocityMesh"/>
         <equation name="LinearMomentum"/>
@@ -259,7 +246,7 @@
           </theta_pressure_gradient>
         </temporal_discretisation>
         <reference_coordinates>
-          <real_value shape="2" dim1="dim" rank="1">0.25 0.5</real_value>
+          <real_value rank="1" dim1="dim" shape="2">0.25 0.5</real_value>
           <specify_components>
             <y_component/>
           </specify_components>
@@ -280,12 +267,12 @@
         </solver>
         <initial_condition name="WholeMesh">
           <constant>
-            <real_value shape="2" dim1="dim" rank="1">0.0 0.0</real_value>
+            <real_value rank="1" dim1="dim" shape="2">0.0 0.0</real_value>
           </constant>
         </initial_condition>
         <boundary_conditions name="Sides">
           <surface_ids>
-            <integer_value shape="2" rank="1">7 9</integer_value>
+            <integer_value rank="1" shape="2">7 9</integer_value>
           </surface_ids>
           <type name="dirichlet">
             <align_bc_with_cartesian>
@@ -299,7 +286,7 @@
         </boundary_conditions>
         <boundary_conditions name="Bottom">
           <surface_ids>
-            <integer_value shape="1" rank="1">6</integer_value>
+            <integer_value rank="1" shape="1">6</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -312,7 +299,7 @@
         </boundary_conditions>
         <boundary_conditions name="Top">
           <surface_ids>
-            <integer_value shape="1" rank="1">8</integer_value>
+            <integer_value rank="1" shape="1">8</integer_value>
           </surface_ids>
           <type name="free_surface">
             <no_normal_stress/>
@@ -320,13 +307,13 @@
         </boundary_conditions>
         <boundary_conditions name="Internal">
           <surface_ids>
-            <integer_value shape="1" rank="1">10</integer_value>
+            <integer_value rank="1" shape="1">10</integer_value>
           </surface_ids>
           <type name="flux">
             <align_bc_with_cartesian>
               <y_component>
                 <python>
-                  <string_value lines="20" type="code" language="python">def val(X,t):
+                  <string_value type="code" language="python" lines="20">def val(X,t):
    from math import pi, cos
    import solution
    k = solution.nond_wavenumber()
@@ -343,7 +330,7 @@
             <value name="WholeMesh">
               <anisotropic_symmetric>
                 <constant>
-                  <real_value symmetric="true" dim2="dim" shape="2 2" dim1="dim" rank="2">1.0 1.0 1.0 1.0</real_value>
+                  <real_value symmetric="true" rank="2" dim1="dim" dim2="dim" shape="2 2">1.0 1.0 1.0 1.0</real_value>
                 </constant>
               </anisotropic_symmetric>
             </value>
@@ -372,12 +359,12 @@
         <consistent_interpolation/>
       </prognostic>
     </vector_field>
-    <scalar_field name="FreeSurface" rank="0">
+    <scalar_field rank="0" name="FreeSurface">
       <prognostic>
         <mesh name="CoordinateMesh"/>
         <initial_condition name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global F, G
 F = solution.nond_F
 G = solution.nond_G
@@ -408,14 +395,14 @@ def val(X,t):
         </solver>
         <output/>
         <stat>
-          <surface_integral type="value" name="Top">
+          <surface_integral name="Top" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
           </surface_integral>
-          <surface_integral type="value" name="Bottom">
+          <surface_integral name="Bottom" type="value">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
           </surface_integral>
         </stat>
@@ -434,12 +421,12 @@ def val(X,t):
         <consistent_interpolation/>
       </prognostic>
     </scalar_field>
-    <scalar_field name="AnalyticalFreeSurface" rank="0">
+    <scalar_field rank="0" name="AnalyticalFreeSurface">
       <prescribed>
         <mesh name="CoordinateMesh"/>
         <value name="WholeMesh">
           <python>
-            <string_value lines="20" type="code" language="python">import solution
+            <string_value type="code" language="python" lines="20">import solution
 global F, G
 F = solution.nond_F
 G = solution.nond_G
@@ -464,59 +451,29 @@ def val(X,t):
         </particles>
       </prescribed>
     </scalar_field>
-    <scalar_field name="FreeSurfaceDifference" rank="0">
+    <scalar_field rank="0" name="FreeSurfaceDifference">
       <diagnostic>
-        <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
+        <algorithm name="scalar_difference" material_phase_support="single" source_field_1_name="FreeSurface" source_field_1_type="scalar" source_field_2_name="AnalyticalFreeSurface" source_field_2_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_explicit/calculate_order_zhong_spatial_explicit.py
+++ b/tests/viscous_fs_zhong_spatial_explicit/calculate_order_zhong_spatial_explicit.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import solution
 from fluidity_tools import stat_parser as stat
-from math import log, sqrt
+from math import log
 
 def report_convergence(file1, file2):
   print(file1, "->", file2)
@@ -10,24 +10,24 @@ def report_convergence(file1, file2):
   stat1 = stat(file1)
   stat2 = stat(file2)
 
-  errortop_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
-  errortop_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
+  errortop_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
+  errortop_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
-  errorbottom_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
+  errorbottom_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
+  errorbottom_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
-  error_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
+  error_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
+  error_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_A.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -473,54 +460,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit/viscous_fs_zhong_B.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -473,54 +460,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/calculate_order_zhong_spatial_explicit_varrho.py
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/calculate_order_zhong_spatial_explicit_varrho.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import solution
 from fluidity_tools import stat_parser as stat
-from math import log, sqrt
+from math import log
 
 def report_convergence(file1, file2):
   print(file1, "->", file2)
@@ -10,24 +10,24 @@ def report_convergence(file1, file2):
   stat1 = stat(file1)
   stat2 = stat(file2)
 
-  errortop_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
-  errortop_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
+  errortop_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
+  errortop_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
   
-  errorbottom_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
-  errorbottom_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
+  errorbottom_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
+  errorbottom_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
   
-  error_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
-  error_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
+  error_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
+  error_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_A.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -475,54 +462,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_explicit_varrho/viscous_fs_zhong_B.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -475,54 +462,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_varrho/calculate_order_zhong_spatial_varrho.py
+++ b/tests/viscous_fs_zhong_spatial_varrho/calculate_order_zhong_spatial_varrho.py
@@ -2,38 +2,38 @@ from __future__ import print_function
 
 import solution
 from fluidity_tools import stat_parser as stat
-from math import log, sqrt
+from math import log
 
 def report_convergence(file1, file2):
   print(file1, "->", file2)
-  
+
   stat1 = stat(file1)
   stat2 = stat(file2)
 
-  errortop_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
-  errortop_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%TopSurfaceL2Norm"][-1])
+  errortop_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
+  errortop_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Top"][-1]
   convergencetop_l2 = log((errortop_l2_1/errortop_l2_2), 2)
 
   print('  convergencetop_l2 = ', convergencetop_l2)
   print('    errortop_l2_1 = ', errortop_l2_1)
   print('    errortop_l2_2 = ', errortop_l2_2)
-  
-  errorbottom_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
-  errorbottom_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%BottomSurfaceL2Norm"][-1])
+
+  errorbottom_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
+  errorbottom_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Bottom"][-1]
   convergencebottom_l2 = log((errorbottom_l2_1/errorbottom_l2_2), 2)
 
   print('  convergencebottom_l2 = ', convergencebottom_l2)
   print('    errorbottom_l2_1 = ', errorbottom_l2_1)
   print('    errorbottom_l2_2 = ', errorbottom_l2_2)
-  
-  error_l2_1 = sqrt(stat1["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
-  error_l2_2 = sqrt(stat2["Fluid"]["DifferenceSquared"]["surface_integral%SurfaceL2Norm"][-1])
+
+  error_l2_1 = stat1["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
+  error_l2_2 = stat2["Fluid"]["FreeSurfaceDifference"]["surface_l2norm%Both"][-1]
   convergence_l2 = log((error_l2_1/error_l2_2), 2)
 
   print('  convergence_l2 = ', convergence_l2)
   print('    error_l2_1 = ', error_l2_1)
   print('    error_l2_2 = ', error_l2_2)
-  
+
   error_linf_1 = stat1["Fluid"]["FreeSurfaceDifference"]["max"][-1]
   error_linf_2 = stat2["Fluid"]["FreeSurfaceDifference"]["max"][-1]
   convergence_linf = log((error_linf_1/error_linf_2), 2)
@@ -43,4 +43,3 @@ def report_convergence(file1, file2):
   print('    error_linf_2 = ', error_linf_2)
 
   return [convergencetop_l2, convergencebottom_l2, convergence_linf]
-  

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_A.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -471,54 +458,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>

--- a/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
+++ b/tests/viscous_fs_zhong_spatial_varrho/viscous_fs_zhong_B.flml
@@ -31,19 +31,6 @@
         </stat>
       </from_mesh>
     </mesh>
-    <mesh name="FreeSurfaceSquaredMesh">
-      <from_mesh>
-        <mesh name="CoordinateMesh"/>
-        <mesh_shape>
-          <polynomial_degree>
-            <integer_value rank="0">2</integer_value>
-          </polynomial_degree>
-        </mesh_shape>
-        <stat>
-          <exclude_from_stat/>
-        </stat>
-      </from_mesh>
-    </mesh>
     <quadrature>
       <degree>
         <integer_value rank="0">5</integer_value>
@@ -471,54 +458,24 @@ def val(X,t):
         <algorithm source_field_2_type="scalar" name="scalar_difference" source_field_1_name="FreeSurface" source_field_2_name="AnalyticalFreeSurface" material_phase_support="single" source_field_1_type="scalar">
           <absolute_difference/>
         </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
-        <output/>
-        <stat/>
-        <convergence>
-          <include_in_convergence/>
-        </convergence>
-        <detectors>
-          <include_in_detectors/>
-        </detectors>
-        <particles>
-          <exclude_from_particles/>
-        </particles>
-        <steady_state>
-          <include_in_steady_state/>
-        </steady_state>
-      </diagnostic>
-    </scalar_field>
-    <scalar_field name="DifferenceSquared" rank="0">
-      <diagnostic>
-        <algorithm name="scalar_python_diagnostic" material_phase_support="single">
-          <string_value lines="20" type="code" language="python">fsd = state.scalar_fields["FreeSurfaceDifference"]
-
-assert(field.node_count==fsd.node_count)
-
-for i in range(field.node_count):
-  field.set(i, fsd.node_val(i)*fsd.node_val(i))</string_value>
-          <depends>
-            <string_value lines="1">FreeSurfaceDifference</string_value>
-          </depends>
-        </algorithm>
-        <mesh name="FreeSurfaceSquaredMesh"/>
+        <mesh name="CoordinateMesh"/>
         <output/>
         <stat>
-          <surface_integral type="value" name="SurfaceL2Norm">
+          <surface_l2norm name="Both">
             <surface_ids>
-              <integer_value shape="1" rank="1">6 8</integer_value>
+              <integer_value rank="1" shape="2">6 8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="TopSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Top">
             <surface_ids>
-              <integer_value shape="1" rank="1">8</integer_value>
+              <integer_value rank="1" shape="1">8</integer_value>
             </surface_ids>
-          </surface_integral>
-          <surface_integral type="value" name="BottomSurfaceL2Norm">
+          </surface_l2norm>
+          <surface_l2norm name="Bottom">
             <surface_ids>
-              <integer_value shape="1" rank="1">6</integer_value>
+              <integer_value rank="1" shape="1">6</integer_value>
             </surface_ids>
-          </surface_integral>
+          </surface_l2norm>
         </stat>
         <convergence>
           <include_in_convergence/>


### PR DESCRIPTION
Add surface_l2norm option
    
Same as surface_integral, except computes sqrt(\int_surface field^2 dx)
Also clean some awkward code in surface_integrals module.

Use this new diagnostic in all the various viscous free surface tests.