### PR TITLE
Add new Dockerfile for focal

### DIFF
--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -1,0 +1,37 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get -y dist-upgrade
+
+RUN apt-get -y install gnupg
+
+RUN echo "deb http://ppa.launchpad.net/fluidity-core/ppa/ubuntu focal main" > /etc/apt/sources.list.d/fluidity-core-ppa-focal.list
+
+# Import the Launchpad PPA public key
+RUN gpg --keyserver keyserver.ubuntu.com --recv 0D45605A33BAC3BE
+RUN gpg --export --armor 33BAC3BE | apt-key add -
+RUN apt-get update
+
+# Install Fluidity development environment
+RUN echo "Europe/London" > /etc/timezone
+
+RUN apt-get -y install fluidity-dev
+
+# Install texlive sufficient for 'make manual'
+RUN apt-get -y install texlive-pstricks texlive texlive-latex-extra texlive-science
+
+ENV LD_LIBRARY_PATH /usr/lib/petscdir/3.12/lib
+ENV LDFLAGS -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+ENV CPPFLAGS "-I/usr/include/hdf5/openmpi -I/usr/include"
+ENV OMPI_MCA_btl_vader_single_copy_mechanism none
+
+# Add a Fluidity user who will be the default user for this container
+# Make sure the user has a userid matching the host system
+# -- pass this as an argument at build time
+ARG userid=1000
+RUN adduser --disabled-password --gecos "" -u $userid fluidity
+
+USER fluidity
+WORKDIR /home/fluidity


### PR DESCRIPTION
Somewhat overdue (sorry!) I've pushed a set of packages for focal onto launchpad, and this PR is intended to discuss updates to support focal, hopefully ending up with a focal-supporting merge.

On the package side:
- PETSc has been changed to be a very close match to system PETSc, just with fortran and cpp turned on in configure, and the version changed to +fluidity instead of +dfsg to give us version-priority when installing. This will need a bit of care to make sure when new upstream versions come in, we bump our version accordingly.
- packages which were prevoiusly built and wrapped into PETSc are now installed from system packages
- zoltan has been updated to be PETSc-independent - it *hasn't* been changed to the libtrilinos-zoltan package as this is a monster of a package which was giving me headaches in the make test.
- libsupermesh has been brought up to the latest version from bitbucket
- spud has been brought up to the latest version from github
- fluidity-dev has been updated to reflect the above, and also for libboost version bump

On the docker side:
- system texlive packages appear to have everything we need for 'make manual' so the bionic hack of building texlive in Docker has been backed out, but texlive has been left out of fluidity-dev to reduce bloat

@stephankramer - please could you cast your eye over the PETSc side of things at some point and check I haven't done anything silly there? Also if you have any thoughts on whether there's any option to use system libtrilinos-zoltan without too much headache from the enormous package, I'd very much appreciate any ideas.
