### PR TITLE
Big L2 nullspace projection

### DIFF
--- a/assemble/Momentum_Equation.F90
+++ b/assemble/Momentum_Equation.F90
@@ -1828,8 +1828,9 @@
          type(block_csr_matrix), dimension(:), intent(inout) :: subcycle_m
          type(vector_field), dimension(:), intent(inout) :: subcycle_rhs
 
-         ! Slope limiter variables:
          integer :: d
+         type(vector_field), pointer :: x
+         type(vector_field) :: u_positions
          type(scalar_field) :: u_cpt
 
          ewrite(1,*) 'Entering finalise_state'
@@ -1854,6 +1855,14 @@
                call limit_vb(state(istate), u_cpt)
             end do
          end if
+
+         if (have_option(trim(u%option_path)//"/prognostic/solver/remove_null_space")) then
+            x => extract_vector_field(state(istate), "Coordinate")
+            u_positions = get_nodal_coordinate_field(state(istate), u%mesh)
+            call L2_project_nullspace_vector(u, trim(u%option_path)//"/solver/remove_null_space", x, u_positions)
+            call deallocate(u_positions)
+         end if
+
          call profiler_toc(u, "assembly")
 
          if(dg(istate)) then

--- a/assemble/Momentum_Equation.F90
+++ b/assemble/Momentum_Equation.F90
@@ -1859,7 +1859,7 @@
          if (have_option(trim(u%option_path)//"/prognostic/solver/remove_null_space")) then
             x => extract_vector_field(state(istate), "Coordinate")
             u_positions = get_nodal_coordinate_field(state(istate), u%mesh)
-            call L2_project_nullspace_vector(u, trim(u%option_path)//"/solver/remove_null_space", x, u_positions)
+            call L2_project_nullspace_vector(u, trim(u%option_path)//"/prognostic/solver/remove_null_space", x, u_positions)
             call deallocate(u_positions)
          end if
 

--- a/femtools/FETools.F90
+++ b/femtools/FETools.F90
@@ -26,7 +26,11 @@ module fetools
      module procedure integral_element_scalar, integral_element_vector, integral_element_scalars
   end interface
 
-  private :: norm2_element
+  interface dot_integral_element
+     module procedure dot_integral_element_vector
+  end interface
+
+  private :: norm2_element, dot_integral_element_vector
   private :: integral_element_scalar, integral_element_vector, integral_element_scalars
 
 contains
@@ -863,6 +867,25 @@ contains
     integral=matmul(matmul(ele_val(field, ele), field%mesh%shape%n), detwei)
 
   end function integral_element_vector
+
+  function dot_integral_element_vector(fieldA, fieldB, X, ele) result&
+       & (integral)
+    !!< Return the integral of dot(fieldA, fieldB) over the element ele
+    type(vector_field), intent(in) :: fieldA, fieldB
+    ! positions field
+    type(vector_field), intent(in) :: X
+    ! The number of the current element
+    integer, intent(in) :: ele
+    
+    real :: integral
+
+    real, dimension(ele_ngi(fieldA, ele)) :: detwei
+    
+    call transform_to_physical(X, ele, detwei=detwei)
+    
+    integral = sum(sum(ele_val_at_quad(fieldA, ele) * ele_val_at_quad(fieldB, ele), dim=1)*detwei)
+
+  end function dot_integral_element_vector
 
   function integral_element_scalars(fields, X, ele) result&
        & (integral)

--- a/femtools/Fields_Calculations.F90
+++ b/femtools/Fields_Calculations.F90
@@ -89,7 +89,7 @@ implicit none
   end interface
 
   interface dot_product
-    module procedure dot_product_scalar, dot_product_vector
+    module procedure dot_product_vector
   end interface dot_product
 
   interface outer_product
@@ -104,7 +104,7 @@ implicit none
 
   public :: mean, maxval, minval, sum, norm2, field_stats, field_cv_stats,&
 	 field_integral, fields_integral, function_val_at_quad,&
-	 dot_product, outer_product, norm2_difference, magnitude,&
+         dot_product, outer_product, norm2_difference, magnitude,&
 	 magnitude_tensor, merge_meshes, distance, divergence_field_stats,&
 	 field_con_stats, function_val_at_quad_scalar, trace, mesh_integral
     
@@ -667,35 +667,11 @@ implicit none
     end do
   end subroutine trace
 
-  function dot_product_scalar(fieldA, fieldB) result(val)
-    type(scalar_field), intent(in) :: fieldA, fieldB
+  function dot_product_vector(fieldA, fieldB, X) result(val)
+    type(vector_field), intent(in) :: fieldA, fieldB, X
     real :: val
-    integer :: i
 
-    if (.not. associated(fieldA%mesh%refcount, fieldB%mesh%refcount)) then
-      ewrite(-1,*) "Hello! dot_product_scalar here."
-      ewrite(-1,*) "I couldn't be bothered remapping the fields,"
-      ewrite(-1,*) "even though this is perfectly possible."
-      ewrite(-1,*) "Code this up to remap the fields to continue!"
-      FLAbort("Programmmer laziness detected")
-    end if
-
-    if (fieldA%field_type == FIELD_TYPE_NORMAL .and. fieldB%field_type == FIELD_TYPE_NORMAL) then
-      val = dot_product(fieldA%val, fieldB%val)
-    else if (fieldA%field_type == FIELD_TYPE_CONSTANT .and. fieldB%field_type == FIELD_TYPE_CONSTANT) then
-      val = fieldA%val(1) * fieldB%val(1) * node_count(fieldA)
-    else
-      val = 0.0
-      do i=1,node_count(fieldA)
-        val = val + node_val(fieldA, i) * node_val(fieldB, i)
-      end do
-    end if
-  end function dot_product_scalar
-
-  function dot_product_vector(fieldA, fieldB) result(val)
-    type(vector_field), intent(in) :: fieldA, fieldB
-    real, dimension(fieldA%dim) :: val
-    integer :: i, d
+    integer :: ele
 
     assert(fieldA%dim==fieldB%dim)
 
@@ -707,20 +683,19 @@ implicit none
       FLAbort("Programmmer laziness detected")
     end if
 
-    if ((fieldA%field_type == FIELD_TYPE_NORMAL) .and. &
-        (fieldB%field_type == FIELD_TYPE_NORMAL)) then
-       do d=1,fieldA%dim
-          val(d) = dot_product(fieldA%val(d,:), fieldB%val(d,:))
-       end do
-    else if (fieldA%field_type == FIELD_TYPE_CONSTANT .and. fieldB%field_type == FIELD_TYPE_CONSTANT) then
-       do d=1,fieldA%dim
-          val(d) = fieldA%val(d,1) * fieldB%val(d,1) * node_count(fieldA)
-       end do
+    if (fieldA%field_type == FIELD_TYPE_CONSTANT .and. fieldB%field_type == FIELD_TYPE_CONSTANT) then
+       val = dot_product(fieldA%val(:,1), fieldB%val(:,1)) * mesh_integral(X)
     else
-       val = 0.0
-       do i=1,node_count(fieldA)
-          val = val + node_val(fieldA, i) * node_val(fieldB, i)
+       val = 0
+
+       do ele=1, element_count(fieldA)
+         if(element_owned(fieldA, ele)) then
+           val = val + dot_integral_element(fieldA, fieldB, X, ele)
+         end if
        end do
+
+       call allsum(val)
+
     end if
   end function dot_product_vector
 

--- a/femtools/Makefile.dependencies
+++ b/femtools/Makefile.dependencies
@@ -537,6 +537,16 @@ Global_Parameters.o ../include/global_parameters.mod: Global_Parameters.F90 \
 Grundmann_Moeller_Quadrature.o ../include/grundmann_moeller_quadrature.mod: \
    Grundmann_Moeller_Quadrature.F90
 
+../include/h5hut.mod: H5hut.o
+	@true
+
+H5hut.o ../include/h5hut.mod: H5hut.F90 ../include/H5Block_attribs.f90 \
+   ../include/H5Block_io.f90 ../include/H5Block_model.f90 \
+   ../include/H5Part_io.f90 ../include/H5Part_model.f90 \
+   ../include/H5_const.f90 ../include/H5_err.f90 ../include/H5_file.f90 \
+   ../include/H5_file_attribs.f90 ../include/H5_log.f90 \
+   ../include/H5_model.f90 ../include/H5_step_attribs.f90
+
 ../include/halo_data_types.mod: Halo_Data_Types.o
 	@true
 
@@ -1064,7 +1074,8 @@ Smoothing_module.o ../include/smoothing_module.mod: Smoothing_module.F90 \
 	@true
 
 Solvers.o ../include/solvers.mod: Solvers.F90 ../include/elements.mod \
-   ../include/fdebug.h ../include/fields.mod ../include/fldebug.mod \
+   ../include/fdebug.h ../include/fields.mod \
+   ../include/fields_calculations.mod ../include/fldebug.mod \
    ../include/futils.mod ../include/global_parameters.mod ../include/halos.mod \
    ../include/meshdiagnostics.mod ../include/multigrid.mod \
    ../include/parallel_tools.mod ../include/petsc_legacy.h \

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -132,7 +132,6 @@ subroutine petsc_solve_scalar(x, matrix, rhs, option_path, &
   KSP ksp
   Mat A
   Vec y, b
-  PetscErrorCode :: ierr
 
   character(len=OPTION_PATH_LEN):: solver_option_path
   type(petsc_numbering_type) petsc_numbering

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -2701,6 +2701,9 @@ subroutine get_null_space_component_options(null_space_option_path, mask, rot_ma
      mask = .true.
    else if(have_option(trim(null_space_option_path)//'/no_components')) then
      mask = .false.
+   else
+     ewrite(0,*) "null_space_option_path: ",  null_space_option_path
+     FLAbort("Invalid null_space_option_path")
    end if
 
    if(have_option(trim(null_space_option_path)//'/specify_rotations')) then
@@ -2792,7 +2795,9 @@ subroutine L2_project_nullspace_vector(field, null_space_option_path, coordinate
       ! the rotational null field is basically j and k swapped, with a sign in front of one
       ! while keeping the i component at zero
       ! note that we do not care about the overall sign here, since the L2 projection takes care of that
-      null_field%val(i,:) = 0.
+      if (i<=field%dim) then
+        null_field%val(i,:) = 0.
+      end if
       null_field%val(j,:) = mesh_positions%val(k,:)
       null_field%val(k,:) = -mesh_positions%val(j,:)
       call L2_project_nullmode_vector(field, null_field, coordinates)


### PR DESCRIPTION
This performs a big L2 projection after the final velocity correction if a nullspace has been specified for Velocity, i.e. it ensure that the final velocity is L2 orthogonal to the specified nullspace. This is to avoid spurious rotations (or translations) that may occur with variable resolution. During the (petsc) solves the nullspace is projected out in the small l2-norm. However if for example the mesh resolution is biased where there are e.g. the same number of nodes with clockwise rotation as there are nodes with counter-clockwise rotation, but the nodes with clockwise rotation are very much concentrated in small area, then in an L2-integrated sense the solution still has a net counter-clockwise rotation (as the same number of associated nodes represent more area).

A possibly controversial aspect: I did not introduce any option. It now always does the L2 projection if Velocity has a nullspace. My reason (other than reluctance to add yet more options) is that I think this is the correct default - so if people really wanted to use the old default (i.e. stick with the small l2 projected solution) we could add an option for that. In practice, nullspaces are only used in Stokes applications anyway  and again I think there it is just the right thing to do.

Second point is that this isn't implemented for scalar solves. The (lazy) reason there is that it mucks quite a bit with solver interfaces, as we need a positions field for L2 projection, and generally we don't really care so much. For pressure we only care about its gradient, and for a scalar diffusion problem it could just be done as a post-processing step. This could be added in the future as well.

Final confession: I seem to have repurposed `dot_product(fieldA, fieldB)` to compute the L2 product rather than the l2-product which it did before. I presume this means it wasn't actually used previously - it certainly wasn't parallel safe previously....