### PR TITLE
Minor bugs spotted in Focal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 ## Linux related
 *~
 
+## VSCode
+.vscode
+
+## Settings for the Fortran Language Server
+.fortls
+
 ## Emacs files
 # -*- mode: gitignore; -*-
 \#*\#
@@ -22,15 +28,38 @@ tramp
  __pycache__/
 *.py[cod]
 
-## C extensions
+## Build extensions
 *.o
 *.so
+*.so.*
+*.a
+*.la
+*.lai
+*.lo
+*.Plo
+*.Po
+*.pc
+*.log
+*.cmake
+
+## Build files
+Makefile
+libtool
+compile
+depcomp
+ltmain.sh
+missing
+py-compile
+config.status
+autom4te.cache/
 
 ## header files
-include/confdefs.h
+## vtk.h, config.h and confdefs.h are present in more that one include dir
+vtk.h
+config.h
+confdefs.h
 include/Judy.h
 include/Wm4*.h
-include/config.h
 include/spatialindex/
 include/spud
 include/spud.h
@@ -38,8 +67,8 @@ include/spud_enums.h
 include/tinystr.h
 include/tinyxml.h
 include/version.h
-include/vtk.h
-
+include/H5*
+include/h5core/
 
 ## Fortran extensions
 *.mod
@@ -47,3 +76,33 @@ include/vtk.h
 ## directories
 bin/
 lib/
+share/
+
+## Configure and compile generated files
+tests/tools.mk
+
+## Tools
+tools/lib
+tools/version-info
+
+## Python
+python/setup.py
+
+## Fortran files
+diagnostics/Diagnostic_Fields_New.F90
+preprocessor/check_options.F90
+preprocessor/register_diagnostics.F90
+
+## libspud
+libspud/diamond/build/
+libspud/diamond/diamond/plugins.py
+libspud/diamond/diamond/preprocess.py
+libspud/diamond/setup.py
+
+## libjudy
+stamp-h1
+Judy1TablesGen
+JudyLTablesGen
+configure.lineno
+libjudy/src/Judy1/Judy1Tables.c
+libjudy/src/JudyL/JudyLTables.c

--- a/femtools/.gitignore
+++ b/femtools/.gitignore
@@ -1,0 +1,3 @@
+H5hut.F90
+## Ignore the reference counter interfaces
+Reference_count*

--- a/femtools/Fields_Allocates.F90
+++ b/femtools/Fields_Allocates.F90
@@ -445,7 +445,7 @@ contains
 
   end subroutine deallocate_subdomain_mesh
 
-  subroutine deallocate_mesh_faces(mesh)
+  recursive subroutine deallocate_mesh_faces(mesh)
     type(mesh_type) :: mesh
 
     if (.not.associated(mesh%faces)) return
@@ -497,7 +497,7 @@ contains
     
   end subroutine deallocate_mesh_faces
 
-  subroutine deallocate_mesh(mesh)
+ recursive subroutine deallocate_mesh(mesh)
     !!< Deallocate the components of mesh. Shape functions are not
     !!< deallocated here.
     type(mesh_type), intent(inout) :: mesh
@@ -613,7 +613,7 @@ contains
     
   end subroutine deallocate_scalar_field
     
-  subroutine remove_boundary_conditions_scalar(field)
+  recursive subroutine remove_boundary_conditions_scalar(field)
      !!< Removes and deallocates all boundary conditions from a field
      type(scalar_field), intent(inout):: field
      
@@ -668,7 +668,7 @@ contains
     
   end subroutine deallocate_vector_field
  
-  subroutine remove_boundary_conditions_vector(field)
+  recursive subroutine remove_boundary_conditions_vector(field)
      !!< Removes and deallocates all boundary conditions from a field
      type(vector_field), intent(inout):: field
      

--- a/preprocessor/Populate_State.F90
+++ b/preprocessor/Populate_State.F90
@@ -2172,7 +2172,7 @@ contains
 
   end subroutine allocate_and_insert_tensor_field
 
