### PR TITLE
Allocate empty attribute arrays for detectors

### DIFF
--- a/assemble/Zoltan_callbacks.F90
+++ b/assemble/Zoltan_callbacks.F90
@@ -1081,24 +1081,20 @@ contains
        ! packing the detectors in that element
        do j=1,zoltan_global_ndets_in_ele(i)
           !check attribute sizes
-          if (size(detector%attributes)>=1) then
-             attribute_size(1)=size(detector%attributes)
-             attribute_size(2)=size(detector%old_attributes)
-             attribute_size(3)=size(detector%old_fields)
-          else
-             attribute_size(1)=0
-             attribute_size(2)=0
-             attribute_size(3)=0
-          end if
+          attribute_size(1) = size(detector%attributes)
+          attribute_size(2) = size(detector%old_attributes)
+          attribute_size(3) = size(detector%old_fields)
+
           total_attributes = sum(attribute_size)
           !pack attribute sizes
           do k = 1,3
-             rbuf(rhead)=attribute_size(k)
-             rhead=rhead+1
+            rbuf(rhead)=attribute_size(k)
+            rhead=rhead+1
           end do
+
           !pack the detector
           call pack_detector(detector, rbuf(rhead:rhead+zoltan_global_ndata_per_det-1+total_attributes), &
-               zoltan_global_ndims, attribute_size=attribute_size)
+               zoltan_global_ndims, attribute_size_in=attribute_size)
           ! keep a pointer to the detector to delete
           detector_to_delete => detector
           ! move on our iterating pointer so it's not left on a deleted node
@@ -1272,7 +1268,8 @@ contains
              
              ! unpack detector information 
              call unpack_detector(detector, rbuf(rhead:rhead+zoltan_global_ndata_per_det-1+total_attributes), zoltan_global_ndims, &
-                    global_to_local=zoltan_global_uen_to_new_local_numbering, coordinates=zoltan_global_new_positions, attribute_size=attribute_size)
+                    global_to_local=zoltan_global_uen_to_new_local_numbering, coordinates=zoltan_global_new_positions, &
+                    attribute_size_in=attribute_size)
 
              ! Make sure the unpacked detector is in this element
              assert(new_local_element_number==detector%element)

--- a/assemble/Zoltan_callbacks.F90
+++ b/assemble/Zoltan_callbacks.F90
@@ -1257,7 +1257,6 @@ contains
           do det=1,ndetectors_in_ele
              ! allocate a detector
              shape=>ele_shape(zoltan_global_new_positions,1)
-             call allocate(detector, zoltan_global_ndims, local_coord_count(shape))
 
              ! determine particle attribute size
              do k = 1,3
@@ -1265,8 +1264,10 @@ contains
                 rhead = rhead + 1
              end do
              total_attributes = sum(attribute_size)
-             
-             ! unpack detector information 
+
+             call allocate(detector, zoltan_global_ndims, local_coord_count(shape), attribute_size=attribute_size)
+
+             ! unpack detector information
              call unpack_detector(detector, rbuf(rhead:rhead+zoltan_global_ndata_per_det-1+total_attributes), zoltan_global_ndims, &
                     global_to_local=zoltan_global_uen_to_new_local_numbering, coordinates=zoltan_global_new_positions, &
                     attribute_size_in=attribute_size)

--- a/assemble/Zoltan_detectors.F90
+++ b/assemble/Zoltan_detectors.F90
@@ -47,16 +47,15 @@ module zoltan_detectors
     ! loop through all registered detector lists
     call get_registered_detector_lists(detector_list_array)
     do det_list = 1, size(detector_list_array)
-
        ! search through all the local detectors in this list
        detector => detector_list_array(det_list)%ptr%first
+
        !Set up particle attribute parameters
-       total_attributes=0
+       total_attributes = 0
        if (associated(detector)) then
-          if (size(detector%attributes)>=1) then
-             total_attributes = size(detector%attributes) + size(detector%old_attributes) + size(detector%old_fields)
-          end if
+          total_attributes = size(detector%attributes) + size(detector%old_attributes) + size(detector%old_fields)
        end if
