### PR TITLE
Sorry, this just showed up.

### DIFF
--- a/tools/statplot.py
+++ b/tools/statplot.py
@@ -179,7 +179,10 @@ class StatplotWindow(Gtk.Window):
 
     def KeyPressed(self, widget, event):
         key = event.string
-        if key == 'r':
+        if (self.xCombo.get_child().has_focus()
+                or self.yCombo.get_child().has_focus()):
+            pass
+        elif key == 'r':
             self.RefreshData()
             self.PlotData('update', self.PlotType, self.ax.get_xscale(),
                           self.ax.get_yscale())
@@ -226,17 +229,9 @@ class StatplotWindow(Gtk.Window):
             self.PlotData('update', self.PlotType, self.ax.get_xscale(),
                           self.ax.get_yscale())
         elif key == 'a':
-            if (self.xCombo.get_child().has_focus()
-                    or self.yCombo.get_child().has_focus()):
-                pass
-            else:
-                self.xCombo.grab_focus()
+            self.xCombo.grab_focus()
         elif key == 'o':
-            if (self.xCombo.get_child().has_focus()
-                    or self.yCombo.get_child().has_focus()):
-                pass
-            else:
-                self.yCombo.grab_focus()
+            self.yCombo.grab_focus()
 
     def PlotData(self, action, type, xscale, yscale):
         self.xData = self.values[..., self.xCombo.get_active()]


### PR DESCRIPTION
I did not realise that keys pressed (apart from a's, o's and the ones without a function) would still have an effect on the window while writing in the combo boxes. For example, open any statfile, press o to have access to the bottom right combo box and then press q: the GUI shuts down. This commit fixes the issue.

Sorry again.