-  subroutine allocate_and_insert_children(path, state, parent_mesh, parent_name, &
+  recursive subroutine allocate_and_insert_children(path, state, parent_mesh, parent_name, &
        dont_allocate_prognostic_value_spaces)
     character(len=*), intent(in) :: path !! option_path including prescribed/prognostic
     type(state_type), intent(inout) :: state

--- a/sediments/Sediment.F90
+++ b/sediments/Sediment.F90
@@ -31,7 +31,7 @@ module sediment
 
   use global_parameters, only:   OPTION_PATH_LEN, FIELD_NAME_LEN, dt, timestep
   use fldebug
-  use futils, only: int2str
+  use futils, only: int2str, present_and_true
   use vector_tools
   use quadrature
   use elements
@@ -88,7 +88,7 @@ contains
     call get_option('/material_phase[0]/sediment/scalar_field['//int2str(i_field -&
          & 1)//']/name', name) 
 
-    if (present(old) .and. old) then
+    if (present_and_true(old)) then
       name = "Old"//trim(name)
     end if
     item => extract_scalar_field(state, trim(name), stat)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,4 @@
 ## Temporary files created for tests
 *.msh
+## Negate ignoring Makefiles
+!Makefile

--- a/tests/Helmholtz-anisotropic-scalar-mms-p1p1cg-structured/Makefile
+++ b/tests/Helmholtz-anisotropic-scalar-mms-p1p1cg-structured/Makefile
@@ -5,7 +5,7 @@ input:	clean
 	gmsh -2 -bin -algo frontal -o MMS_D_structured.msh src/MMS_D_structured.geo
 
 clean:
-	rm -f *.vtu *.msh *.stat fluidity.err-0 fluidity.log-0
+	rm -f *.vtu *.msh *.stat *.log* *.err*
 
 flmls:
 	@$(foreach M,B C D, \

--- a/tests/Stokes_square_convection_1e4_p1p1_parallel/Makefile
+++ b/tests/Stokes_square_convection_1e4_p1p1_parallel/Makefile
@@ -23,7 +23,7 @@ clean-run:
 	rm -f $(FLMLMODEL)_?*_?*_checkpoint.pvtu $(FLMLMODEL)_?*_?*_checkpoint.vtu
 	rm -f $(FLMLMODEL)_?*_checkpoint.msh
 	rm -f $(FLMLMODEL)_?*_checkpoint.vtu
-	rm -rf *flredecomp*
+	rm -rf *flredecomp* *.h5part
 clean-run-debug: clean-run
 	rm -f adapted_mesh_?*.vtu bounding_box_?*_?*.vtu final_metric_?*.vtu gmon.out gradation_metric_?*.vtu interpolation_metric_final_?*.vtu interpolation_metric_hessian_?*_?*.vtu interpolation_metric_merge_?*_?*.vtu interpolation_metric_metric_?*_?*.vtu metric_input_?*_?*.vtu
 	rm -rf $(FLMLMODEL)_?

--- a/tests/Stokes_square_convection_1e4_p1p1cv/Makefile
+++ b/tests/Stokes_square_convection_1e4_p1p1cv/Makefile
@@ -13,7 +13,7 @@ clean: clean-mesh clean-run-debug
 clean-mesh:
 	rm -f $(MESH).msh
 clean-run:
-	rm -f $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.msh $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info
+	rm -f $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.msh $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info *.h5part
 clean-run-debug: clean-run
 	rm -f adapted_mesh_?*.vtu bounding_box_?*_?*.vtu final_metric_?*.vtu gmon.out gradation_metric_?*.vtu interpolation_metric_final_?*.vtu interpolation_metric_hessian_?*_?*.vtu interpolation_metric_merge_?*_?*.vtu interpolation_metric_metric_?*_?*.vtu metric_input_?*_?*.vtu
 

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_fv/Makefile
@@ -1,4 +1,4 @@
-SHELL = sh
+SHELL = bash
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_fv
 
@@ -47,4 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
-	rm -f $(SIM)_{BCD}.flml
+	rm -f $(SIM)_{B,C,D}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cg/Makefile
@@ -1,4 +1,4 @@
-SHELL = sh
+SHELL = bash
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1cg
 
@@ -47,4 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
-	rm -f $(SIM)_{BCD}.flml
+	rm -f $(SIM)_{B,C,D}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1cv/Makefile
@@ -1,4 +1,4 @@
-SHELL = sh
+SHELL = bash
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1cv
 
@@ -47,4 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
-	rm -f $(SIM)_{BCD}.flml
+	rm -f $(SIM)_{B,C,D}.flml

--- a/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/Makefile
+++ b/tests/add_src_directly_1d_2grp_hom_zerobc_eig_p1dg/Makefile
@@ -1,4 +1,4 @@
-SHELL = sh
+SHELL = bash
 
 SIM = add_src_directly_1d_2grp_hom_zerobc_eig_p1dg
 
@@ -47,4 +47,4 @@ clean:
 	rm -f first_timestep_adapted_mesh*
 	rm -f $(SIM)*.eig_iteration_convergence
 	rm -f $(SIM)*checkpoint*
-	rm -f $(SIM)_{BCD}.flml
+	rm -f $(SIM)_{B,C,D}.flml

--- a/tests/analytical-sphere-cg-tracer/Makefile
+++ b/tests/analytical-sphere-cg-tracer/Makefile
@@ -5,4 +5,5 @@ input: clean
 	mpirun -n 2 ../../bin/flredecomp -i 1 -o 2 sphericalSegment sphericalSegment_flredecomp
 
 clean:
-	rm -f  *.vtu *.stat *.msh *_flredecomp* matrixdump*
+	rm -f  *.log* *.err* *.vtu *.pvtu *.stat *.msh *_flredecomp* matrixdump*
+	rm -rf sphericalSegment_[0-9]

--- a/tests/bc-smoothing/Makefile
+++ b/tests/bc-smoothing/Makefile
@@ -2,5 +2,6 @@ input: clean
 	gmsh -3 -o cube.msh src/cube.geo
 
 clean:
-	rm -rf out* cube.msh
+	rm -f *.log* *.err* smoothed_bcs_parallel.flml
+	rm -rf out* *.msh *.halo
 	rm -rf matrixdump matrixdump.info

--- a/tests/biology_conservation/Makefile
+++ b/tests/biology_conservation/Makefile
@@ -3,4 +3,4 @@ input: clean
 
 clean:
 	rm -f  *.ele *.edge *.face *.node *.poly *.vtu *.s *.d.1 *.stat *.detectors \
-	matrixdump matrixdump.info
+	matrixdump matrixdump.info *.h5part

--- a/tests/biology_conservation_adapt/Makefile
+++ b/tests/biology_conservation_adapt/Makefile
@@ -2,4 +2,4 @@ input: clean
 
 clean:
 	rm -f  fluidity* *.ele *.edge *.face *.node *.poly *.vtu *.s *.d.1 *.stat *.detectors \
-	matrixdump matrixdump.info
+	matrixdump matrixdump.info *.h5part

--- a/tests/flredecomp_repart/Makefile
+++ b/tests/flredecomp_repart/Makefile
@@ -10,4 +10,4 @@ clean-mesh:
 clean-run:
 	rm -f cube_?*.ele cube_?*.face cube_?*.halo cube_?*.node
 	rm -f *.log* *.err* test_flredecomp_repart.flml
-	rm -f test_flredecomp_repart_CoordinateMesh_*
+	rm -f test_flredecomp*

--- a/tests/parallel_refinement_2d/Makefile
+++ b/tests/parallel_refinement_2d/Makefile
@@ -2,5 +2,6 @@ input:
 	gmsh -2 src/square.geo -o square.msh
 
 clean:
-	rm -rf fluidity.* square.msh refinep* refine_* refine.stat
+	rm -rf fluidity.* square.msh refinep* refine_* refine.stat *.pvtu
 	rm -rf matrixdump*
+	rm -rf adapted_state_[0-9] gradation_metric_[0-9] bounding_box_[0-9] metric_input_1_[0-9]

--- a/tests/particle_attributes_checkpoint_parallel_flredecomp/Makefile
+++ b/tests/particle_attributes_checkpoint_parallel_flredecomp/Makefile
@@ -3,3 +3,6 @@ default: clean
 	gmsh -format msh2 -2 -bin square.geo -o square.msh
 clean: 
 	rm -rf *.msh *.halo *.vtu *.pvtu *.log* *.err* *.stat blob_[012] *.particles.* particle_attributes_? *~ *.h5part P4* particle_attributes_checkpoint_?
+	rm -f particle_attributes_1_checkpoint.flml
+	rm -f particle_attributes_checkpoint_1_checkpoint.flml
+	rm -f particle-attributes-flredecomp.flml

--- a/tests/prescribed_adaptivity_spaces/Makefile
+++ b/tests/prescribed_adaptivity_spaces/Makefile
@@ -7,7 +7,7 @@ input:
 	
 clean: clean-mesh clean-run-debug
 clean-mesh:
-	rm -f *.ele *.edge *.node
+	rm -f *.geo *.msh *.ele *.edge *.node
 clean-run:
 	rm -f $(FLMLMODEL)_?*.pvtu $(FLMLMODEL)_?*.vtu
 	rm -f $(FLMLMODEL).detectors $(FLMLMODEL).stat tmpf*

--- a/tests/sigma_layer_sphere_parallel/Makefile
+++ b/tests/sigma_layer_sphere_parallel/Makefile
@@ -8,3 +8,4 @@ clean:
 	rm -f *.msh *.halo
 	rm -f *.pvtu *.vtu
 	rm -f *flredecomp.flml
+	rm -rf sigma_layers_[0-9]

--- a/tests/sloshing_tank/Makefile
+++ b/tests/sloshing_tank/Makefile
@@ -3,5 +3,5 @@ input: clean
 	
 
 clean:
-	rm -rf *.d.* *.s* *.vtu *.log *.node *.ele *.face *.vtu matrixdump* *.pyc src/*.msh fluidity.* *.detectors
+	rm -rf *.d.* *.s* *.vtu *.log *.node *.ele *.face *.vtu matrixdump* *.pyc src/*.msh fluidity.* *.detectors *.h5part
 

--- a/tests/square-convection-parallel/Makefile
+++ b/tests/square-convection-parallel/Makefile
@@ -15,7 +15,7 @@ clean-mesh:
 clean-run:
 	rm -f *.dat *.halo *.pvtu *.vtu *.edge *.ele *.node $(FLMLMODEL)_?*_checkpoint.flml *.detectors *.stat *.err-? *.log-? matrixdump matrixdump.info
 	rm -rf $(MODEL)*_checkpoint $(MODEL)_?
-	rm -rf *flredecomp*
+	rm -rf *flredecomp* *.h5part
 clean-run-debug: clean-run
 	rm -f adapted_mesh_?*.vtu bounding_box_?*_?*.vtu final_metric_?*.vtu gmon.out gradation_metric_?*.vtu interpolation_metric_final_?*.vtu interpolation_metric_hessian_?*_?*.vtu interpolation_metric_merge_?*_?*.vtu interpolation_metric_metric_?*_?*.vtu metric_input_?*_?*.vtu
 

--- a/tests/square-convection/checkpoint/Makefile
+++ b/tests/square-convection/checkpoint/Makefile
@@ -11,7 +11,7 @@ clean: clean-checkpoint clean-run-debug
 clean-checkpoint:
 	rm -f $(CHECKPOINTEDMODEL)_?*_checkpoint.edge $(CHECKPOINTEDMODEL)_?*_checkpoint.ele $(CHECKPOINTEDMODEL)_?*_checkpoint.node $(CHECKPOINTEDMODEL)_?*_checkpoint.flml $(CHECKPOINTEDMODEL)_?*_?*_checkpoint.vtu
 clean-run:
-	rm -f $(FLMLMODEL).detectors.dat $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.edge $(FLMLMODEL)_?*_checkpoint.ele $(FLMLMODEL)_?*_checkpoint.node $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info
+	rm -f $(FLMLMODEL).detectors.dat $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.edge $(FLMLMODEL)_?*_checkpoint.ele $(FLMLMODEL)_?*_checkpoint.node $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info $(FLMLMODEL).h5part
 clean-run-debug: clean-run
 	rm -f adapted_mesh_?*.vtu bounding_box_?*_?*.vtu final_metric_?*.vtu gmon.out gradation_metric_?*.vtu interpolation_metric_final_?*.vtu interpolation_metric_hessian_?*_?*.vtu interpolation_metric_merge_?*_?*.vtu interpolation_metric_metric_?*_?*.vtu metric_input_?*_?*.vtu
 	rm -f pre_adapt_linear_mesh_?*.ele pre_adapt_linear_mesh_?*.face pre_adapt_linear_mesh_?*.node

--- a/tests/square-convection/checkpoint/Makefile
+++ b/tests/square-convection/checkpoint/Makefile
@@ -11,7 +11,7 @@ clean: clean-checkpoint clean-run-debug
 clean-checkpoint:
 	rm -f $(CHECKPOINTEDMODEL)_?*_checkpoint.edge $(CHECKPOINTEDMODEL)_?*_checkpoint.ele $(CHECKPOINTEDMODEL)_?*_checkpoint.node $(CHECKPOINTEDMODEL)_?*_checkpoint.flml $(CHECKPOINTEDMODEL)_?*_?*_checkpoint.vtu
 clean-run:
-	rm -f $(FLMLMODEL).detectors.dat $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.edge $(FLMLMODEL)_?*_checkpoint.ele $(FLMLMODEL)_?*_checkpoint.node $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info $(FLMLMODEL).h5part
+	rm -f $(FLMLMODEL).detectors.dat $(FLMLMODEL)_?*.vtu $(FLMLMODEL)_?*_checkpoint.edge $(FLMLMODEL)_?*_checkpoint.ele $(FLMLMODEL)_?*_checkpoint.node $(FLMLMODEL)_?*_checkpoint.flml $(FLMLMODEL)_?*_?*_checkpoint.vtu $(FLMLMODEL).stat $(FLMLMODEL).detectors fluidity.err-0 fluidity.log-0 matrixdump matrixdump.info *.h5part
 clean-run-debug: clean-run
 	rm -f adapted_mesh_?*.vtu bounding_box_?*_?*.vtu final_metric_?*.vtu gmon.out gradation_metric_?*.vtu interpolation_metric_final_?*.vtu interpolation_metric_hessian_?*_?*.vtu interpolation_metric_merge_?*_?*.vtu interpolation_metric_metric_?*_?*.vtu metric_input_?*_?*.vtu
 	rm -f pre_adapt_linear_mesh_?*.ele pre_adapt_linear_mesh_?*.face pre_adapt_linear_mesh_?*.node

--- a/tests/standing_wave-dg-adapt/Makefile
+++ b/tests/standing_wave-dg-adapt/Makefile
@@ -5,7 +5,7 @@ input: clean
 
 clean:
 	rm -f $(PROJECT).stat
-	rm -f *.vtu *.detectors
+	rm -f *.vtu *.detectors *.h5part
 	rm -f fluidity.err-0 fluidity.log-0
 	rm -f *.ele *.face *.node *.msh \
 	matrixdump matrixdump.info


### PR DESCRIPTION
While doing some work I encountered one more short-circuit evaluation in Sediments along with some compiler failures
when enabling for using recursion in routines not marked as such (you can replicate the failures by turning -fcheck=recursion` on during compilation).

I also fixed some of the `clean` targets in our test Makefiles because they were polluting the git tree after running tests.

## Summary of changes

1. Fixes short circuit evaluations in sediments
2. Adds missing recursion keyword for subroutines that are used in recursion
3. Edits some make files in tests to completely clean the test output
4. Made `.gitignore` slightly more aggressive to specifically ignore all the configure and compile generated files and nothing more

I believe this is now done.