+
        detector_loop: do while (associated(detector))
           ! store the list ID with the detector, so we can map the detector back when receiving it
           detector%list_id=det_list

--- a/assemble/Zoltan_integration.F90
+++ b/assemble/Zoltan_integration.F90
@@ -2133,7 +2133,8 @@ module zoltan_integration
        detector => detector_send_list%first
        do i=1,send_count
           ! Pack the particle information and delete from send_list (delete advances particle to detector%next)
-          call pack_detector(detector, send_buff(i,1:zoltan_global_ndata_per_det+total_attributes), zoltan_global_ndims, attribute_size=detector_list%total_attributes)
+          call pack_detector(detector, send_buff(i,1:zoltan_global_ndata_per_det+total_attributes), zoltan_global_ndims, &
+               attribute_size_in=detector_list%total_attributes)
           call delete(detector, detector_send_list)
        end do
 
@@ -2161,9 +2162,10 @@ module zoltan_integration
                    ! Allocate and unpack the particle
                    shape=>ele_shape(zoltan_global_new_positions,1)                     
                    call allocate(detector, zoltan_global_ndims, local_coord_count(shape), detector_list%total_attributes)
-                   call unpack_detector(detector, recv_buff(k, 1:zoltan_global_ndata_per_det+total_attributes), zoltan_global_ndims, attribute_size=detector_list%total_attributes)
-                   
-                   if (has_key(zoltan_global_uen_to_new_local_numbering, detector%element)) then 
+                   call unpack_detector(detector, recv_buff(k, 1:zoltan_global_ndata_per_det+total_attributes), zoltan_global_ndims, &
+                     attribute_size_in=detector_list%total_attributes)
+
+                   if (has_key(zoltan_global_uen_to_new_local_numbering, detector%element)) then
                       new_local_element_number = fetch(zoltan_global_uen_to_new_local_numbering, detector%element)
                       if (element_owned(zoltan_global_new_positions%mesh, new_local_element_number)) then
                          detector%element = new_local_element_number

--- a/femtools/Detector_Parallel.F90
+++ b/femtools/Detector_Parallel.F90
@@ -236,7 +236,7 @@ contains
 
                    ! Pack the first detector from the bcast_list
                    detector=>detector_bcast_list%first
-                   call pack_detector(detector, send_buff(1:ndata_per_det), xfield%dim,attribute_size=detector_list%total_attributes)
+                   call pack_detector(detector, send_buff(1:ndata_per_det), xfield%dim, attribute_size_in=detector_list%total_attributes)
                    call delete(detector, detector_bcast_list)
 
                    ! Broadcast the detectors you want to send
@@ -257,7 +257,7 @@ contains
                       shape=>ele_shape(xfield,1)
                       detector=>null()
                       call allocate(detector, xfield%dim, local_coord_count(shape), detector_list%total_attributes)
-                      call unpack_detector(detector, send_buff(1:ndata_per_det), xfield%dim, attribute_size=detector_list%total_attributes)
+                      call unpack_detector(detector, send_buff(1:ndata_per_det), xfield%dim, attribute_size_in=detector_list%total_attributes)
                       call insert(detector, lost_detectors_list)
                    end if
 
@@ -275,7 +275,7 @@ contains
                    shape=>ele_shape(xfield,1)
                    detector=>null()
                    call allocate(detector, xfield%dim, local_coord_count(shape),detector_list%total_attributes )
-                   call unpack_detector(detector, recv_buff(1:ndata_per_det), xfield%dim, attribute_size=detector_list%total_attributes)
+                   call unpack_detector(detector, recv_buff(1:ndata_per_det), xfield%dim, attribute_size_in=detector_list%total_attributes)
 
                    ! Try to find the detector position locally
                    call picker_inquire(xfield, detector%position, detector%element, detector%local_coords, global=.false.)
@@ -395,9 +395,11 @@ contains
              detector%element = halo_universal_number(ele_halo, detector%element)
 
              if (have_update_vector) then
