### PR TITLE
Fix short-circuit evaluation division by zero GCC v9+

### DIFF
--- a/assemble/qmesh.F90
+++ b/assemble/qmesh.F90
@@ -69,7 +69,7 @@ contains
     real, intent(in) :: current_time
     integer, intent(in) :: timestep
     
-    logical :: do_adapt_mesh
+    logical :: do_adapt_mesh, dump
     
     integer :: int_adapt_period, i, stat
     real :: real_adapt_period, current_cpu_time
@@ -95,7 +95,14 @@ contains
         case(3)
           call get_option("/mesh_adaptivity/hr_adaptivity/period_in_timesteps", int_adapt_period, stat)
           if(stat == SPUD_NO_ERROR) then
-            if(int_adapt_period == 0 .or. mod(timestep, int_adapt_period) == 0) then
+            if (int_adapt_period == 0) then
+              dump = .true.
+            else if (mod(timestep, int_adapt_period) == 0) then
+              dump = .true.
+            else
+              dump = .false.
+            end if
+            if (dump) then
               do_adapt_mesh = .true.
               exit
             end if

--- a/femtools/Write_State.F90
+++ b/femtools/Write_State.F90
@@ -57,6 +57,7 @@ contains
     
     integer ::  i, stat
     real :: current_cpu_time, current_wall_time
+    logical :: dump
     
     do_write_state = .false.
     
@@ -88,7 +89,14 @@ contains
           end if
         case(3) 
           if(have_option("/io/dump_period_in_timesteps")) then
-            if(int_dump_period == 0 .or. mod(timestep, int_dump_period) == 0) then
+            if (int_dump_period == 0) then
+              dump = .true.
+            else if (mod(timestep, int_dump_period) == 0) then
+              dump = .true.
+            else
+              dump = .false.
+            end if
+            if (dump) then
               if(have_option("/io/dump_period_in_timesteps/constant")) then
                 call get_option("/io/dump_period_in_timesteps/constant", int_dump_period)
               else if (have_option("/io/dump_period_in_timesteps/python")) then

--- a/tools/petsc_readnsolve.F90
+++ b/tools/petsc_readnsolve.F90
@@ -368,6 +368,9 @@ contains
       
       universal_nodes=petsc_numbering%universal_length
       
+      ! Escape division by zero in mod() by exiting prior to evaluation
+      if (universal_nodes==0) FLExit("Cannot have 0 nodes in specified mesh")
+
       ! and compare it with the size of the PETSc vector
       if (universal_nodes==n) then
         


### PR DESCRIPTION
Fixes Division by zero in Write_State.F90 #289

Fortran does not have short-circuit evaluation!

NOTE: I am not sure I have removed all the short-circuit expressions.
I do believe however that I have removed all the divs by 0 in mod.
Validated using Rust flavoured regex: `mod\((.*)\)(\s*?)`

-------

This should probably be merged to master before the focal update or merged into the focal update PR