### PR TITLE
Improved error messages from python

### DIFF
--- a/femtools/embed_python.c
+++ b/femtools/embed_python.c
@@ -65,7 +65,15 @@ int eval_user_func(char *function, int function_len, PyObject *pLocals, PyObject
 
   // Execute the user's code and clean up allocated string.
   pCode = PyRun_String(function_c, Py_file_input, pGlobals, pLocals);
+
   free(function_c);
+
+  // Check for errors in executing user code.
+  if (PyErr_Occurred()) {
+    PyErr_Print();
+    return 1;
+  }
+
   Py_DECREF(pCode);
 
   // Extract the function from the code.
@@ -75,11 +83,6 @@ int eval_user_func(char *function, int function_len, PyObject *pLocals, PyObject
       return 1;
   }
 
-  // Check for errors in executing user code.
-  if (PyErr_Occurred()) {
-    PyErr_Print();
-    return 1;
-  }
 
   return 0;
 }

--- a/femtools/python_statec.c
+++ b/femtools/python_statec.c
@@ -21,6 +21,10 @@ void python_init_(void){
 #if PY_MAJOR_VERSION >= 3
   PyImport_AppendInittab("spud_manager", &PyInit_spud_manager);
 #endif
+  // Force the stdout and stderr streams to be unbuffered
+  // This is to ensure backtrace+error actually gets printed
+  // through PyErr_Print before we abort.
+  Py_UnbufferedStdioFlag = 1;   
   Py_Initialize();
   PyRun_SimpleString("import string");
 


### PR DESCRIPTION
Often when an error occurs in the python embedded in fluidity, the
error+backtrace would not show up despite use calling PyErr_Print and
only prints the useless FLAbort message "Dying!". This
is caused by some internal buffering in python of stdio and stderr
(internal to python so independent of whether we have redirected the
actual stdio/stderr of the process at the system level). This commit
switches all such buffering off. As suggested here:
https://stackoverflow.com/questions/29352485/python-print-not-working-when-embedded-into-mpi-program/49076389#49076389
under option 1) Note that it should only affect stdio/err and not all
I/O from python (as it claims on stackexchange), and since we
shouldn't normally be printing much from python this should hopefully
not affect performance.

Also fixed a case where the error would result in a segfault because we
try to decref the pyobject returned from PyRun_String before checking
whether an error has occured, in which case PyRun_String returns null.

This came up in #315