-                call pack_detector(detector, send_buffer(target_proc)%ptr(j,1:det_size), dim, nstages=n_stages, attribute_size=detector_list%total_attributes)
+                call pack_detector(detector, send_buffer(target_proc)%ptr(j,1:det_size), dim, nstages=n_stages, &
+                     attribute_size_in=detector_list%total_attributes)
              else
-                call pack_detector(detector, send_buffer(target_proc)%ptr(j,1:det_size), dim, attribute_size=detector_list%total_attributes)
+                call pack_detector(detector, send_buffer(target_proc)%ptr(j,1:det_size), dim, &
+                     attribute_size_in=detector_list%total_attributes)
              end if
 
              ! delete also advances detector
@@ -444,11 +446,13 @@ contains
           ! Unpack routine uses ele_numbering_inverse to translate universal element 
           ! back to local detector element
           if (have_update_vector) then
-             call unpack_detector(detector_received,recv_buffer(receive_proc)%ptr(j,1:det_size),dim,&
-                    global_to_local=ele_numbering_inverse,coordinates=xfield,nstages=n_stages, attribute_size=detector_list%total_attributes)
+             call unpack_detector(detector_received,recv_buffer(receive_proc)%ptr(j,1:det_size),dim, &
+                    global_to_local=ele_numbering_inverse,coordinates=xfield,nstages=n_stages, &
+                    attribute_size_in=detector_list%total_attributes)
           else
-             call unpack_detector(detector_received,recv_buffer(receive_proc)%ptr(j,1:det_size),dim,&
-                    global_to_local=ele_numbering_inverse,coordinates=xfield, attribute_size=detector_list%total_attributes)
+             call unpack_detector(detector_received,recv_buffer(receive_proc)%ptr(j,1:det_size),dim, &
+                    global_to_local=ele_numbering_inverse,coordinates=xfield, &
+                    attribute_size_in=detector_list%total_attributes)
           end if
 
           call insert(detector_received, detector_list)           

--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -127,6 +127,11 @@ contains
        allocate(new_detector%attributes(attribute_size(1)))
        allocate(new_detector%old_attributes(attribute_size(2)))
        allocate(new_detector%old_fields(attribute_size(3)))
+    else
+       ! match the behaviour of create_single_detector, with empty attribute arrays
+       allocate(new_detector%attributes(0))
+       allocate(new_detector%old_attributes(0))
+       allocate(new_detector%old_fields(0))
     end if
       
     assert(associated(new_detector))
@@ -585,7 +590,15 @@ contains
        if (.not. allocated(detector%position)) then
           allocate(detector%position(ndims))
        end if
-       
+
+       ! ensure we at least allocate the attributes to be empty
+       ! to match the behaviour of create_single_detector
+       if (.not. allocated(detector%attributes)) then
+          allocate(detector%attributes(0))
+          allocate(detector%old_attributes(0))
+          allocate(detector%old_fields(0))
+       end if
+
        ! Basic fields: ndims+4
        detector%position = buff(1:ndims)
        detector%element = buff(ndims+1)

--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -412,26 +412,27 @@ contains
     integer, intent(in), optional :: nstages
     integer :: detector_buffer_size, det_params
     integer, dimension(3), optional, intent(in) :: attribute_size !array to hold size of attributes
+
     det_params = 3 !size of basic detector fields: detector element, id_number and proc_id
+
+    ! common to everything is a position + basic fields
+    detector_buffer_size = ndims + det_params
+
     if (present(attribute_size)) then
-       if (have_update_vector) then
-          assert(present(nstages))
-          detector_buffer_size=(nstages+2)*ndims+det_params+sum(attribute_size)
-       else
-          detector_buffer_size=ndims+det_params+1+sum(attribute_size)
-       end if
+      detector_buffer_size = detector_buffer_size + sum(attribute_size)
+    end if
+
+    if (have_update_vector) then
+      ! update vector adds ndims + nstages*ndims
+      detector_buffer_size = detector_buffer_size + (nstages + 1)*ndims
     else
