### PR TITLE
Fix "mg" preconditioner with petsc 3.14

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -439,9 +439,9 @@ AC_COMPUTE_INT(PETSC_VERSION_MAJOR, "PETSC_VERSION_MAJOR", [#include "petscversi
 AC_COMPUTE_INT(PETSC_VERSION_MINOR, "PETSC_VERSION_MINOR", [#include "petscversion.h"], 
   [AC_MSG_ERROR([Unknown petsc minor version])])
 AC_MSG_NOTICE([Detected PETSc version "$PETSC_VERSION_MAJOR"."$PETSC_VERSION_MINOR"])
-# if major<3 or minor<4
-if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 4; then
-  AC_MSG_ERROR([Fluidity needs PETSc version >=3.4])
+# if major<3 or minor<8
+if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 8; then
+  AC_MSG_ERROR([Fluidity needs PETSc version >=3.8])
 fi
 
 AC_LANG(Fortran)
@@ -451,35 +451,27 @@ ac_ext=F90
 # may need some extra flags for testing that we don't want to use in the end
 SAVE_FCFLAGS="$FCFLAGS"
 
-if test "$enable_petsc_fortran_modules" != "no" ; then
-  # now try if the petsc fortran modules work:
-  AC_LINK_IFELSE(
-          [AC_LANG_PROGRAM([],[[
-                          use petsc
-                          integer :: ierr
-                          print*, "hello petsc"
-                          call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
-                          ]])],
-          [
-              AC_MSG_NOTICE([PETSc modules are working.])
-              AC_DEFINE(HAVE_PETSC_MODULES,1,[Define if you have petsc fortran modules.] )
-              FCFLAGS="$FCFLAGS -DHAVE_PETSC_MODULES"
-          ],
-          [
-              AC_MSG_NOTICE([PETSc modules don't work, using headers instead.])
-          ])
-elif test "0$PETSC_VERSION_MINOR" -ge 8; then
-  AC_MSG_ERROR([PETSc v3.8 and newer requires petsc fortran modules. Do not use the --disable-petsc-fortran-modules option])
-fi
+# now try if the petsc fortran modules work:
+AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([],[[
+                        use petsc
+                        integer :: ierr
+                        print*, "hello petsc"
+                        call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
+                        ]])],
+        [
+            AC_MSG_NOTICE([PETSc modules are working.])
+        ],
+        [
+            AC_MSG_ERROR([PETSc fortran modules cannot be used. Either it the petsc*.mod files cannot be found, or petsc has been built using a different fortran compiler.])
+        ])
 
 # now try a more realistic program, it's a stripped down
 # petsc tutorial - using the headers in the same way as we do in the code
 AC_LINK_IFELSE(
 [AC_LANG_SOURCE([
 program test_petsc
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
 implicit none
 #include "petsc_legacy.h"
       double precision  norm

--- a/assemble/Full_Projection.F90
+++ b/assemble/Full_Projection.F90
@@ -31,9 +31,7 @@
     use global_parameters
     use elements
     use spud
-#ifdef HAVE_PETSC_MODULES
     use petsc
-#endif
     use parallel_tools
     use data_structures
     use sparse_tools
@@ -359,11 +357,7 @@
       else
          ! workaround bug in petsc 3.8: missing CHKFORTRANNULLOBJECT, so PETSC_NULL_MAT isn't translated to C null
          ! this however seems to do the trick:
-#if PETSC_VERSION_MINOR>=8
          S%v = 0
-#else
-         S = PETSC_NULL_OBJECT
-#endif
          call MatCreateSchurComplement(inner_M%M,inner_M%M,G,G_t_comp,S,A,ierr)
       end if
       

--- a/assemble/tests/test_matrix_free.F90
+++ b/assemble/tests/test_matrix_free.F90
@@ -236,9 +236,7 @@ subroutine petsc_solve_matrix_free(x, matrix, rhs)
   use petsc_tools
   use matrix_free_solvers
 
-#ifdef HAVE_PETSC_MODULES
   use petsc 
-#endif
   implicit none
 #include "petsc_legacy.h"
   type(scalar_field), intent(inout) :: x

--- a/assemble/tests/test_pressure_solve.F90
+++ b/assemble/tests/test_pressure_solve.F90
@@ -15,9 +15,7 @@
     use boundary_conditions
     use global_parameters, only: OPTION_PATH_LEN
     use free_surface_module
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+    use petsc
     implicit none
 #include "petsc_legacy.h"
 

--- a/configure
+++ b/configure
@@ -785,7 +785,6 @@ with_femdem
 with_psmile
 with_netcdf
 with_exodusii
-enable_petsc_fortran_modules
 with_x
 enable_sam
 enable_dp
@@ -1463,12 +1462,6 @@ Optional Features:
   --enable-shared         Compile objects with -fPIC to enable the 'make
                           shared' target.
   --enable-verbose        turns on super verbosity
-  --disable-petsc-fortran-modules
-                          By default fluidity tries to use fortran modules
-                          provided with petsc. Use
-                          --disable-petsc-fortran-modules if these are known
-                          to be not functional (e.g. compiled with different
-                          compiler version)
   --enable-sam            use sam rather than zoltan for adaptive load
                           rebalancing
   --enable-dp=flag        compile with 64 bit floating point numbers (default)
@@ -6001,7 +5994,7 @@ then
     if test -z "$PYTHON_VERSION"; then
       # if PYTHON_VERSION is set we use python$PYTHON_VERSION as the python interpreter
       # if not, if there is no `python` in the path, or there is a `python` but its version is <3
-      # then use `python3` (by setting PETSC_VERSION=3).
+      # then use `python3` (by setting PYTHON_VERSION=3).
       # If there *is* a `python` of version 3, we use that
       # Extract the first word of "python", so it can be a program name with args.
 set dummy python; ac_word=$2
@@ -11793,11 +11786,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 fi
 
-# Check whether --enable-petsc-fortran-modules was given.
-if test "${enable_petsc_fortran_modules+set}" = set; then :
-  enableval=$enable_petsc_fortran_modules;
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for X" >&5
 $as_echo_n "checking for X... " >&6; }
 
@@ -12724,9 +12712,9 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&5
 $as_echo "$as_me: Detected PETSc version \"$PETSC_VERSION_MAJOR\".\"$PETSC_VERSION_MINOR\"" >&6;}
-# if major<3 or minor<4
-if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 4; then
-  as_fn_error $? "Fluidity needs PETSc version >=3.4" "$LINENO" 5
+# if major<3 or minor<8
+if test "0$PETSC_VERSION_MAJOR" -lt 3 -o "0$PETSC_VERSION_MINOR" -lt 8; then
+  as_fn_error $? "Fluidity needs PETSc version >=3.8" "$LINENO" 5
 fi
 
 ac_ext=${ac_fc_srcext-f}
@@ -12740,47 +12728,36 @@ ac_ext=F90
 # may need some extra flags for testing that we don't want to use in the end
 SAVE_FCFLAGS="$FCFLAGS"
 
-if test "$enable_petsc_fortran_modules" != "no" ; then
-  # now try if the petsc fortran modules work:
-  cat > conftest.$ac_ext <<_ACEOF
+# now try if the petsc fortran modules work:
+cat > conftest.$ac_ext <<_ACEOF
       program main
 
-                          use petsc
-                          integer :: ierr
-                          print*, "hello petsc"
-                          call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
+                        use petsc
+                        integer :: ierr
+                        print*, "hello petsc"
+                        call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
 
       end
 _ACEOF
 if ac_fn_fc_try_link "$LINENO"; then :
 
-              { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc modules are working." >&5
+            { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc modules are working." >&5
 $as_echo "$as_me: PETSc modules are working." >&6;}
-
-$as_echo "#define HAVE_PETSC_MODULES 1" >>confdefs.h
-
-              FCFLAGS="$FCFLAGS -DHAVE_PETSC_MODULES"
 
 else
 
-              { $as_echo "$as_me:${as_lineno-$LINENO}: PETSc modules don't work, using headers instead." >&5
-$as_echo "$as_me: PETSc modules don't work, using headers instead." >&6;}
+            as_fn_error $? "PETSc fortran modules cannot be used. Either it the petsc*.mod files cannot be found, or petsc has been built using a different fortran compiler." "$LINENO" 5
 
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-elif test "0$PETSC_VERSION_MINOR" -ge 8; then
-  as_fn_error $? "PETSc v3.8 and newer requires petsc fortran modules. Do not use the --disable-petsc-fortran-modules option" "$LINENO" 5
-fi
 
 # now try a more realistic program, it's a stripped down
 # petsc tutorial - using the headers in the same way as we do in the code
 cat > conftest.$ac_ext <<_ACEOF
 
 program test_petsc
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
 implicit none
 #include "petsc_legacy.h"
       double precision  norm

--- a/configure.in
+++ b/configure.in
@@ -193,7 +193,7 @@ then
     if test -z "$PYTHON_VERSION"; then
       # if PYTHON_VERSION is set we use python$PYTHON_VERSION as the python interpreter
       # if not, if there is no `python` in the path, or there is a `python` but its version is <3
-      # then use `python3` (by setting PETSC_VERSION=3).
+      # then use `python3` (by setting PYTHON_VERSION=3).
       # If there *is* a `python` of version 3, we use that
       AC_CHECK_PROG(have_bare_python, python, "yes")
       if test "x$have_bare_python" = "xyes"; then
@@ -828,9 +828,6 @@ if test "$with_exodusii" = "yes" ; then
                                            ])
 fi
 AC_SUBST(HAVE_EXODUSII)
-AC_ARG_ENABLE(petsc-fortran-modules,
-    [AC_HELP_STRING([--disable-petsc-fortran-modules],
-    [By default fluidity tries to use fortran modules provided with petsc. Use --disable-petsc-fortran-modules if these are known to be not functional (e.g. compiled with different compiler version)])])
 ACX_PETSc([AC_MSG_NOTICE(["PETSc found, enabling scalable solver"])], [AC_MSG_ERROR(["PETSc not found"])])
 ACX_hypre([AC_MSG_NOTICE(["hypre found, enabling hypre preconditioners"])], [AC_MSG_WARN(["hypre not found"])])
 CPPFLAGS="$CPPFLAGS -DHAVE_PETSC"

--- a/femtools/Petsc_Tools.F90
+++ b/femtools/Petsc_Tools.F90
@@ -33,9 +33,7 @@ module Petsc_Tools
   use Reference_Counting
   use halo_data_types
   use halos_base
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+  use petsc
   use Sparse_Tools
   use fields_data_types
   use fields_base
@@ -52,12 +50,7 @@ module Petsc_Tools
 ! it is possible (and not unlikely) that the uninitialised object happens to contain -1 which
 ! in petsc v3.8 is recognized as a NULL object. Therefore in petsc v3.8 we have to pass in an
 ! object that is known not to be a null vec
-#if PETSC_VERSION_MINOR>=8
   Vec, parameter, public :: PETSC_NOTANULL_VEC = tVec(1)
-#else
-  ! previously Vec was just an integer (and NULL was checked by comparing its memory address with the one cannonical PETSC_NULL_OBJECT)
-  Vec, parameter, public :: PETSC_NOTANULL_VEC = 1
-#endif
 
   PetscReal, parameter, private :: dummy_petsc_real = 0.0
   integer, parameter, public :: PetscReal_kind = kind(dummy_petsc_real)
@@ -124,12 +117,6 @@ module Petsc_Tools
   ! for unit-testing:
   logical, public, save :: petsc_test_error_handler_called = .false.
   public petsc_test_error_handler
-#if PETSC_VERSION_MINOR<5
-  public mykspgetoperators
-#endif
-#if PETSC_VERSION_MINOR<7
-  public NullPetscViewerAndFormatCreate
-#endif
   public IsNullMatNullSpace
 
 contains
@@ -1538,54 +1525,17 @@ subroutine petsc_test_error_handler(comm,line, func, file, dir, n, p, mess, ctx,
   
 end subroutine petsc_test_error_handler
 
-! this is a wrapper around KSPGetOperators, that in petsc <3.5
-! has an extra mat_structure flag. We need to wrap this because
-! we need a local variable.
-! in include/petsc_legacy.h we #define KSPGetOperators -> mykspgetoperators
-#if PETSC_VERSION_MINOR<5
-subroutine mykspgetoperators(ksp, amat, pmat, ierr)
-  KSP, intent(in):: ksp
-  Mat, intent(in):: amat, pmat
-  PetscErrorCode, intent(out):: ierr
-
-  MatStructure:: mat_structure
-  
-  ! need small caps, to avoid #define from include/petsc_legacy.h
-  call  kspgetoperators(ksp, amat, pmat, mat_structure, ierr)
-
-end subroutine mykspgetoperators
-#endif
-
-#if PETSC_VERSION_MINOR<7
-subroutine NullPetscViewerAndFormatCreate(viewer, format, vf, ierr)
-  PetscViewer, intent(in) :: viewer
-  PetscEnum, intent(in) :: format
-  PetscObject, intent(out) :: vf
-  PetscErrorCode, intent(out) :: ierr
-
-  assert(viewer==PETSC_VIEWER_STDOUT_WORLD)
-  assert(format==PETSC_VIEWER_DEFAULT)
-  vf = PETSC_NULL_VIEWER
-  ierr = 0
-
-end subroutine NullPetscViewerAndFormatCreate
-#endif
-
 function IsNullMatNullSpace(nullsp)
   ! This function checks whether `nullsp` is a NULL nullspace
   ! (the equivalent of (MatNullspace *) null in C)
   MatNullSpace, intent(in) :: nullsp
   logical :: IsNullMatNullSpace
 
-#if PETSC_VERSION_MINOR>=8
     ! MatNullSpace(-1) is what is recognized as null in CHKFORTRANNULLOBJECT
     ! MatNullSpace(0) is what is returned by MatGetNullspace if no nullspace is present
     ! (because a wrapper on the output is missing, and there isn't a PETSC_NULL_MATNULLSPACE
     ! in the first place)
     IsNullMatNullSpace = nullsp%v==-1 .or. nullsp%v==0
-#else
-    IsNullMatNullSpace = nullsp==PETSC_NULL_OBJECT
-#endif
 
 end function IsNullMatNullSpace
 

--- a/femtools/Solvers.F90
+++ b/femtools/Solvers.F90
@@ -33,9 +33,7 @@ module solvers
   use elements
   use spud
   use parallel_tools
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
   use Sparse_Tools
   use fields_calculations
   use Fields
@@ -1588,9 +1586,6 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
     type(csr_matrix), optional, intent(in) :: matrix_csr
     integer, optional, intent(in) :: internal_smoothing_option
     
-#if PETSC_VERSION_MINOR<6 || (PETSC_VERSION_MINOR==6 && PETSC_VERSION_SUBMINOR==0)
-    MatNullSpace nullsp
-#endif
     KSPType ksptype
     PC pc
     PetscReal rtol, atol, dtol
@@ -1715,42 +1710,6 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
        call KSPMonitorSet(ksp, MyKSPMonitor, vf, &
             &                     PETSC_NULL_FUNCTION, ierr)
     end if
-
-#if PETSC_VERSION_MINOR<6
-    if (mat/=pmat) then
-      ! This is to make things consistent with the situation in petsc>=3.6:
-      ! there the nullspace is picked up directly from the Mat during KSPSolve.
-      ! The routine KSPSetNullSpace no longer exists. Previously
-      ! however, the nullspace was picked up from *pmat* inside KSPSetOperators
-      ! At this point KSPSetOperators, has already been called, so if mat has 
-      ! a nullspace we want it to be set as the nullspace of the KSP
-      call MatGetNullSpace(mat, nullsp, ierr)
-      if (ierr==0 .and. .not. IsNullMatNullSpace(nullsp)) then
-        call KSPSetNullSpace(ksp, nullsp, ierr)
-      else
-        call MatGetNullSpace(pmat, nullsp, ierr)
-        if (ierr==0 .and. .not. IsNullMatNullSpace(nullsp)) then
-          FLAbort("Preconditioner matrix has nullspace whereas the matrix itself doesn't")
-          ! This is a problem because the nullspace on the preconditioner matrix is now
-          ! attached to the ksp already. Not sure how to remove it again; Can I just call
-          ! KSPSetNullSpace with PETSC_NULL_OBJECT? I don't think this combination
-          ! does anything useful anyway, so let's just error. You can try it out with 
-          ! PETSc>=3.6 which should do the right thing.
-        end if
-      end if
-    end if
-#elif PETSC_VERSION_MINOR==6 && PETSC_VERSION_SUBMINOR==0
-    ! this is 3.6.0 case where KSPSetNullSpace no longer exists, but the nullspace picked up
-    ! in the krylov iteration is from *pmat* not mat (as it is in 3.6.1 and later)
-    if (mat/=pmat) then
-      call MatGetNullSpace(mat, nullsp, ierr)
-      if (ierr==0 .and. .not. IsNullMatNullSpace(nullsp)) then
-        ewrite(0,*) "Matrix and preconditioner matrix are different. For this case nullspaces"
-        ewrite(0,*) "and petsc 3.6.0 are not supported. Please upgrade to petsc 3.6.1 or higher"
-        FLExit("Cannot use petsc 3.6.0 with nullspaces when mat/=pmat")
-      end if
-    end if
-#endif
 
   end subroutine setup_ksp_from_options
 
@@ -1965,7 +1924,7 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
             petsc_numbering=petsc_numbering)
 
     else
-      
+
        ! this doesn't work for hypre
        call PCSetType(pc, pctype, ierr)
        ! set options that may have been supplied via the
@@ -1982,9 +1941,7 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
       if (pctype==PCGAMG) then
         ! we think this is a more useful default - the default value of 0.0
         ! causes spurious "unsymmetric" failures as well
-#if PETSC_VERSION_MINOR<8
-        call PCGAMGSetThreshold(pc, 0.01, ierr)
-#else
+
         ! From petsc v3.8: the threshold can be set at each level, levels that
         ! are left unspecified are scaled by a factor level-by-level
         ! I believe the following leads to the same default we were using previously:
@@ -1992,7 +1949,7 @@ subroutine create_ksp_from_options(ksp, mat, pmat, solver_option_path, parallel,
         ! so that other levels get the same threshold value
         call PCGAMGSetThresholdScale(pc, 1.0, ierr)
         call PCGAMGSetThreshold(pc, (/ 0.01/), 1, ierr)
-#endif
+
         ! this was the old default:
         call PCGAMGSetCoarseEqLim(pc, 800, ierr)
         ! PC setup seems to be required so that the Coarse Eq Lim option is used.

--- a/femtools/Sparse_Tools.F90
+++ b/femtools/Sparse_Tools.F90
@@ -37,9 +37,7 @@ module sparse_tools
   use memory_diagnostics
   use ieee_arithmetic
   use data_structures
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
   
   implicit none
   

--- a/femtools/Sparse_Tools_Petsc.F90
+++ b/femtools/Sparse_Tools_Petsc.F90
@@ -37,9 +37,7 @@ module sparse_tools_petsc
   use parallel_tools
   use halo_data_types
   use halos_allocates
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
   use Sparse_Tools
   use fields_data_types
   use fields_base

--- a/femtools/tests/test_matrix_conversions.F90
+++ b/femtools/tests/test_matrix_conversions.F90
@@ -4,9 +4,7 @@ subroutine test_matrix_conversions
   use sparse_tools
   use petsc_tools
   use unittest_tools
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+  use petsc
   implicit none
   
 #include "petsc_legacy.h"

--- a/femtools/tests/test_multigrid.F90
+++ b/femtools/tests/test_multigrid.F90
@@ -12,9 +12,7 @@ subroutine test_multigrid
   use solvers
   use fields
   use parallel_tools
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+  use petsc
   implicit none
 #include "petsc_legacy.h"
   integer, parameter:: DIM=100, NNZ=1000

--- a/femtools/tests/test_petsc_csr_matrix.F90
+++ b/femtools/tests/test_petsc_csr_matrix.F90
@@ -5,9 +5,7 @@ subroutine test_petsc_csr_matrix()
   use parallel_tools
   use petsc_tools
   use unittest_tools
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+  use petsc
   implicit none
 #include "petsc_legacy.h"
   

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -108,9 +108,6 @@
 /* Define if you have the PETSc library. */
 #undef HAVE_PETSC
 
-/* Define if you have petsc fortran modules. */
-#undef HAVE_PETSC_MODULES
-
 /* If available, contains the Python version number currently in use. */
 #undef HAVE_PYTHON
 

--- a/include/petsc_legacy.h
+++ b/include/petsc_legacy.h
@@ -5,77 +5,14 @@
 ! names can be used in the code everywhere. Where interfaces have changed we
 ! still need #ifdef PETSC_VERSION>... in the main code
 #include "petscversion.h"
-#ifdef HAVE_PETSC_MODULES
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR>=8) || (PETSC_VERSION_MAJOR>=4)
 #include "petsc/finclude/petsc.h"
-#elif (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR>=6)
-#include "petsc/finclude/petscdef.h"
-#else
-#include "finclude/petscdef.h"
-#endif
-#else
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR>=8) || (PETSC_VERSION_MAJOR>=4)
-#error "From PETSc v3.8, petsc fortran modules are required. Ensure petsc fortran modules, compiled with the same fortran compiler, are installed and configure without the --disable-petsc-fortran-modules option."
-#elif (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR>=6)
-#include "petsc/finclude/petsc.h"
-#else
-#include "finclude/petsc.h"
-#endif
+
+#define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x%v, ierr)
+#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<9)
+#define MatSolverType MatSolverPackage
+#define PCFactorSetMatSolverType PCFactorSetMatSolverPackage
 #endif
 
 #ifndef PC_COMPOSITE_SYMMETRIC_MULTIPLICATIVE
 #define PC_COMPOSITE_SYMMETRIC_MULTIPLICATIVE PC_COMPOSITE_SYM_MULTIPLICATIVE
-#endif
-! Changes in petsc 3.5 PETSC_DEFAULT_DOUBLE_PRECISION -> PETSC_DEFAULT_REAL
-! (can't use #ifndef cause PETSC_DEFAULT_REAL is a module variable)
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<5)
-#define PETSC_DEFAULT_REAL PETSC_DEFAULT_DOUBLE_PRECISION
-#endif
-! MatStructure argument to KSP/PCSetOperators has been dropped:
-! we use this macro hack which means that the call cannot be split over multiple lines
-! also note the (ab)use of fortran's case insensivity to avoid recursion
-! for PCSetOperators we use small caps because otherwise the preprocessor trips up on an occurence of PCSetoperators directly followed by () in a fortran comment in one of the petsc headers
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<5)
-#define KSPSetOperators(ksp, amat, pmat, ierr) kspsetoperators(ksp, amat, pmat, DIFFERENT_NONZERO_PATTERN, ierr)
-#define pcsetoperators(pc, amat, pmat, ierr) PCSetOperators(pc, amat, pmat, DIFFERENT_NONZERO_PATTERN, ierr)
-! mykspgetoperators is a wrapper function defined in Petsc_Tools.F90:
-#define KSPGetOperators(ksp, amat, pmat, ierr) mykspgetoperators(ksp, amat, pmat, ierr)
-#endif
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<6)
-#define MatCreateVecs MatGetVecs
-#endif
-! from petsc 3.7 onward all PetscOptionsXXX() calls have an additional PetscOptions first argument
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<7)
-#define PetscOptionsGetInt(options, pre, name, ivalue, set, ierr) petscoptionsgetint(pre, name, ivalue, set, ierr)
-#define PetscOptionsGetReal(options, pre, name, dvalue, set, ierr) petscoptionsgetreal(pre, name, dvalue, set, ierr)
-#define PetscOptionsGetString(options, pre, name, string, set, ierr) petscoptionsgetstring(pre, name, string, set, ierr)
-#define PetscOptionsHasName(options, pre, name, set, ierr) petscoptionshasname(pre, name, set, ierr)
-#endif
-! these PetscViewerAndFormatCreate/Destroy don't exist in petsc<3.7
-! but we only use them to combine PETSC_VIEWER_STDOUT_WORLD and PETSC_VIEWER_DEFAULT
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<7)
-#define PetscViewerAndFormatCreate NullPetscViewerAndFormatCreate
-#define PetscViewerAndFormatDestroy PETSC_NULL_FUNCTION
-#endif
-! from petsc 3.8 onward PETSC_NULL_OBJECT is gone, a specific PETSC_NULL_XXX needs to be used
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<8)
-#define PETSC_NULL_OPTIONS PETSC_NULL_OBJECT
-#define PETSC_NULL_KSP PETSC_NULL_OBJECT
-#define PETSC_NULL_VEC PETSC_NULL_OBJECT
-#define PETSC_NULL_MAT PETSC_NULL_OBJECT
-#define PETSC_NULL_VECSCATTER PETSC_NULL_OBJECT
-#define PETSC_NULL_VIEWER PETSC_NULL_OBJECT
-#define PETSC_NULL_IS PETSC_NULL_OBJECT
-#endif
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<8)
-#define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x, ierr)
-#else
-#define PetscObjectReferenceWrapper(x, ierr) PetscObjectReference(x%v, ierr)
-#endif
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<8)
-#define MatCreateSubMatrix MatGetSubMatrix
-#endif
-#if (PETSC_VERSION_MAJOR==3 && PETSC_VERSION_MINOR<9)
-#define MatSolverType MatSolverPackage
-#define PCFactorSetMatSolverType PCFactorSetMatSolverPackage
 #endif

