### PR TITLE
Change time.clock() to time.process_time()

### DIFF
--- a/python/fluidity/regressiontest.py
+++ b/python/fluidity/regressiontest.py
@@ -133,7 +133,7 @@ class TestProblem:
         self.log("Running")
 
         run_time=0.0
-        start_time=time.clock()
+        start_time=time.process_time()
         wall_time=time.time()
 
         try:
@@ -151,7 +151,7 @@ class TestProblem:
         else:
           self.log(self.command_line)
           os.system("cd "+dir+"; "+self.command_line)
-          run_time=time.clock()-start_time
+          run_time=time.process_time()-start_time
 
         self.xml_reports.append(TestCase(self.name,
                                             '%s.%s'%(self.length,


### PR DESCRIPTION
`time.clock()` was removed in Python 3.8 (and deprecated since Python 3.3). Use `time.process_time()` instead, which gives the sum of system and user CPU time, but doesn't include time elapsed during sleep.

I don't quite know the context for the current call: if doesn't seem to be measuring a particularly tight loop, so I don't think `time.perf_counter()` is necessary.