-       if (have_update_vector) then
-          assert(present(nstages))
-          detector_buffer_size=(nstages+2)*ndims+det_params
-       else
-          detector_buffer_size=ndims+det_params+1
-       end if 
+      ! otherwise, there's a list id
+      detector_buffer_size = detector_buffer_size + 1
     end if
 
   end function detector_buffer_size
 
-  subroutine pack_detector(detector,buff,ndims,nstages, attribute_size)
+  subroutine pack_detector(detector,buff,ndims,nstages, attribute_size_in)
     ! Packs (serialises) detector into buff
     ! Basic fields are: element, position, id_number and type
     ! If nstages is given, the detector is still moving
@@ -440,70 +441,62 @@ contains
     real, dimension(:), intent(out) :: buff
     integer, intent(in) :: ndims
     integer, intent(in), optional :: nstages
-    integer, dimension(3), optional, intent(in) :: attribute_size !array to hold size of attributes
-    integer :: det_params
-    assert(size(detector%position)==ndims)
+    integer, dimension(3), optional, intent(in) :: attribute_size_in
+
+    integer :: det_params, buf_pos
+    integer, dimension(3) :: attribute_size
+
+    assert(size(detector%position) == ndims)
+
     !Set size of basic detector fields: detector element, id_number, proc_id
     det_params = 3
-    !Check if this is a particle carrying attributes
-    if (present(attribute_size)) then
-       assert(size(buff)>=ndims+det_params+sum(attribute_size))
-       ! Basic fields: ndims+det_params
-       buff(1:ndims) = detector%position
-       buff(ndims+1) = detector%element
-       buff(ndims+2) = detector%id_number
-       buff(ndims+3) = detector%proc_id
-       if (attribute_size(1).ne.0) then
-          buff(ndims+det_params+1:ndims+det_params+attribute_size(1)) = detector%attributes
-       end if
-       if (attribute_size(2).ne.0) then
-          buff(ndims+det_params+1+attribute_size(1):ndims+det_params+attribute_size(1)+attribute_size(2)) &
-               = detector%old_attributes
-       end if
-       if (attribute_size(3).ne.0) then
-          buff(ndims+det_params+1+attribute_size(1)+attribute_size(2):ndims+det_params+sum(attribute_size)) &
-               = detector%old_fields
-       end if
-       ! Lagrangian advection fields: (nstages+1)*ndims
-       if (present(nstages)) then
-          assert(size(buff)==(nstages+2)*ndims+det_params+sum(attribute_size))
-          assert(allocated(detector%update_vector))
-          assert(allocated(detector%k))
-          
-          buff(ndims+det_params+1+sum(attribute_size):2*ndims+det_params &
-               +sum(attribute_size)) = detector%update_vector
-          buff(2*ndims+det_params+1+sum(attribute_size):(nstages+2)*ndims &
-               +det_params+sum(attribute_size)) = reshape(detector%k,(/nstages*ndims/))
-       else
-          assert(size(buff)==ndims+det_params+1+sum(attribute_size))
-          buff(ndims+det_params+1+sum(attribute_size)) = detector%list_id
-       end if
-    else
-       assert(size(buff)>=ndims+det_params)
+    attribute_size(:) = 0
 
-       ! Basic fields: ndims+det_params
-       buff(1:ndims) = detector%position
-       buff(ndims+1) = detector%element
-       buff(ndims+2) = detector%id_number
-       buff(ndims+3) = detector%proc_id
-
-       ! Lagrangian advection fields: (nstages+1)*ndims
-       if (present(nstages)) then
-          assert(size(buff)==(nstages+2)*ndims+det_params)
-          assert(allocated(detector%update_vector))
-          assert(allocated(detector%k))
-          
-          buff(ndims+det_params+1:2*ndims+det_params) = detector%update_vector
-          buff(2*ndims+det_params+1:(nstages+2)*ndims+det_params) = reshape(detector%k,(/nstages*ndims/))
-       else
-          assert(size(buff)==ndims+det_params+1)
-          buff(ndims+det_params+1) = detector%list_id
-       end if
+    if (present(attribute_size_in)) then
+      attribute_size = attribute_size_in
     end if