--- a/manual/external_libraries.tex
+++ b/manual/external_libraries.tex
@@ -22,7 +22,7 @@ run:
 \item BLAS (tested netlib, ATLAS, MKL)
 \item LAPACK (tested netlib, ATLAS, MKL)
 \item MPI2 implementation (tested OpenMPI version 1.6.5)
-\item PETSc (tested version 3.4.3)
+\item PETSc (tested version 3.8)
 \item ParMetis (tested version 3.2, 4.x not supported)
 \item Python (build tested version 2.7.5) 
 \item NumPy (build tested version 1.8.1)
@@ -552,8 +552,7 @@ make, and install.
 
 PETSc is required for
 efficient solver methods within \fluidity. Currently,
-\fluidity supports PETSc versions 3.1 to 3.4, using version 3.4
-is recommended. It can be downloaded from
+\fluidity supports PETSc versions 3.8 to 3.15. It can be downloaded from
 \url{http://www.mcs.anl.gov/petsc/download/} and built in the source directory.
 First, set PETSC{\textunderscore}DIR in the source directory:
 

--- a/tools/petsc_readnsolve.F90
+++ b/tools/petsc_readnsolve.F90
@@ -36,9 +36,7 @@ use populate_state_module
 use field_options
 use halos_registration
 use parallel_tools
-#ifdef HAVE_PETSC_MODULES
-  use petsc 
-#endif
+use petsc
 implicit none
 #include "petsc_legacy.h"
   ! options read from command-line (-prns_... options)

--- a/tools/petsc_readnsolve_main.cpp
+++ b/tools/petsc_readnsolve_main.cpp
@@ -41,11 +41,7 @@ void usage(int argc, char **argv){
   PetscBool      flg;
   
   // if it's already specified as a PETSc option, we do nothing:
-#if PETSC_VERSION_MINOR<7
-  ierr = PetscOptionsHasName("prns_","-flml",&flg);
-#else
   ierr = PetscOptionsHasName(NULL, "prns_","-flml",&flg);
-#endif
   if (flg) {
     return;
   }
@@ -63,27 +59,15 @@ void usage(int argc, char **argv){
     my_PETSc_options+= flml_file;
     // see if next argument is a valid fieldname
     // but only if not already in the PETSc options database
-#if PETSC_VERSION_MINOR<7
-    ierr = PetscOptionsHasName("prns_","-field",&flg);
-#else
     ierr = PetscOptionsHasName(NULL, "prns_","-field",&flg);
-#endif
     if( !flg && (i+1<argc) && (argv[i+1][0]!='-') ) {
       my_PETSc_options+= " -prns_field " + string(argv[i+1]);
     }
-#if PETSC_VERSION_MINOR<7
-    ierr = PetscOptionsInsertString( my_PETSc_options.c_str() );
-#else
     ierr = PetscOptionsInsertString(NULL, my_PETSc_options.c_str() );
-#endif
   }
   
   // -l option needs to be dealt with in c++ already
-#if PETSC_VERSION_MINOR<7
-  ierr = PetscOptionsHasName("","-l",&flg);
-#else
   ierr = PetscOptionsHasName(NULL, "","-l",&flg);
-#endif
   if (flg) {
     int rank = 0;
 #ifdef HAVE_MPI

--- a/tools/test_laplacian.F90
+++ b/tools/test_laplacian.F90
@@ -22,10 +22,7 @@ program test_laplacian
   use state_module
   use adapt_state_module 
   use boundary_conditions
-
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
   implicit none
 #include "petsc_legacy.h"
   
@@ -63,10 +60,8 @@ program test_laplacian
   end interface
   character(len=256) :: filename
 
-#ifdef HAVE_PETSC
   integer :: ierr
   call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
-#endif
 
   call python_init
 

--- a/tools/test_pressure_solve.F90
+++ b/tools/test_pressure_solve.F90
@@ -19,9 +19,7 @@
     use global_parameters, only: OPTION_PATH_LEN, PYTHON_FUNC_LEN
     use free_surface_module
     use FLDebug
-#ifdef HAVE_PETSC_MODULES
-  use petsc
-#endif
+    use petsc
   implicit none
 #include "petsc_legacy.h"
 
@@ -307,9 +305,7 @@
        & exact_sol_filename, vl_as, vl_as_wsor, vl, no_vl, sor)
     use Fldebug
     use petsc_tools
-#ifdef HAVE_PETSC_MODULES
   use petsc
-#endif
   implicit none
 #include "petsc_legacy.h"
 


### PR DESCRIPTION
This is dealing with bug https://gitlab.com/petsc/petsc/-/issues/868
Which is fixed only for 3.15. Unfortunately no workarounds for 3.14 exists in fortran,
because even if we do provide the optional argument it still gets
recognized for NULL and hits the bug. So instead write our own wrapper
in C.

This also drop support for petsc version <3.8 Note that Bionic official
packages are 3.7 - but we have always supplied our own 3.8 package for
it. Groovy and Hirsute are now on 3.14 Dropping support for <3.8
simplifies/removes a lot of the legacy workarounds. We no longer support
linking with petsc without fortran modules (we never did for versions >=3.8).