### PR TITLE
Remove Python 2 from python_validate test

### DIFF
--- a/tests/python_validation/python_validation.xml
+++ b/tests/python_validation/python_validation.xml
@@ -117,7 +117,6 @@ print("Failures: " + str(len(optionErrors)))</variable>
   </variables>
   <pass_tests/>
   <warn_tests>
-    <test name="Two python versions on machine" language="python">assert(len(python_versions)==2)</test>
     <test name="Options files validate" language="python">failures = []
 for filename, types in optionErrors.items():
   if not filename in ignoredOptionsFiles:


### PR DESCRIPTION
Since we no longer expect to maintain backwards compatibility, this test is generating unnecessary warnings.