-    
+
+    ! ensure buffer is big enough to receive this detector
+    assert(size(buff) >= ndims + det_params + sum(attribute_size))
+
+    ! Basic fields: ndims+det_params
+    buff(1:ndims) = detector%position
+    buff(ndims+1) = detector%element
+    buff(ndims+2) = detector%id_number
+    buff(ndims+3) = detector%proc_id
+
+    buf_pos = ndims + det_params
+
+    if (attribute_size(1) /= 0) then
+       buff(buf_pos + 1:buf_pos + attribute_size(1)) = detector%attributes
+       buf_pos = buf_pos + attribute_size(1)
+    end if
+    if (attribute_size(2) /= 0) then
+       buff(buf_pos + 1:buf_pos + attribute_size(2)) = detector%old_attributes
+       buf_pos = buf_pos + attribute_size(2)
+    end if
+    if (attribute_size(3) /= 0) then
+       buff(buf_pos + 1:buf_pos + attribute_size(3)) = detector%old_fields
+       buf_pos = buf_pos + attribute_size(3)
+    end if
+
+    ! Lagrangian advection fields: (nstages+1)*ndims
+    if (present(nstages)) then
+       assert(size(buff) == (nstages+2)*ndims + det_params + sum(attribute_size))
+       assert(allocated(detector%update_vector))
+       assert(allocated(detector%k))
+
+       buff(buf_pos + 1:buf_pos + ndims) = detector%update_vector
+       buf_pos = buf_pos + ndims
+
+       buff(buf_pos + 1:buf_pos + nstages*ndims) = reshape(detector%k, (/nstages*ndims/))
+    else
+       assert(size(buff) == ndims + det_params + sum(attribute_size) + 1)
+       buff(buf_pos + 1) = detector%list_id
+    end if
   end subroutine pack_detector
 
-  subroutine unpack_detector(detector,buff,ndims,global_to_local,coordinates,nstages,attribute_size)
+  subroutine unpack_detector(detector,buff,ndims,global_to_local,coordinates,nstages,attribute_size_in)
     ! Unpacks the detector from buff and fills in the blanks
     type(detector_type), pointer :: detector
     real, dimension(:), intent(in) :: buff
@@ -511,140 +504,95 @@ contains
     type(integer_hash_table), intent(in), optional :: global_to_local
     type(vector_field), intent(in), optional :: coordinates
     integer, intent(in), optional :: nstages
-    integer, dimension(3), optional, intent(in) :: attribute_size !array to hold size of attributes
+    integer, dimension(3), optional, intent(in) :: attribute_size_in
 
-    integer :: det_params
+    integer :: det_params, buf_pos
+    integer, dimension(3) :: attribute_size
     !Set size of basic detector fields, being detector element, id_number
     det_params = 3
-    
-    !Check if this is a particle carrying attributes
-    if (present(attribute_size)) then
+    attribute_size(:) = 0
 
