### PR TITLE
Remove is_sorted allowing configure with PETSc3.13

### DIFF
--- a/femtools/Sparse_Tools.F90
+++ b/femtools/Sparse_Tools.F90
@@ -419,10 +419,6 @@ module sparse_tools
      module procedure sparsity_is_symmetric
   end interface
 
-  interface is_sorted
-    module procedure sparsity_is_sorted
-  end interface
-
   interface write_minmax
     module procedure csr_write_minmax, block_csr_write_minmax
   end interface
@@ -446,7 +442,7 @@ module sparse_tools
        & addto_diag, set_diag,  set, val, ival, dense, dense_i, wrap, matmul, matmul_addto, matmul_T,&
        & matrix2file, mmwrite, mmread, transpose, sparsity_sort,&
        & sparsity_merge, scale, set_inactive, get_inactive_mask, &
-       & reset_inactive, has_solver_cache, destroy_solver_cache, is_symmetric, is_sorted, &
+       & reset_inactive, has_solver_cache, destroy_solver_cache, is_symmetric, sparsity_is_sorted, &
        & write_minmax
        
   public :: posinm

--- a/femtools/tests/test_block_csr_transpose_symmetric_sparsity.F90
+++ b/femtools/tests/test_block_csr_transpose_symmetric_sparsity.F90
@@ -39,9 +39,9 @@ subroutine test_block_csr_transpose_symmetric_sparsity
   call allocate(sparsity, 2, 2, nnz = (/ 2, 1 /), name="Sparsity")
   sparsity%colm = (/ 2, 1, 1 /)
   call report_test("[sparsity is symmetric]", .not. is_symmetric(sparsity), .false., "sparsity is not symmetric")
-  call report_test("[sparsity is not yet sorted]", is_sorted(sparsity), .false., "sparsity should be not sorted before calling sort(sparsity).")
+  call report_test("[sparsity is not yet sorted]", sparsity_is_sorted(sparsity), .false., "sparsity should be not sorted before calling sort(sparsity).")
   call sparsity_sort(sparsity)
-  call report_test("[sparsity is sorted]", .not. is_sorted(sparsity), .false., "sparsity is not sorted after calling sort(sparsity).")
+  call report_test("[sparsity is sorted]", .not. sparsity_is_sorted(sparsity), .false., "sparsity is not sorted after calling sort(sparsity).")
 
 
   sparsity%sorted_rows = .true.


### PR DESCRIPTION
PETSc 3.13 added is_sorted as an enum hence causing
a compiler conflict.

Fixes issue #266.