### PR TITLE
Allocate empty attribute arrays for detectors

### DIFF
--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -127,6 +127,11 @@ contains
        allocate(new_detector%attributes(attribute_size(1)))
        allocate(new_detector%old_attributes(attribute_size(2)))
        allocate(new_detector%old_fields(attribute_size(3)))
+    else
+       ! match the behaviour of create_single_detector, with empty attribute arrays
+       allocate(new_detector%attributes(0))
+       allocate(new_detector%old_attributes(0))
+       allocate(new_detector%old_fields(0))
     end if
       
     assert(associated(new_detector))
@@ -585,7 +590,15 @@ contains
        if (.not. allocated(detector%position)) then
           allocate(detector%position(ndims))
        end if
-       
+
+       ! ensure we at least allocate the attributes to be empty
+       ! to match the behaviour of create_single_detector
+       if (.not. allocated(detector%attributes)) then
+          allocate(detector%attributes(0))
+          allocate(detector%old_attributes(0))
+          allocate(detector%old_fields(0))
+       end if
+
        ! Basic fields: ndims+4
        detector%position = buff(1:ndims)
        detector%element = buff(ndims+1)


### PR DESCRIPTION
When we allocate/unpack detectors from Zoltan, some code expects that their attribute arrays (used for particles) are at least allocated, even if length 0. Ensuring this is done avoids potential segfaults when these arrays are unconditionally accessed.

Thanks @stephankramer for the detailed analysis of this issue! I think this is probably the right place for this allocation? Of course, the other approach would be to figure out where `attribute_size` is being passed into `unpack_detector` as a non-optional on a detector. (As an aside, that subroutine looks like it could just take a non-optional `attribute_size` and then the logic wouldn't be exactly duplicated in both branches...)

Closes #317.