-       if (.not. allocated(detector%position)) then
-          allocate(detector%position(ndims))
-       end if
-       if (.not. allocated(detector%attributes)) then
-          allocate(detector%attributes(attribute_size(1)))
-          allocate(detector%old_attributes(attribute_size(2)))
-          allocate(detector%old_fields(attribute_size(3)))
-       end if
-       ! Basic fields: ndims+4
-       detector%position = buff(1:ndims)
-       detector%element = buff(ndims+1)
-       detector%id_number = buff(ndims+2)
-       detector%proc_id = buff(ndims+3)
-       if (attribute_size(1)/=0) then  
-          detector%attributes = buff(ndims+det_params+1:ndims+det_params+attribute_size(1))
-       end if
-       if (attribute_size(2)/=0) then  
-          detector%old_attributes = buff(ndims+det_params+1+attribute_size(1):ndims+det_params+attribute_size(1) &
-               +attribute_size(2))
-       end if
-       if (attribute_size(3)/=0) then  
-          detector%old_fields = buff(ndims+det_params+1+attribute_size(1)+attribute_size(2):ndims+det_params+ &
-               sum(attribute_size))
-       end if
-       
-       ! Reconstruct element number if global-to-local mapping is given
-       if (present(global_to_local)) then
-          assert(has_key(global_to_local, detector%element))
-          detector%element=fetch(global_to_local,detector%element)
-          
-       ! Update local coordinates if coordinate field is given
-          if (present(coordinates)) then
-             if (.not. allocated(detector%local_coords)) then
-                allocate(detector%local_coords(local_coord_count(ele_shape(coordinates,1))))
-             end if
-             detector%local_coords=local_coords(coordinates,detector%element,detector%position)
-          end if
-       end if
-       
-       ! Lagrangian advection fields: (nstages+1)*ndims
-       if (present(nstages)) then
-          assert(size(buff)==(nstages+2)*ndims+det_params+sum(attribute_size))
-          
-          ! update_vector, dimension(ndim)
-          if (.not. allocated(detector%update_vector)) then
-             allocate(detector%update_vector(ndims))
-          end if
-          detector%update_vector = buff(ndims+det_params+1+sum(attribute_size) &
-               :2*ndims+det_params+sum(attribute_size))
-          
-          ! k, dimension(nstages:ndim)
-          if (.not. allocated(detector%k)) then
-             allocate(detector%k(nstages,ndims))
-          end if
-          detector%k = reshape(buff(2*ndims+det_params+1+sum(attribute_size):(nstages+2) &
-               *ndims+det_params+sum(attribute_size)),(/nstages,ndims/))
-          
-          ! If update_vector still exists, we're not done moving
-          detector%search_complete=.false.
-       else
-          assert(size(buff)==ndims+det_params+1+sum(attribute_size))
-          
-          detector%list_id = buff(ndims+det_params+1+sum(attribute_size))
-          detector%search_complete=.true.
-       end if
-    else
+    ! we default to assuming there are no attributes,
+    ! but this can be overridden by the caller
+    if (present(attribute_size_in)) then
+      attribute_size = attribute_size_in
+    end if
 
-       if (.not. allocated(detector%position)) then
-          allocate(detector%position(ndims))
-       end if
+    ! allocate some arrays that we might not have
+    ! set up beforehand
+    if (.not. allocated(detector%position)) then
+       allocate(detector%position(ndims))
+    end if
 
-       ! ensure we at least allocate the attributes to be empty
-       ! to match the behaviour of create_single_detector
-       if (.not. allocated(detector%attributes)) then
-          allocate(detector%attributes(0))
-          allocate(detector%old_attributes(0))
-          allocate(detector%old_fields(0))
-       end if
+    if (.not. allocated(detector%attributes)) then
+       allocate(detector%attributes(attribute_size(1)))
+       allocate(detector%old_attributes(attribute_size(2)))
+       allocate(detector%old_fields(attribute_size(3)))
+    end if
 
-       ! Basic fields: ndims+4
-       detector%position = buff(1:ndims)
-       detector%element = buff(ndims+1)
-       detector%id_number = buff(ndims+2)
-       detector%proc_id = buff(ndims+3)
-       
-       ! Reconstruct element number if global-to-local mapping is given
-       if (present(global_to_local)) then
-          assert(has_key(global_to_local, detector%element))
-          detector%element=fetch(global_to_local,detector%element)
-          
-       ! Update local coordinates if coordinate field is given
-          if (present(coordinates)) then
-             if (.not. allocated(detector%local_coords)) then
-                allocate(detector%local_coords(local_coord_count(ele_shape(coordinates,1))))
-             end if
-             detector%local_coords=local_coords(coordinates,detector%element,detector%position)
+    ! Basic fields: ndims+4
+    detector%position = buff(1:ndims)
+    detector%element = buff(ndims+1)
+    detector%id_number = buff(ndims+2)
+    detector%proc_id = buff(ndims+3)
+
+    buf_pos = ndims + det_params
+
+    ! unpack attributes if necessary
+    if (attribute_size(1) /= 0) then
+       detector%attributes = buff(buf_pos + 1:buf_pos + attribute_size(1))
+       buf_pos = buf_pos + attribute_size(1)
+    end if
+    if (attribute_size(2) /= 0) then
+       detector%old_attributes = buff(buf_pos + 1:buf_pos + attribute_size(2))
+       buf_pos = buf_pos + attribute_size(2)
+    end if
+    if (attribute_size(3) /= 0) then
+       detector%old_fields = buff(buf_pos + 1:buf_pos + attribute_size(3))
+       buf_pos = buf_pos + attribute_size(3)
+    end if
+
+    ! Reconstruct element number if global-to-local mapping is given
+    if (present(global_to_local)) then
+       assert(has_key(global_to_local, detector%element))
+       detector%element=fetch(global_to_local,detector%element)
+
+    ! Update local coordinates if coordinate field is given
+       if (present(coordinates)) then
+          if (.not. allocated(detector%local_coords)) then
+             allocate(detector%local_coords(local_coord_count(ele_shape(coordinates,1))))
           end if
-       end if
-       
-       ! Lagrangian advection fields: (nstages+1)*ndims
-       if (present(nstages)) then
-          assert(size(buff)==(nstages+2)*ndims+det_params)
-          
-          ! update_vector, dimension(ndim)
-          if (.not. allocated(detector%update_vector)) then
-             allocate(detector%update_vector(ndims))
-          end if
-          detector%update_vector = buff(ndims+det_params+1:2*ndims+det_params)
-          
-          ! k, dimension(nstages:ndim)
-          if (.not. allocated(detector%k)) then
-             allocate(detector%k(nstages,ndims))
-          end if
-          detector%k = reshape(buff(2*ndims+det_params+1:(nstages+2)*ndims+det_params),(/nstages,ndims/))
-          
-          ! If update_vector still exists, we're not done moving
-          detector%search_complete=.false.
-       else
-          assert(size(buff)==ndims+det_params+1)
-          
-          detector%list_id = buff(ndims+det_params+1)
-          detector%search_complete=.true.
+          detector%local_coords=local_coords(coordinates,detector%element,detector%position)
        end if
     end if
-   
+
+    ! Lagrangian advection fields: (nstages+1)*ndims
+    if (present(nstages)) then
+       assert(size(buff) == (nstages+2)*ndims + det_params + sum(attribute_size))
+
+       ! update_vector, dimension(ndim)
+       if (.not. allocated(detector%update_vector)) then
+          allocate(detector%update_vector(ndims))
+       end if
+       detector%update_vector = buff(buf_pos + 1:buf_pos + ndims)
+       buf_pos = buf_pos + ndims
+
+       ! k, dimension(nstages:ndim)
+       if (.not. allocated(detector%k)) then
+          allocate(detector%k(nstages,ndims))
+       end if
+       detector%k = reshape(buff(buf_pos + 1:buf_pos + nstages*ndims), &
+          (/nstages,ndims/))
+
+       ! If update_vector still exists, we're not done moving
+       detector%search_complete=.false.
+    else
+       assert(size(buff) == ndims + det_params + sum(attribute_size) + 1)
+
+       detector%list_id = buff(buf_pos + 1)
+       detector%search_complete = .true.
+    end if
+
   end subroutine unpack_detector
 
   function detector_value_scalar(sfield, detector) result(value)


### PR DESCRIPTION
(Duplicated from #319)

When we allocate/unpack detectors from Zoltan, some code expects that their attribute arrays (used for particles) are at least allocated, even if length 0. Ensuring this is done avoids potential segfaults when these arrays are unconditionally accessed.

Thanks @stephankramer for the detailed analysis of this issue! I think this is probably the right place for this allocation? Of course, the other approach would be to figure out where attribute_size is being passed into unpack_detector as a non-optional on a detector. (As an aside, that subroutine looks like it could just take a non-optional attribute_size and then the logic wouldn't be exactly duplicated in both branches...)

Closes #317.