### PR TITLE
ENH: Allow for independent particle attribute values on initialisation and advection

### DIFF
--- a/assemble/Adapt_State.F90
+++ b/assemble/Adapt_State.F90
@@ -1006,7 +1006,7 @@ contains
 
       !Set particle attributes and dependent fields
       call get_option("/timestepping/current_time", current_time)
-      call update_particle_attributes_and_fields(states, current_time, dt, initial=.true.)
+      call update_particle_attributes_and_fields(states, current_time, dt)
       call calculate_diagnostic_fields_from_particles(states)
 
       ! Form the new metric

--- a/assemble/Adapt_State.F90
+++ b/assemble/Adapt_State.F90
@@ -1006,7 +1006,7 @@ contains
 
       !Set particle attributes and dependent fields
       call get_option("/timestepping/current_time", current_time)
-      call update_particle_attributes_and_fields(states, current_time, dt)
+      call update_particle_attributes_and_fields(states, current_time, dt, initial=.true.)
       call calculate_diagnostic_fields_from_particles(states)
 
       ! Form the new metric

--- a/assemble/Particle_Diagnostics.F90
+++ b/assemble/Particle_Diagnostics.F90
@@ -94,9 +94,12 @@ module particle_diagnostics
        do j = 1,particle_arrays(i)
           particle => particle_lists(list_counter)%first
           subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(j-1)//"]"
-          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/constant") + &
-               & option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/constant") + &
-               & option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/constant")>0) then
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/initial_attribute_value/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/scalar_attribute/attribute_value/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/vector_attribute/initial_attribute_value/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/vector_attribute/attribute_value/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/tensor_attribute/initial_attribute_value/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/tensor_attribute/attribute_value/constant")>0) then
              call initialise_constant_particle_attributes(state, subgroup_path, particle_lists(list_counter))
           end if
           list_counter = list_counter + 1

--- a/assemble/Particle_Diagnostics.F90
+++ b/assemble/Particle_Diagnostics.F90
@@ -48,16 +48,15 @@ module particle_diagnostics
   use detector_tools, only: temp_list_insert, insert, allocate, deallocate, temp_list_deallocate, &
        & remove, temp_list_remove
   use particles, only : get_particle_arrays, initialise_constant_particle_attributes, &
-       & update_particle_attributes_and_fields, get_particle_arrays, particle_lists
+       & particle_lists
   use multimaterial_module, only: calculate_sum_material_volume_fractions
 
   implicit none
 
   private
 
-  public :: update_particle_attributes_and_fields, calculate_particle_material_fields, &
-       & calculate_diagnostic_fields_from_particles, initialise_constant_particle_diagnostics, &
-       & particle_cv_check
+  public :: calculate_particle_material_fields, calculate_diagnostic_fields_from_particles, &
+       & initialise_constant_particle_diagnostics, particle_cv_check
 
   contains
 
@@ -126,24 +125,24 @@ module particle_diagnostics
 
     !Initialise diagnostic fields generated from particles
     do i = 1,size(state)
-       do k = 1,scalar_field_count(state(i))
-          s_field => extract_scalar_field(state(i),k)
-          if (have_option(trim(s_field%option_path)//"/diagnostic/algorithm::from_particles")) then
-             call get_option(trim(s_field%option_path)//"/name", name)
-             if (name=="MaterialVolumeFraction") cycle
-             call calculate_field_from_particles(state, i, s_field)
-          end if
-       end do
+      do k = 1,scalar_field_count(state(i))
+        s_field => extract_scalar_field(state(i),k)
+        if (have_option(trim(s_field%option_path)//"/diagnostic/algorithm::from_particles")) then
+          call get_option(trim(s_field%option_path)//"/name", name)
+          if (name=="MaterialVolumeFraction") cycle
+          call calculate_field_from_particles(state, i, s_field)
+        end if
+      end do
     end do
 
     !Initialise fields based on number of particles if present
     do i = 1,size(state)
-       do k = 1,scalar_field_count(state(i))
-          s_field => extract_scalar_field(state(i),k)
-          if (have_option(trim(s_field%option_path)//"/diagnostic/algorithm::number_of_particles")) then
-             call calculate_field_from_particles(state, i, s_field)
-          end if
-       end do
+      do k = 1,scalar_field_count(state(i))
+        s_field => extract_scalar_field(state(i),k)
+        if (have_option(trim(s_field%option_path)//"/diagnostic/algorithm::number_of_particles")) then
+          call calculate_field_from_particles(state, i, s_field)
+        end if
+      end do
     end do
 
   end subroutine calculate_diagnostic_fields_from_particles

--- a/assemble/Particle_Diagnostics.F90
+++ b/assemble/Particle_Diagnostics.F90
@@ -94,9 +94,9 @@ module particle_diagnostics
        do j = 1,particle_arrays(i)
           particle => particle_lists(list_counter)%first
           subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(j-1)//"]"
-          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/constant") + &
-               & option_count(trim(subgroup_path) // "/attributes/vector_attribute/constant") + &
-               & option_count(trim(subgroup_path) // "/attributes/tensor_attribute/constant")>0) then
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/constant") + &
+               & option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/constant")>0) then
              call initialise_constant_particle_attributes(state, subgroup_path, particle_lists(list_counter))
           end if
           list_counter = list_counter + 1

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -27,7 +27,7 @@ RUN apt-get update && \
      rm -rf /var/cache/apt && \
      rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --upgrade junit-xml numpy
+RUN python3 -m pip install --upgrade junit-xml
 
 WORKDIR /usr/local
 RUN curl -fsL https://gmsh.info/bin/Linux/gmsh-2.16.0-Linux64.tgz | tar --strip-components=1 -zxf -

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -27,7 +27,7 @@ RUN apt-get update && \
      rm -rf /var/cache/apt && \
      rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --upgrade junit-xml
+RUN python3 -m pip install --upgrade junit-xml numpy
 
 WORKDIR /usr/local
 RUN curl -fsL https://gmsh.info/bin/Linux/gmsh-2.16.0-Linux64.tgz | tar --strip-components=1 -zxf -

--- a/docker/actions/Dockerfile.actions.bionic
+++ b/docker/actions/Dockerfile.actions.bionic
@@ -8,7 +8,7 @@ RUN apt-get -y update && \
       rm -rf /var/cache/apt/archives && \
       rm -rf /var/lib/apt/lists
 
-RUN python3 -m pip install --upgrade numpy
+RUN python3 -m pip install --upgrade numpy scipy
 
 RUN adduser fluidity sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/docker/actions/Dockerfile.actions.bionic
+++ b/docker/actions/Dockerfile.actions.bionic
@@ -8,6 +8,8 @@ RUN apt-get -y update && \
       rm -rf /var/cache/apt/archives && \
       rm -rf /var/lib/apt/lists
 
+RUN python3 -m pip install --upgrade numpy
+
 RUN adduser fluidity sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-24.flml
+++ b/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-24.flml
@@ -125,11 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -158,11 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-24.flml
+++ b/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-24.flml
@@ -125,9 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -156,9 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-48.flml
+++ b/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-48.flml
@@ -125,11 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -158,11 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-48.flml
+++ b/examples/particle_rayleigh_taylor_mu10/particle-rayleigh-taylor-mu10-48.flml
@@ -125,9 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -156,9 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/femtools/CGAL_Tools.F90
+++ b/femtools/CGAL_Tools.F90
@@ -2,8 +2,8 @@
 module cgal_tools
 
   use fldebug
-  use fields
   use element_numbering
+  use fields
   implicit none
 
   interface

--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -649,6 +649,7 @@ contains
          lvx, lvy, lvz, stat)
 
     if (stat/=0) then
+      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -774,6 +775,7 @@ contains
            size(attributes,2), lvx, lvy, lvz, time, dt, attributes, stat)
     end if
     if (stat/=0) then
+      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -784,7 +786,7 @@ contains
   !! specified in the string func at that location.
   subroutine set_particle_scalar_attribute_from_python_fields(particle_list, state, positions, lcoords, ele, natt, &
        attributes, old_attr_names, old_attr_counts, old_attr_Dims, old_attributes, field_names, field_counts, old_field_names, &
-       old_field_counts, func, time, dt, is_array)
+       old_field_counts, func, time, dt, is_array, first_newly_init_part)
     !! Particle list for which to evaluate the function
     type(detector_linked_list), intent(in) :: particle_list
     !! Model state structure
@@ -828,6 +830,8 @@ contains
     real, intent(in) :: dt
     !! Whether this is an array-valued attribute
     logical, intent(in) :: is_array
+    !> Pointer to the first newly initialised particle
+    type(detector_type), pointer, optional :: first_newly_init_part
 
     ! locals
     integer :: i
@@ -864,7 +868,12 @@ contains
          field_vals, dim)
 
     ! copy old fields off particles
-    particle => particle_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => particle_list%first
+    end if
+
     do i = 1, nparts
       old_field_vals(:,i) = particle%old_fields(:)
       particle => particle%next
@@ -874,9 +883,10 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, attributes, stat)
     if (stat/=0) then
-       ewrite(-1, *) "Python error, Python string was:"
-       ewrite(-1 , *) trim(func)
-       FLExit("Dying")
+      ! FIX ME - Does not print
+      ewrite(-1, *) "Python error, Python string was:"
+      ewrite(-1 , *) trim(func)
+      FLExit("Dying")
     end if
 
     deallocate(field_vals)
@@ -933,6 +943,7 @@ contains
             size(attributes,2), lvx, lvy, lvz, time, dt, attributes, stat)
     end if
     if (stat/=0) then
+      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -943,7 +954,7 @@ contains
   !! specified in the string func at that location.
   subroutine set_particle_vector_attribute_from_python_fields(particle_list, state, positions, lcoords, ele, natt, &
        attributes, old_attr_names, old_attr_counts, old_attr_dims, old_attributes, field_names, field_counts, old_field_names, &
-       old_field_counts, func, time, dt, is_array)
+       old_field_counts, func, time, dt, is_array, first_newly_init_part)
     !! Particle list for which to evaluate the function
     type(detector_linked_list), intent(in) :: particle_list
     !! Model state structure
@@ -987,6 +998,8 @@ contains
     real, intent(in) :: dt
     !! Whether this is an array-valued attribute
     logical, intent(in) :: is_array
+    !> Pointer to the first newly initialised particle
+    type(detector_type), pointer, optional :: first_newly_init_part
 
     ! locals
     integer :: i
@@ -1023,7 +1036,12 @@ contains
          field_vals, dim)
 
     ! copy old fields off particles
-    particle => particle_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => particle_list%first
+    end if
+
     do i = 1, nparts
       old_field_vals(:,i) = particle%old_fields(:)
       particle => particle%next
@@ -1033,6 +1051,7 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, attributes, stat)
     if (stat/=0) then
+      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -1096,6 +1115,7 @@ contains
             nparts, lvx, lvy, lvz, time, dt, tensor_res, stat)
     end if
     if (stat/=0) then
+      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -1109,7 +1129,7 @@ contains
   !! specified in the string func at that location.
   subroutine set_particle_tensor_attribute_from_python_fields(particle_list, state, positions, lcoords, ele, natt, &
        attributes, old_attr_names, old_attr_counts, old_attr_dims, old_attributes, field_names, field_counts, old_field_names, &
-       old_field_counts, func, time, dt, is_array)
+       old_field_counts, func, time, dt, is_array, first_newly_init_part)
     !! Particle list for which to evaluate the function
     type(detector_linked_list), intent(in) :: particle_list
     !! Model state structure
@@ -1153,6 +1173,8 @@ contains
     real, intent(in) :: dt
     !! Whether this is an array-valued attribute
     logical, intent(in) :: is_array
+    !> Pointer to the first newly initialised particle
+    type(detector_type), pointer, optional :: first_newly_init_part
 
     ! locals
     integer :: i
@@ -1190,7 +1212,12 @@ contains
          field_vals, dim)
 
     ! copy old fields off particles
-    particle => particle_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => particle_list%first
+    end if
+
     do i = 1, nparts
       old_field_vals(:,i) = particle%old_fields(:)
       particle => particle%next
@@ -1202,6 +1229,7 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, tensor_res, stat)
     if (stat/=0) then
+      ! FIX ME - Does not print
        ewrite(-1, *) "Python error, Python string was:"
        ewrite(-1 , *) trim(func)
        FLExit("Dying")

--- a/femtools/Detector_Tools.F90
+++ b/femtools/Detector_Tools.F90
@@ -649,7 +649,6 @@ contains
          lvx, lvy, lvz, stat)
 
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -775,7 +774,6 @@ contains
            size(attributes,2), lvx, lvy, lvz, time, dt, attributes, stat)
     end if
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -883,7 +881,6 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, attributes, stat)
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -943,7 +940,6 @@ contains
             size(attributes,2), lvx, lvy, lvz, time, dt, attributes, stat)
     end if
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -1051,7 +1047,6 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, attributes, stat)
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -1115,7 +1110,6 @@ contains
             nparts, lvx, lvy, lvz, time, dt, tensor_res, stat)
     end if
     if (stat/=0) then
-      ! FIX ME - Does not print
       ewrite(-1, *) "Python error, Python string was:"
       ewrite(-1 , *) trim(func)
       FLExit("Dying")
@@ -1229,7 +1223,6 @@ contains
          lvx, lvy, lvz, time, dt, field_counts, field_names, field_vals, old_field_counts, old_field_names, &
          old_field_vals, old_attr_counts, old_attr_names, old_attr_dims, old_attributes, is_array, tensor_res, stat)
     if (stat/=0) then
-      ! FIX ME - Does not print
        ewrite(-1, *) "Python error, Python string was:"
        ewrite(-1 , *) trim(func)
        FLExit("Dying")

--- a/femtools/Node_Owner_Finder_Fortran.F90
+++ b/femtools/Node_Owner_Finder_Fortran.F90
@@ -190,7 +190,7 @@ contains
 
     integer, dimension(1) :: lele_id
 
-    call node_owner_finder_find(id, positions_a, spread(position, 2, 1), lele_id, global = global)
+    call node_owner_finder_find(id, positions_a, spread(position, 2, 1), lele_id, global=global)
     ele_id = lele_id(1)
 
   end subroutine node_owner_finder_find_single_position
@@ -276,7 +276,7 @@ contains
         possible_elements_loop: do j = 1, nele_ids
           call cnode_owner_finder_get_output(id, possible_ele_id, j)
           ! If this process does not own this possible_ele_id element then
-          ! don't consider it.  This filter is needed to make this subroutine work in
+          ! don't consider it. This filter is needed to make this subroutine work in
           ! parallel without having to use universal numbers, which aren't defined
           ! for all the meshes that use this subroutine.
           if(.not.element_owned(positions_a,possible_ele_id)) then
@@ -328,7 +328,6 @@ contains
         ! on all processes.  This matches the find_serial(0) behaviour.
       end do
 #endif
-
       deallocate(closest_misses)
 
     end subroutine find_parallel
@@ -433,7 +432,7 @@ contains
       lpositions(:, node_b) = node_val(positions_b, node_b)
     end do
 
-    call node_owner_finder_find(id, positions_a, lpositions, eles_a, global = global)
+    call node_owner_finder_find(id, positions_a, lpositions, eles_a, global=global)
 
     deallocate(lpositions)
 

--- a/femtools/Node_Owner_Finder_Fortran.F90
+++ b/femtools/Node_Owner_Finder_Fortran.F90
@@ -190,7 +190,7 @@ contains
 
     integer, dimension(1) :: lele_id
 
-    call node_owner_finder_find(id, positions_a, spread(position, 2, 1), lele_id, global=global)
+    call node_owner_finder_find(id, positions_a, spread(position, 2, 1), lele_id, global = global)
     ele_id = lele_id(1)
 
   end subroutine node_owner_finder_find_single_position
@@ -276,7 +276,7 @@ contains
         possible_elements_loop: do j = 1, nele_ids
           call cnode_owner_finder_get_output(id, possible_ele_id, j)
           ! If this process does not own this possible_ele_id element then
-          ! don't consider it. This filter is needed to make this subroutine work in
+          ! don't consider it.  This filter is needed to make this subroutine work in
           ! parallel without having to use universal numbers, which aren't defined
           ! for all the meshes that use this subroutine.
           if(.not.element_owned(positions_a,possible_ele_id)) then
@@ -328,6 +328,7 @@ contains
         ! on all processes.  This matches the find_serial(0) behaviour.
       end do
 #endif
+
       deallocate(closest_misses)
 
     end subroutine find_parallel
@@ -432,7 +433,7 @@ contains
       lpositions(:, node_b) = node_val(positions_b, node_b)
     end do
 
-    call node_owner_finder_find(id, positions_a, lpositions, eles_a, global=global)
+    call node_owner_finder_find(id, positions_a, lpositions, eles_a, global = global)
 
     deallocate(lpositions)
 

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -1474,8 +1474,6 @@ contains
              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
              field_names, field_counts, old_field_names, old_field_counts, &
              func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
-      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
-        ! don't do anything, the attribute was already loaded from file
       end if
 
       attr_idx = attr_idx + n
@@ -1522,8 +1520,6 @@ contains
              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
              field_names, field_counts, old_field_names, old_field_counts, &
              func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
-      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
-        ! don't do anything, the attribute was already loaded from file
       end if
 
       attr_idx = attr_idx + n*dim
@@ -1570,8 +1566,6 @@ contains
              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
              field_names, field_counts, old_field_names, old_field_counts, &
              func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
-      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
-        ! don't do anything, the attribute was already loaded from file
       end if
 
       attr_idx = attr_idx + n*dim**2
@@ -2187,34 +2181,6 @@ contains
     if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
        FLAbort("Failed to set particles options filename when checkpointing particles with option path " // "/particles/particle_array::" // trim(temp_string))
     end if
-
-    do j = 1, tot_atts
-      particles_s = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/attribute_value/constant")
-      particles_v = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/attribute_value/constant")
-      particles_t = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/attribute_value/constant")
-      if (particles_s) then
-        call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/attribute_value/constant")
-        call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)// &
-             "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-             FLAbort("Failed to set scalar field particles filename when checkpointing")
-          end if
-       else if (particles_v) then
-          call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/attribute_value/constant")
-          call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)// &
-               "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-             FLAbort("Failed to set vector field particles filename when checkpointing")
-          end if
-       else if (particles_t) then
-          call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/attribute_value/constant")
-          call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)// &
-               "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-             FLAbort("Failed to set tensor field particles filename when checkpointing")
-          end if
-       end if
-    end do
 
   end subroutine update_particle_subgroup_options
 

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -1181,11 +1181,14 @@ contains
     type(state_type), dimension(:), intent(in) :: state
     real, intent(in) :: time
     real, intent(in) :: dt
-    logical, optional :: initial
+    logical, intent(in), optional :: initial
+
     character(len = OPTION_PATH_LEN) :: group_path, subgroup_path, particles_filename
 
     integer :: i, k
     integer :: particle_groups, particle_subgroups, list_counter
+
+    logical :: initial_aux
 
     ! Check whether there are any particles.
     particle_groups = option_count("/particles/particle_group")
@@ -1214,19 +1217,21 @@ contains
             if (index(particles_filename, 'checkpoint_particles') /= 0 &
                 .and. index(particles_filename, 'h5part') /= 0) then
               ! Assume this is a checkpoint
-              initial = .false.
+              initial_aux = .false.
             else
               ! Assume this is simulation start
-              initial = .true.
+              initial_aux = .true.
             end if
           ! Particles are initialised from Python: we are at simulation start
           else
-            initial = .true.
+            initial_aux = .true.
           end if
+        else
+          initial_aux = initial
         end if
 
         call update_particle_subgroup_attributes_and_fields( &
-          state, time, dt, subgroup_path, particle_lists(list_counter), initial=initial)
+          state, time, dt, subgroup_path, particle_lists(list_counter), initial=initial_aux)
         list_counter = list_counter + 1
       end do
     end do

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -1192,7 +1192,7 @@ contains
     type(state_type), dimension(:), intent(in) :: state
     real, intent(in) :: time
     real, intent(in) :: dt
-    logical, intent(in), optional :: initial
+    logical, intent(in) :: initial
 
     character(len = OPTION_PATH_LEN) :: group_path, subgroup_path, particles_filename
 
@@ -1220,22 +1220,16 @@ contains
           cycle
         end if
 
-        ! If initial is not present, then we are in adapt_at_first_timestep
-        if (.not. present(initial)) then
-          ! If from_file exists, then it could be a checkpoint
-          if (have_option(trim(subgroup_path) // "/initial_position/from_file")) then
-            call get_option(trim(subgroup_path) // "/initial_position/from_file/file_name", particles_filename)
-            if (index(particles_filename, 'checkpoint_particles') /= 0 &
-                .and. index(particles_filename, 'h5part') /= 0) then
-              ! Assume this is a checkpoint
-              initial_aux = .false.
-            else
-              ! Assume this is simulation start
-              initial_aux = .true.
-            end if
-          ! Particles are initialised from Python: we are at simulation start
+        ! Determine if this is the initial timestep of the whole simulation
+        if (have_option(trim(subgroup_path) // "/initial_position/from_file")) then
+          ! If from_file exists, then this is likely a simulation restart from a checkpoint
+          call get_option(trim(subgroup_path) // "/initial_position/from_file/file_name", particles_filename)
+          if (index(particles_filename, 'checkpoint_particles') /= 0 &
+              .and. index(particles_filename, 'h5part') /= 0) then
+            ! Assume this is a simulation restart from a checkpoint
+            initial_aux = .false.
           else
-            initial_aux = .true.
+            initial_aux = initial
           end if
         else
           initial_aux = initial

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -1181,7 +1181,7 @@ contains
     type(state_type), dimension(:), intent(in) :: state
     real, intent(in) :: time
     real, intent(in) :: dt
-    logical, intent(in), optional :: initial
+    logical, optional :: initial
     character(len = OPTION_PATH_LEN) :: group_path, subgroup_path, particles_filename
 
     integer :: i, k

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -327,12 +327,12 @@ contains
 
           ! If any attributes are from fields, we'll need to store old fields too
           store_old_fields = .false.
-          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/value_on_advection/python_fields") > 0) then
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/attribute_value/python_fields") > 0) then
              store_old_fields = .true.
           end if
 
@@ -496,12 +496,12 @@ contains
 
           ! If any attributes are from fields, we'll need to store old fields too
           store_old_fields = .false.
-          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/value_on_advection/python_fields") > 0) then
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/attribute_value/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/attribute_value/python_fields") > 0) then
             store_old_fields = .true.
           end if
 
@@ -564,8 +564,8 @@ contains
     single_count = option_count(key)
     array_count = option_count(array_key)
 
-    single_old_count = option_count(key//"/value_on_advection/python_fields/store_old_attribute")
-    array_old_count = option_count(trim(array_key)//"/value_on_advection/python_fields/store_old_attribute")
+    single_old_count = option_count(key//"/attribute_value/python_fields/store_old_attribute")
+    array_old_count = option_count(trim(array_key)//"/attribute_value/python_fields/store_old_attribute")
 
     allocate(names(single_count + array_count))
     allocate(old_names(single_old_count + array_old_count))
@@ -587,7 +587,7 @@ contains
 
       to_write(i) = .not. have_option(trim(subkey)//"/exclude_from_output")
 
-      if (have_option(trim(subkey)//"/value_on_advection/python_fields/store_old_attribute")) then
+      if (have_option(trim(subkey)//"/attribute_value/python_fields/store_old_attribute")) then
         ! prefix with "old%" to distinguish from current attribute
         old_names(old_i) = "old%" // trim(names(i))
         old_dims(old_i) = 0
@@ -603,7 +603,7 @@ contains
 
       to_write(i+single_count) = .not. have_option(trim(subkey)//"/exclude_from_output")
 
-      if (have_option(trim(subkey)//"/value_on_advection/python_fields/store_old_attribute")) then
+      if (have_option(trim(subkey)//"/attribute_value/python_fields/store_old_attribute")) then
         old_names(old_i) = "old%" // trim(names(i+single_count))
         old_dims(old_i) = dims(i+single_count)
         old_i = old_i + 1
@@ -1122,11 +1122,11 @@ contains
           ! single-valued attribute
           attr_key = trim(subgroup_path) // '/attributes/scalar_attribute['//int2str(i_single-1)//']'
           i_single = i_single + 1
-          if (have_option(trim(attr_key)//'/value_on_initialisation/constant')) then
-             call get_option(trim(attr_key)//'/value_on_initialisation/constant', constant)
+          if (have_option(trim(attr_key)//'/initial_attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/initial_attribute_value/constant', constant)
              attribute_array(attr_idx:attr_idx,:) = constant
-          else if (have_option(trim(attr_key)//'/value_on_advection/constant')) then
-             call get_option(trim(attr_key)//'/value_on_advection/constant', constant)
+          else if (have_option(trim(attr_key)//'/attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/attribute_value/constant', constant)
              attribute_array(attr_idx:attr_idx,:) = constant
           end if
           attr_idx = attr_idx + 1
@@ -1141,12 +1141,12 @@ contains
           ! single-valued attribute
           attr_key = trim(subgroup_path) // '/attributes/vector_attribute['//int2str(i_single-1)//']'
           i_single = i_single + 1
-          if (have_option(trim(attr_key)//'/value_on_initialisation/constant')) then
-             call get_option(trim(attr_key)//'/value_on_initialisation/constant', vconstant)
+          if (have_option(trim(attr_key)//'/initial_attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/initial_attribute_value/constant', vconstant)
              ! broadcast vector constant out to all particles
              attribute_array(attr_idx:attr_idx+dim-1,:) = spread(vconstant, 2, nparticles)
-          else if (have_option(trim(attr_key)//'/value_on_advection/constant')) then
-             call get_option(trim(attr_key)//'/value_on_advection/constant', vconstant)
+          else if (have_option(trim(attr_key)//'/attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/attribute_value/constant', vconstant)
              ! broadcast vector constant out to all particles
              attribute_array(attr_idx:attr_idx+dim-1,:) = spread(vconstant, 2, nparticles)
           end if
@@ -1162,12 +1162,12 @@ contains
           ! single-valued attribute
           attr_key = trim(subgroup_path) // '/attributes/tensor_attribute['//int2str(i_single-1)//']'
           i_single = i_single + 1
-          if (have_option(trim(attr_key)//'/value_on_initialisation/constant')) then
-             call get_option(trim(attr_key)//'/value_on_initialisation/constant', tconstant)
+          if (have_option(trim(attr_key)//'/initial_attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/initial_attribute_value/constant', tconstant)
              ! flatten tensor, then broadcast out to all particles
              attribute_array(attr_idx:attr_idx+dim**2-1,:) = spread(reshape(tconstant, [dim**2]), 2, nparticles)
-          else if (have_option(trim(attr_key)//'/value_on_advection/constant')) then
-             call get_option(trim(attr_key)//'/value_on_advection/constant', tconstant)
+          else if (have_option(trim(attr_key)//'/attribute_value/constant')) then
+             call get_option(trim(attr_key)//'/attribute_value/constant', tconstant)
              ! flatten tensor, then broadcast out to all particles
              attribute_array(attr_idx:attr_idx+dim**2-1,:) = spread(reshape(tconstant, [dim**2]), 2, nparticles)
           end if
@@ -1452,10 +1452,10 @@ contains
         is_array = .true.
       end if
 
-      if (initial .and. have_option(trim(attr_key)//'/value_on_initialisation')) then
-        value_attr_str = "/value_on_initialisation"
+      if (initial .and. have_option(trim(attr_key)//'/initial_attribute_value')) then
+        value_attr_str = "/initial_attribute_value"
       else
-        value_attr_str = "/value_on_advection"
+        value_attr_str = "/attribute_value"
       end if
 
       if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
@@ -1499,10 +1499,10 @@ contains
         is_array = .true.
       end if
 
-      if (initial .and. have_option(trim(attr_key)//'/value_on_initialisation')) then
-        value_attr_str = "/value_on_initialisation"
+      if (initial .and. have_option(trim(attr_key)//'/initial_attribute_value')) then
+        value_attr_str = "/initial_attribute_value"
       else
-        value_attr_str = "/value_on_advection"
+        value_attr_str = "/attribute_value"
       end if
 
       if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
@@ -1547,10 +1547,10 @@ contains
         is_array = .true.
       end if
 
-      if (initial .and. have_option(trim(attr_key)//'/value_on_initialisation')) then
-        value_attr_str = "/value_on_initialisation"
+      if (initial .and. have_option(trim(attr_key)//'/initial_attribute_value')) then
+        value_attr_str = "/initial_attribute_value"
       else
-        value_attr_str = "/value_on_advection"
+        value_attr_str = "/attribute_value"
       end if
 
       if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
@@ -1602,12 +1602,12 @@ contains
         n = p_list%attr_names%sn(i)
         if (n == 0) then
           store_old_attr(attr_idx) = have_option(trim(subgroup_path) // &
-               '/attributes/scalar_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/scalar_attribute['//int2str(i_single-1)//']/attribute_value/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + 1
         else
           store_old_attr(attr_idx:attr_idx+n-1) = have_option(trim(subgroup_path) // &
-               '/attributes/scalar_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/scalar_attribute_array['//int2str(i_array-1)//']/attribute_value/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n
         end if
@@ -1619,12 +1619,12 @@ contains
         n = p_list%attr_names%vn(i)
         if (n == 0) then
           store_old_attr(attr_idx:attr_idx+dim-1) = have_option(trim(subgroup_path) // &
-               '/attributes/vector_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/vector_attribute['//int2str(i_single-1)//']/attribute_value/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + dim
         else
           store_old_attr(attr_idx:attr_idx + n*dim-1) = have_option(trim(subgroup_path) // &
-               '/attributes/vector_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/vector_attribute_array['//int2str(i_array-1)//']/attribute_value/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n*dim
         end if
@@ -1636,12 +1636,12 @@ contains
         n = p_list%attr_names%tn(i)
         if (n == 0) then
           store_old_attr(attr_idx:attr_idx + dim**2 - 1) = have_option(trim(subgroup_path) // &
-               '/attributes/tensor_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/tensor_attribute['//int2str(i_single-1)//']/attribute_value/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + dim**2
         else
           store_old_attr(attr_idx:attr_idx + n*dim**2 - 1) = have_option(trim(subgroup_path) // &
-               '/attributes/tensor_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
+               '/attributes/tensor_attribute_array['//int2str(i_array-1)//']/attribute_value/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n*dim**2
         end if
@@ -2188,33 +2188,33 @@ contains
        FLAbort("Failed to set particles options filename when checkpointing particles with option path " // "/particles/particle_array::" // trim(temp_string))
     end if
 
-    ! do j = 1, tot_atts
-    !   particles_s = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/constant")
-    !   particles_v = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/constant")
-    !   particles_t = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/constant")
-    !   if (particles_s) then
-    !     call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/constant")
-    !     call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)// &
-    !          "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-    !       if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-    !          FLAbort("Failed to set scalar field particles filename when checkpointing")
-    !       end if
-    !    else if (particles_v) then
-    !       call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/constant")
-    !       call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)// &
-    !            "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-    !       if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-    !          FLAbort("Failed to set vector field particles filename when checkpointing")
-    !       end if
-    !    else if (particles_t) then
-    !       call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/constant")
-    !       call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)// &
-    !            "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
-    !       if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
-    !          FLAbort("Failed to set tensor field particles filename when checkpointing")
-    !       end if
-    !    end if
-    ! end do
+    do j = 1, tot_atts
+      particles_s = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/attribute_value/constant")
+      particles_v = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/attribute_value/constant")
+      particles_t = have_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/attribute_value/constant")
+      if (particles_s) then
+        call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)//"]/attribute_value/constant")
+        call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/scalar_attribute["//int2str(j-1)// &
+             "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
+          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
+             FLAbort("Failed to set scalar field particles filename when checkpointing")
+          end if
+       else if (particles_v) then
+          call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)//"]/attribute_value/constant")
+          call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/vector_attribute["//int2str(j-1)// &
+               "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
+          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
+             FLAbort("Failed to set vector field particles filename when checkpointing")
+          end if
+       else if (particles_t) then
+          call delete_option(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)//"]/attribute_value/constant")
+          call set_option_attribute(trim(subgroup_path_name) // trim(temp_string) // "/attributes/tensor_attribute["//int2str(j-1)// &
+               "]/from_checkpoint_file/file_name", trim(filename) // "." // trim(temp_string), stat)
+          if(stat /= SPUD_NO_ERROR .and. stat /= SPUD_NEW_KEY_WARNING .and. stat /= SPUD_ATTR_SET_FAILED_WARNING) then
+             FLAbort("Failed to set tensor field particles filename when checkpointing")
+          end if
+       end if
+    end do
 
   end subroutine update_particle_subgroup_options
 

--- a/femtools/Particles.F90
+++ b/femtools/Particles.F90
@@ -327,12 +327,12 @@ contains
 
           ! If any attributes are from fields, we'll need to store old fields too
           store_old_fields = .false.
-          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/python_fields") > 0 .or. &
-              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/python_fields") > 0) then
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/value_on_advection/python_fields") > 0) then
              store_old_fields = .true.
           end if
 
@@ -380,7 +380,7 @@ contains
             else
               call read_particles_from_python(subname, subgroup_path, &
                    particle_lists(list_counter), xfield, dim, &
-                   current_time, state, attr_counts, global, sub_particles)
+                   current_time, state, attr_counts, sub_particles, global=global)
             end if
           end if
 
@@ -389,8 +389,7 @@ contains
           if (do_output) then
             ! Only set up output if we need to (i.e. actually running,
             ! not flredecomping)
-            call set_particle_output_file(subname, filename, &
-                 particle_lists(list_counter))
+            call set_particle_output_file(subname, filename, particle_lists(list_counter))
           end if
 
           ! Get options for lagrangian particle movement
@@ -426,20 +425,25 @@ contains
   end subroutine initialise_particles
 
   !> Initialise particles for times greater than 0
-  subroutine initialise_particles_during_simulation(state, current_time)
+  subroutine initialise_particles_during_simulation(state, current_time, dt)
     !> Model state structure
     type(state_type), dimension(:), intent(in) :: state
     !> Current simulation time
     real, intent(in) :: current_time
+    !> Current model timestep
+    real, intent(in) :: dt
 
     integer :: i, k, j, dim, id_number
     integer :: particle_groups, particle_subgroups, list_counter, sub_particles
+    integer :: nb_part_created
+    integer, dimension(:), allocatable :: init_check
 
     type(vector_field), pointer :: xfield
     type(attr_counts_type) :: attr_counts
     type(attr_names_type) :: attr_names, old_attr_names
     type(attr_write_type) :: attr_write
-    integer, dimension(3) :: old_field_counts
+    type(detector_type), pointer :: first_newly_init_part
+    integer, dimension(3) :: field_counts, old_field_counts
 
     character(len=OPTION_PATH_LEN) :: group_path, subgroup_path
     character(len=FIELD_NAME_LEN) :: subname
@@ -448,7 +452,7 @@ contains
     character(len=*), dimension(3), parameter :: orders = ["scalar", "vector", "tensor"]
     character(len=*), dimension(3), parameter :: types = ["prescribed", "diagnostic", "prognostic"]
 
-    logical :: global, store_old_fields
+    logical :: store_old_fields
 
     ! Check whether there are any particles.
     particle_groups = option_count("/particles/particle_group")
@@ -474,51 +478,63 @@ contains
 
     !Check if initialise_during_simulation is enabled
     do i = 1, particle_groups
-       group_path = "/particles/particle_group["//int2str(i-1)//"]"
-       particle_subgroups = option_count(trim(group_path) // "/particle_subgroup")
-       do k = 1, particle_subgroups
-          subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(k-1)//"]"
-          if (have_option(trim(subgroup_path)//"/initialise_during_simulation")) then
-             ! Find number of attributes, old attributes, and names of each
-             call attr_names_and_count(trim(subgroup_path) // "/attributes/scalar_attribute", &
-               attr_names%s, old_attr_names%s, attr_names%sn, old_attr_names%sn, attr_write%s, &
-               attr_counts%attrs(1), attr_counts%old_attrs(1))
-             call attr_names_and_count(trim(subgroup_path) // "/attributes/vector_attribute", &
-               attr_names%v, old_attr_names%v, attr_names%vn, old_attr_names%vn, attr_write%v, &
-               attr_counts%attrs(2), attr_counts%old_attrs(2))
-             call attr_names_and_count(trim(subgroup_path) // "/attributes/tensor_attribute", &
-               attr_names%t, old_attr_names%t, attr_names%tn, old_attr_names%tn, attr_write%t, &
-               attr_counts%attrs(3), attr_counts%old_attrs(3))
+      group_path = "/particles/particle_group["//int2str(i-1)//"]"
+      particle_subgroups = option_count(trim(group_path) // "/particle_subgroup")
+      do k = 1, particle_subgroups
+        subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(k-1)//"]"
+        if (have_option(trim(subgroup_path)//"/initialise_during_simulation")) then
+          ! Find number of attributes, old attributes, and names of each
+          call attr_names_and_count(trim(subgroup_path) // "/attributes/scalar_attribute", &
+            attr_names%s, old_attr_names%s, attr_names%sn, old_attr_names%sn, attr_write%s, &
+            attr_counts%attrs(1), attr_counts%old_attrs(1))
+          call attr_names_and_count(trim(subgroup_path) // "/attributes/vector_attribute", &
+            attr_names%v, old_attr_names%v, attr_names%vn, old_attr_names%vn, attr_write%v, &
+            attr_counts%attrs(2), attr_counts%old_attrs(2))
+          call attr_names_and_count(trim(subgroup_path) // "/attributes/tensor_attribute", &
+            attr_names%t, old_attr_names%t, attr_names%tn, old_attr_names%tn, attr_write%t, &
+            attr_counts%attrs(3), attr_counts%old_attrs(3))
 
-             ! If any attributes are from fields, we'll need to store old fields too
-             store_old_fields = .false.
-             if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/python_fields") > 0 .or. &
-                  option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/python_fields") > 0 .or. &
-                  option_count(trim(subgroup_path) // "/attributes/vector_attribute/python_fields") > 0 .or. &
-                  option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/python_fields") > 0 .or. &
-                  option_count(trim(subgroup_path) // "/attributes/tensor_attribute/python_fields") > 0 .or. &
-                  option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/python_fields") > 0) then
-                store_old_fields = .true.
-             end if
-
-             if (store_old_fields) then
-                attr_counts%old_fields(:) = old_field_counts(:)
-             else
-                attr_counts%old_fields(:) = 0
-             end if
-
-             call get_option(trim(subgroup_path)//"/initialise_during_simulation/python", script)
-
-             id_number = particle_lists(list_counter)%proc_part_count
-             call get_option(trim(subgroup_path) // "/name", subname)
-             call read_particles_from_python(subname, subgroup_path, particle_lists(list_counter), xfield, dim, &
-                  current_time, state, attr_counts, global, sub_particles, id_number=id_number, script=script)
-
-             particle_lists(list_counter)%total_num_det = particle_lists(list_counter)%total_num_det + sub_particles
-
+          ! If any attributes are from fields, we'll need to store old fields too
+          store_old_fields = .false.
+          if (option_count(trim(subgroup_path) // "/attributes/scalar_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/scalar_attribute_array/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/vector_attribute_array/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute/value_on_advection/python_fields") > 0 .or. &
+              option_count(trim(subgroup_path) // "/attributes/tensor_attribute_array/value_on_advection/python_fields") > 0) then
+            store_old_fields = .true.
           end if
-          list_counter = list_counter + 1
-       end do
+
+          if (store_old_fields) then
+            attr_counts%old_fields(:) = old_field_counts(:)
+          else
+            attr_counts%old_fields(:) = 0
+          end if
+
+          call get_option(trim(subgroup_path)//"/initialise_during_simulation/python", script)
+
+          id_number = particle_lists(list_counter)%proc_part_count
+          call get_option(trim(subgroup_path) // "/name", subname)
+          first_newly_init_part => particle_lists(list_counter)%last
+          call read_particles_from_python(subname, subgroup_path, particle_lists(list_counter), xfield, dim, &
+            current_time, state, attr_counts, sub_particles, global=.true., &
+            id_number=id_number, script=script, nb_part_created=nb_part_created)
+
+          particle_lists(list_counter)%total_num_det = particle_lists(list_counter)%total_num_det + sub_particles
+
+          if (nb_part_created > 0) then
+            if (.not. associated(first_newly_init_part)) then
+              first_newly_init_part => particle_lists(list_counter)%first
+            else
+              first_newly_init_part => first_newly_init_part%next
+            end if
+            call update_particle_subgroup_attributes_and_fields( &
+              state, current_time, dt, subgroup_path, particle_lists(list_counter), &
+              initial=.true., first_newly_init_part=first_newly_init_part, nb_part_created=nb_part_created)
+          end if
+        end if
+        list_counter = list_counter + 1
+      end do
     end do
 
 
@@ -548,8 +564,8 @@ contains
     single_count = option_count(key)
     array_count = option_count(array_key)
 
-    single_old_count = option_count(key//"/python_fields/store_old_attribute")
-    array_old_count = option_count(trim(array_key)//"/python_fields/store_old_attribute")
+    single_old_count = option_count(key//"/value_on_advection/python_fields/store_old_attribute")
+    array_old_count = option_count(trim(array_key)//"/value_on_advection/python_fields/store_old_attribute")
 
     allocate(names(single_count + array_count))
     allocate(old_names(single_old_count + array_old_count))
@@ -571,7 +587,7 @@ contains
 
       to_write(i) = .not. have_option(trim(subkey)//"/exclude_from_output")
 
-      if (have_option(trim(subkey)//"/python_fields/store_old_attribute")) then
+      if (have_option(trim(subkey)//"/value_on_advection/python_fields/store_old_attribute")) then
         ! prefix with "old%" to distinguish from current attribute
         old_names(old_i) = "old%" // trim(names(i))
         old_dims(old_i) = 0
@@ -587,7 +603,7 @@ contains
 
       to_write(i+single_count) = .not. have_option(trim(subkey)//"/exclude_from_output")
 
-      if (have_option(trim(subkey)//"/python_fields/store_old_attribute")) then
+      if (have_option(trim(subkey)//"/value_on_advection/python_fields/store_old_attribute")) then
         old_names(old_i) = "old%" // trim(names(i+single_count))
         old_dims(old_i) = dims(i+single_count)
         old_i = old_i + 1
@@ -601,10 +617,8 @@ contains
 
   !> Initialise particles which are defined by a Python function
   subroutine read_particles_from_python(subgroup_name, subgroup_path, &
-       p_list, xfield, dim, &
-       current_time, state, &
-       attr_counts, global, &
-       n_particles, id_number, script)
+      p_list, xfield, dim, current_time, state, attr_counts, n_particles, &
+      global, id_number, script, nb_part_created)
 
     !> Name of the particles' subgroup
     character(len=FIELD_NAME_LEN), intent(in) :: subgroup_name
@@ -623,14 +637,16 @@ contains
     !> Counts of attributes, old attributes, and old fields
     !! for each scalar, vector and tensor
     type(attr_counts_type), intent(in) :: attr_counts
-    !> Whether to consider this particle in a global element search
-    logical, intent(in), optional :: global
     !> Number of particles being initialized
     integer, intent(out) :: n_particles
+    !> Whether to consider this particle in a global element search
+    logical, intent(in), optional :: global
     !> ID number of last particle currently in list
     integer, optional, intent(in) :: id_number
     !> Python script used by initialise_during_simulation
     character(len=PYTHON_FUNC_LEN), optional, intent(in) :: script
+    !> Number of particles created as part of initialise_during_simulation
+    integer, optional, intent(out) :: nb_part_created
 
     integer :: i, proc_num, stat, offset
     character(len=PYTHON_FUNC_LEN) :: func
@@ -646,9 +662,10 @@ contains
     ewrite(2,*) "Reading particles from options"
 
     if (present(script)) then
-       func=script
+      func=script
+      nb_part_created = 0
     else
-       call get_option(trim(subgroup_path)//"/initial_position/python", func)
+      call get_option(trim(subgroup_path)//"/initial_position/python", func)
     end if
     call get_option("/timestepping/timestep", dt)
 
@@ -662,8 +679,8 @@ contains
     offset = 0
     if (present(id_number)) offset = id_number
     do i = 1, n_particles
-       call create_single_particle(p_list, xfield, coords(:,i), &
-            i+offset, proc_num, dim, attr_counts, global=global)
+      call create_single_particle(p_list, xfield, coords(:,i), i+offset, proc_num, dim, attr_counts, &
+          global=global, nb_part_created=nb_part_created)
     end do
 
     deallocate(coords)
@@ -902,7 +919,7 @@ contains
   !> Allocate a single particle, populate and insert it into the given list
   !! In parallel, first check if the particle would be local and only allocate if it is
   subroutine create_single_particle(detector_list, xfield, position, id, proc_id, dim, &
-       attr_counts, attr_vals, old_attr_vals, old_field_vals, global)
+      attr_counts, attr_vals, old_attr_vals, old_field_vals, global, nb_part_created)
     !> The detector list to hold the particle
     type(detector_linked_list), intent(inout) :: detector_list
     !> Coordinate vector field
@@ -924,13 +941,15 @@ contains
     !! or for the local processor only (false).
     !! This affects the inquiry of the element owning the particle
     logical, intent(in), optional :: global
+    !> Number of particles created as part of initialise_during_simulation
+    integer, intent(inout), optional :: nb_part_created
 
     type(detector_type), pointer :: detector
     type(element_type), pointer :: shape
     real, dimension(xfield%dim+1) :: lcoords
     integer :: element
 
-    real ::  dt
+    real :: dt
     logical :: picker_global = .true.
 
     if (present(global)) picker_global = global
@@ -943,14 +962,14 @@ contains
     call get_option("/timestepping/timestep", dt)
     ! If we're in parallel and don't own the element, skip this particle
     if (isparallel()) then
-       if (element<0) return
-       if (.not.element_owned(xfield,element)) return
+      if (element<0) return
+      if (.not.element_owned(xfield,element)) return
     else
-       ! In serial make sure the particle is in the domain
-       ! unless we have the write_nan_outside override
-       if (element<0 .and. .not.detector_list%write_nan_outside) then
-          ewrite(-1,*) "Dealing with particle ", id, " proc_id:", proc_id
-          FLExit("Trying to initialise particle outside of computational domain")
+      ! In serial make sure the particle is in the domain
+      ! unless we have the write_nan_outside override
+      if (element<0 .and. .not.detector_list%write_nan_outside) then
+        ewrite(-1,*) "Dealing with particle ", id, " proc_id:", proc_id
+        FLExit("Trying to initialise particle outside of computational domain")
       end if
     end if
 
@@ -959,6 +978,10 @@ contains
     allocate(detector%position(xfield%dim))
     allocate(detector%local_coords(local_coord_count(shape)))
     call insert(detector, detector_list)
+
+    if (present(nb_part_created)) then
+      nb_part_created = nb_part_created + 1
+    end if
 
     ! Populate particle
     detector%position = position
@@ -1154,10 +1177,11 @@ contains
   end subroutine initialise_constant_particle_attributes
 
   !> Update attributes and fields for every subgroup of every particle group
-  subroutine update_particle_attributes_and_fields(state, time, dt)
+  subroutine update_particle_attributes_and_fields(state, time, dt, initial)
     type(state_type), dimension(:), intent(in) :: state
     real, intent(in) :: time
     real, intent(in) :: dt
+    logical, intent(in), optional :: initial
     character(len = OPTION_PATH_LEN) :: group_path, subgroup_path
 
     integer :: i, k
@@ -1172,19 +1196,20 @@ contains
     list_counter = 1
 
     do i = 1, particle_groups
-       group_path = "/particles/particle_group["//int2str(i-1)//"]"
-       particle_subgroups = option_count(trim(group_path) // "/particle_subgroup")
-       do k = 1, particle_subgroups
-         subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(k-1)//"]"
+      group_path = "/particles/particle_group["//int2str(i-1)//"]"
+      particle_subgroups = option_count(trim(group_path) // "/particle_subgroup")
+      do k = 1, particle_subgroups
+        subgroup_path = trim(group_path) // "/particle_subgroup["//int2str(k-1)//"]"
 
-         if (particle_lists(list_counter)%length==0) then
-           list_counter = list_counter + 1
-           cycle
-         end if
+        if (particle_lists(list_counter)%length==0) then
+          list_counter = list_counter + 1
+          cycle
+        end if
 
-         call update_particle_subgroup_attributes_and_fields(state, time, dt, subgroup_path, particle_lists(list_counter))
-         list_counter = list_counter + 1
-       end do
+        call update_particle_subgroup_attributes_and_fields( &
+          state, time, dt, subgroup_path, particle_lists(list_counter), initial=initial)
+        list_counter = list_counter + 1
+      end do
     end do
   end subroutine update_particle_attributes_and_fields
 
@@ -1276,7 +1301,9 @@ contains
   end subroutine copy_names_to_array
 
   !> Set particle attributes for a single subgroup
-  subroutine update_particle_subgroup_attributes_and_fields(state, time, dt, subgroup_path, p_list)
+  subroutine update_particle_subgroup_attributes_and_fields( &
+        state, time, dt, subgroup_path, p_list, &
+        initial, first_newly_init_part, nb_part_created)
     !> Model state structure
     type(state_type), dimension(:), intent(in) :: state
     !> Current model time
@@ -1287,6 +1314,12 @@ contains
     character(len=OPTION_PATH_LEN), intent(in) :: subgroup_path
     !> Subgroup particle list
     type(detector_linked_list), intent(in) :: p_list
+    !> Whether this is the first time attributes are having values filled
+    logical, intent(in), optional :: initial
+    !> Pointer to the first newly initialised particle
+    type(detector_type), pointer, optional :: first_newly_init_part
+    !> Number of particles to update
+    integer, intent(in), optional :: nb_part_created
 
     character(len=PYTHON_FUNC_LEN) :: func
     type(detector_type), pointer :: particle
@@ -1312,11 +1345,16 @@ contains
     integer :: nscalar, nvector, ntensor
     integer, dimension(3) :: old_attr_counts, field_counts, old_field_counts
     logical :: is_array
+    character(len=30) :: value_attr_str
 
-    nparticles = p_list%length
+    if (present(nb_part_created)) then
+      nparticles = nb_part_created
+    else
+      nparticles = p_list%length
+    end if
     ! return if no particles
     if (nparticles == 0) then
-       return
+      return
     end if
 
     ! get attribute sizes from the detector list
@@ -1326,7 +1364,7 @@ contains
 
     ! return if no attributes
     if (nscalar+nvector+ntensor== 0) then
-       return
+      return
     end if
 
     ! store all the old attribute names in a contiguous list
@@ -1341,7 +1379,12 @@ contains
     allocate(tconstant(dim, dim))
 
     ! allocate space to hold data for all particles in the group
-    particle => p_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => p_list%first
+    end if
+
     allocate(positions(size(particle%position), nparticles))
     allocate(attribute_array(size(particle%attributes), nparticles))
     allocate(lcoords(size(particle%local_coords), nparticles))
@@ -1350,13 +1393,13 @@ contains
 
     ! copy the data
     do i = 1, nparticles
-       positions(:,i) = particle%position
-       lcoords(:,i) = particle%local_coords
-       ele(i) = particle%element
-       ! copy current attributes in case we loaded from file
-       attribute_array(:,i) = particle%attributes
-       old_attributes(:,i) = particle%old_attributes
-       particle => particle%next
+      positions(:,i) = particle%position
+      lcoords(:,i) = particle%local_coords
+      ele(i) = particle%element
+      ! copy current attributes in case we loaded from file
+      attribute_array(:,i) = particle%attributes
+      old_attributes(:,i) = particle%old_attributes
+      particle => particle%next
     end do
 
     attr_idx = 1
@@ -1380,26 +1423,31 @@ contains
         is_array = .true.
       end if
 
-      if (have_option(trim(attr_key)//'/constant')) then
-        call get_option(trim(attr_key)//'/constant', constant)
-        attribute_array(attr_idx:attr_idx+n-1,:) = constant
+      if (present(initial)) then
+        if (initial .and. have_option(trim(attr_key)//'/value_on_spawn')) then
+          value_attr_str = "/value_on_spawn"
+        end if
+      else
+        value_attr_str = "/value_on_advection"
+      end if
 
-      else if (have_option(trim(attr_key)//'/python')) then
-        call get_option(trim(attr_key)//'/python', func)
+      if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/constant', constant)
+        attribute_array(attr_idx:attr_idx+n-1,:) = constant
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python', func)
         call set_particle_scalar_attribute_from_python( &
              attribute_array(attr_idx:attr_idx+n-1,:), &
              positions(:,:), n, func, time, dt, is_array)
-
-      else if (have_option(trim(attr_key)//'/python_fields')) then
-        call get_option(trim(attr_key)//'/python_fields', func)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python_fields')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python_fields', func)
         call set_particle_scalar_attribute_from_python_fields( &
              p_list, state, positions(:,:), lcoords(:,:), ele(:), n, &
              attribute_array(attr_idx:attr_idx+n-1,:), &
              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
              field_names, field_counts, old_field_names, old_field_counts, &
-             func, time, dt, is_array)
-
-      else if (have_option(trim(attr_key)//'/from_checkpoint_file')) then
+             func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
         ! don't do anything, the attribute was already loaded from file
       end if
 
@@ -1424,27 +1472,24 @@ contains
         is_array = .true.
       end if
 
-      if (have_option(trim(attr_key)//'/constant')) then
-        call get_option(trim(attr_key)//'/constant', vconstant)
+      if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/constant', vconstant)
         ! broadcast vector constant out to all particles
         attribute_array(attr_idx:attr_idx+n*dim-1,:) = spread(vconstant, 2, nparticles)
-
-      else if (have_option(trim(attr_key)//'/python')) then
-        call get_option(trim(attr_key)//'/python', func)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python', func)
         call set_particle_vector_attribute_from_python( &
              attribute_array(attr_idx:attr_idx+n*dim-1,:), &
              positions(:,:), n, func, time, dt, is_array)
-
-      else if (have_option(trim(attr_key)//'/python_fields')) then
-        call get_option(trim(attr_key)//'/python_fields', func)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python_fields')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python_fields', func)
         call set_particle_vector_attribute_from_python_fields( &
              p_list, state, positions(:,:), lcoords(:,:), ele(:), n, &
              attribute_array(attr_idx:attr_idx+n*dim-1,:), &
              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
              field_names, field_counts, old_field_names, old_field_counts, &
-             func, time, dt, is_array)
-
-      else if (have_option(trim(attr_key)//'/from_checkpoint_file')) then
+             func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
         ! don't do anything, the attribute was already loaded from file
       end if
 
@@ -1469,35 +1514,37 @@ contains
         is_array = .true.
       end if
 
-      if (have_option(trim(attr_key)//'/constant')) then
-        call get_option(trim(attr_key)//'/constant', tconstant)
+      if (have_option(trim(attr_key)//trim(value_attr_str)//'/constant')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/constant', tconstant)
         ! flatten tensor, then broadcast out to all particles
         attribute_array(attr_idx:attr_idx+n*dim**2-1,:) = spread(reshape(tconstant, [dim**2]), 2, nparticles)
-
-       else if (have_option(trim(attr_key)//'/python')) then
-         call get_option(trim(attr_key)//'/python', func)
-         call set_particle_tensor_attribute_from_python( &
-              attribute_array(attr_idx:attr_idx + n*dim**2 - 1,:), &
-              positions(:,:), n, func, time, dt, is_array)
-
-       else if (have_option(trim(attr_key)//'/python_fields')) then
-         call get_option(trim(attr_key)//'/python_fields', func)
-         call set_particle_tensor_attribute_from_python_fields( &
-              p_list, state, positions(:,:), lcoords(:,:), ele(:), n, &
-              attribute_array(attr_idx:attr_idx + n*dim**2 - 1,:), &
-              old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
-              field_names, field_counts, old_field_names, old_field_counts, &
-              func, time, dt, is_array)
-
-       else if (have_option(trim(attr_key)//'/from_checkpoint_file')) then
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python', func)
+        call set_particle_tensor_attribute_from_python( &
+             attribute_array(attr_idx:attr_idx + n*dim**2 - 1,:), &
+             positions(:,:), n, func, time, dt, is_array)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/python_fields')) then
+        call get_option(trim(attr_key)//trim(value_attr_str)//'/python_fields', func)
+        call set_particle_tensor_attribute_from_python_fields( &
+             p_list, state, positions(:,:), lcoords(:,:), ele(:), n, &
+             attribute_array(attr_idx:attr_idx + n*dim**2 - 1,:), &
+             old_attr_names, old_attr_counts, old_attr_dims, old_attributes, &
+             field_names, field_counts, old_field_names, old_field_counts, &
+             func, time, dt, is_array, first_newly_init_part=first_newly_init_part)
+      else if (have_option(trim(attr_key)//trim(value_attr_str)//'/from_checkpoint_file')) then
         ! don't do anything, the attribute was already loaded from file
-       end if
+      end if
 
-       attr_idx = attr_idx + n*dim**2
-     end do
+      attr_idx = attr_idx + n*dim**2
+    end do
 
     ! Set attribute values and old_attribute values
-    particle => p_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => p_list%first
+    end if
+
     if (size(particle%old_attributes) == 0) then
       ! no old attributes to store; only store current attributes
       do j = 1, nparticles
@@ -1516,12 +1563,12 @@ contains
         n = p_list%attr_names%sn(i)
         if (n == 0) then
           store_old_attr(attr_idx) = have_option(trim(subgroup_path) // &
-               '/attributes/scalar_attribute['//int2str(i_single-1)//']/python_fields/store_old_attribute')
+               '/attributes/scalar_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + 1
         else
           store_old_attr(attr_idx:attr_idx+n-1) = have_option(trim(subgroup_path) // &
-               '/attributes/scalar_attribute_array['//int2str(i_array-1)//']/python_fields/store_old_attribute')
+               '/attributes/scalar_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n
         end if
@@ -1533,12 +1580,12 @@ contains
         n = p_list%attr_names%vn(i)
         if (n == 0) then
           store_old_attr(attr_idx:attr_idx+dim-1) = have_option(trim(subgroup_path) // &
-               '/attributes/vector_attribute['//int2str(i_single-1)//']/python_fields/store_old_attribute')
+               '/attributes/vector_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + dim
         else
           store_old_attr(attr_idx:attr_idx + n*dim-1) = have_option(trim(subgroup_path) // &
-               '/attributes/vector_attribute_array['//int2str(i_array-1)//']/python_fields/store_old_attribute')
+               '/attributes/vector_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n*dim
         end if
@@ -1550,12 +1597,12 @@ contains
         n = p_list%attr_names%tn(i)
         if (n == 0) then
           store_old_attr(attr_idx:attr_idx + dim**2 - 1) = have_option(trim(subgroup_path) // &
-               '/attributes/tensor_attribute['//int2str(i_single-1)//']/python_fields/store_old_attribute')
+               '/attributes/tensor_attribute['//int2str(i_single-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_single = i_single + 1
           attr_idx = attr_idx + dim**2
         else
           store_old_attr(attr_idx:attr_idx + n*dim**2 - 1) = have_option(trim(subgroup_path) // &
-               '/attributes/tensor_attribute_array['//int2str(i_array-1)//']/python_fields/store_old_attribute')
+               '/attributes/tensor_attribute_array['//int2str(i_array-1)//']/value_on_advection/python_fields/store_old_attribute')
           i_array = i_array + 1
           attr_idx = attr_idx + n*dim**2
         end if
@@ -1580,7 +1627,8 @@ contains
     end if
 
     ! update old field values on the particles
-    call update_particle_subgroup_fields(state, ele, lcoords, p_list, old_field_counts)
+    call update_particle_subgroup_fields(state, ele, lcoords, p_list, old_field_counts, &
+      first_newly_init_part=first_newly_init_part, nparticles=nparticles)
 
     deallocate(positions)
     deallocate(lcoords)
@@ -1594,7 +1642,8 @@ contains
   end subroutine update_particle_subgroup_attributes_and_fields
 
   !> Update old values of fields stored on particles
-  subroutine update_particle_subgroup_fields(state, ele, lcoords, p_list, counts)
+  subroutine update_particle_subgroup_fields( &
+      state, ele, lcoords, p_list, counts, first_newly_init_part, nparticles)
     !! Model state structure
     type(state_type), dimension(:), intent(in) :: state
     !! Elements containing particles
@@ -1605,13 +1654,22 @@ contains
     type(detector_linked_list), intent(in) :: p_list
     !! Number of scalar/vector/tensor old fields
     integer, dimension(3), intent(in) :: counts
+    !> Pointer to the first newly initialised particle
+    type(detector_type), pointer, optional :: first_newly_init_part
+    !> Number of particles to update
+    integer, intent(in), optional :: nparticles
 
     integer :: i, dim, nparts
     real, allocatable, dimension(:,:) :: vals
     type(detector_type), pointer :: particle
 
     call get_option("/geometry/dimension", dim)
-    nparts = p_list%length
+
+    if (present(nparticles)) then
+      nparts = nparticles
+    else
+      nparts = p_list%length
+    end if
 
     allocate(vals(counts(1) + dim*counts(2) + dim**2*counts(3), nparts))
 
@@ -1619,7 +1677,11 @@ contains
          p_list%old_field_names, p_list%old_field_phases, counts, vals, dim)
 
     ! assign back to particles
-    particle => p_list%first
+    if (present(first_newly_init_part)) then
+      particle => first_newly_init_part
+    else
+      particle => p_list%first
+    end if
     do i = 1, nparts
       particle%old_fields = vals(:,i)
       particle => particle%next

--- a/femtools/Pickers_Inquire.F90
+++ b/femtools/Pickers_Inquire.F90
@@ -29,355 +29,351 @@
 
 module pickers_inquire
 
-  use fldebug
-  use data_structures
-  use element_numbering, only: FAMILY_SIMPLEX
-  use parallel_tools
-  use detector_data_types
-  use picker_data_types
-  use pickers_base
-  use transform_elements
-  use fields
-  use node_owner_finder
-  use pickers_allocates
+   use fldebug
+   use data_structures
+   use element_numbering, only: FAMILY_SIMPLEX
+   use parallel_tools
+   use detector_data_types
+   use picker_data_types
+   use pickers_base
+   use transform_elements
+   use fields
+   use node_owner_finder
+   use pickers_allocates
 
-  implicit none
+   implicit none
 
-  interface picker_inquire
-    module procedure picker_inquire_single_position, &
+   interface picker_inquire
+      module procedure picker_inquire_single_position, &
       & picker_inquire_single_position_xyz, picker_inquire_multiple_positions, &
       & picker_inquire_single_position_tolerance, &
       & picker_inquire_multiple_positions_tolerance, &
       & picker_inquire_multiple_positions_xyz, picker_inquire_node, &
       & picker_inquire_nodes, picker_inquire_node_tolerance, &
       & picker_inquire_nodes_tolerance
-  end interface picker_inquire
+   end interface picker_inquire
 
-  real, parameter, public :: max_picker_ownership_tolerance = rtree_tolerance
+   real, parameter, public :: max_picker_ownership_tolerance = rtree_tolerance
 
-  public :: picker_inquire, search_for_detectors
+   public :: picker_inquire, search_for_detectors
 
-  private
+   private
 
 contains
 
-  subroutine picker_inquire_single_position_xyz(positions, coordx, coordy, coordz, ele, local_coord, global)
-    !!< Find the owning elements in positions of the supplied coordinate
+   subroutine picker_inquire_single_position_xyz(positions, coordx, coordy, coordz, ele, local_coord, global)
+      !!< Find the owning elements in positions of the supplied coordinate
 
-    type(vector_field), intent(inout) :: positions
-    real, intent(in) :: coordx
-    real, optional, intent(in) :: coordy
-    real, optional, intent(in) :: coordz
-    integer, intent(out) :: ele
-    !! The local coordinates of the coordinate in the owning element
-    real, dimension(positions%dim+1), optional, intent(out) :: local_coord
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+      type(vector_field), intent(inout) :: positions
+      real, intent(in) :: coordx
+      real, optional, intent(in) :: coordy
+      real, optional, intent(in) :: coordz
+      integer, intent(out) :: ele
+      !! The local coordinates of the coordinate in the owning element
+      real, dimension(positions%dim+1), optional, intent(out) :: local_coord
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
 
-    real, dimension(:), allocatable :: coord
+      real, dimension(:), allocatable :: coord
 
-    if(present(coordy)) then
-      if(present(coordz)) then
-        allocate(coord(3))
-        coord = (/coordx, coordy, coordz/)
+      if(present(coordy)) then
+         if(present(coordz)) then
+            allocate(coord(3))
+            coord = (/coordx, coordy, coordz/)
+         else
+            allocate(coord(2))
+            coord = (/coordx, coordy/)
+         end if
       else
-        allocate(coord(2))
-        coord = (/coordx, coordy/)
+         assert(.not. present(coordz))
+         allocate(coord(1))
+         coord = (/coordx/)
       end if
-    else
-      assert(.not. present(coordz))
-      allocate(coord(1))
-      coord = (/coordx/)
-    end if
 
-<<<<<<< HEAD
-    call picker_inquire(positions, coord, ele, local_coord = local_coord, global = global)
-=======
-    call picker_inquire(positions, coord, ele, local_coord = local_coord, global=global)
->>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
+      call picker_inquire(positions, coord, ele, local_coord = local_coord, global = global)
 
-    deallocate(coord)
+      deallocate(coord)
 
-  end subroutine picker_inquire_single_position_xyz
+   end subroutine picker_inquire_single_position_xyz
 
-  subroutine picker_inquire_single_position(positions, coord, ele, local_coord, global)
-    !!< Find the owning elements in positions of the supplied coordinate
+   subroutine picker_inquire_single_position(positions, coord, ele, local_coord, global)
+      !!< Find the owning elements in positions of the supplied coordinate
 
-    type(vector_field), intent(inout) :: positions
-    real, dimension(positions%dim), intent(in) :: coord
-    integer, intent(out) :: ele
-    !! The local coordinates of the coordinate in the owning element
-    real, dimension(positions%dim+1), optional, intent(out) :: local_coord
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+      type(vector_field), intent(inout) :: positions
+      real, dimension(positions%dim), intent(in) :: coord
+      integer, intent(out) :: ele
+      !! The local coordinates of the coordinate in the owning element
+      real, dimension(positions%dim+1), optional, intent(out) :: local_coord
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
 
-    call initialise_picker(positions)
+      call initialise_picker(positions)
 
-    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, global = global)
-    if(present(local_coord)) then
-      if(ele > 0) then
-        local_coord = local_coords(positions, ele, coord)
+      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, global=global)
+      if(present(local_coord)) then
+         if(ele > 0) then
+            local_coord = local_coords(positions, ele, coord)
+         else
+            ! If we don't own this node then we really shouldn't be using any local
+            ! coord information
+            local_coord = huge(0.0)
+         end if
+      end if
+
+   end subroutine picker_inquire_single_position
+
+   subroutine picker_inquire_multiple_positions_xyz(positions, coordsx, coordsy, coordsz, eles, local_coords, global)
+      !!< Find the owning elements in positions of the supplied coordinates
+
+      type(vector_field), intent(inout) :: positions
+      real, dimension(:), intent(in) :: coordsx
+      real, dimension(size(coordsx)), optional, intent(in) :: coordsy
+      real, dimension(size(coordsx)), optional, intent(in) :: coordsz
+      integer, dimension(size(coordsx)), intent(out) :: eles
+      !! The local coordinates of the coordinates in the owning elements
+      real, dimension(positions%dim+1, size(coordsx)), optional, intent(out) :: local_coords
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
+
+      real, dimension(:, :), allocatable :: coords
+
+      if(present(coordsy)) then
+         if(present(coordsz)) then
+            allocate(coords(3, size(coordsx)))
+            coords(1, :) = coordsx
+            coords(2, :) = coordsy
+            coords(3, :) = coordsz
+         else
+            allocate(coords(2, size(coordsx)))
+            coords(1, :) = coordsx
+            coords(2, :) = coordsy
+         end if
       else
-        ! If we don't own this node then we really shouldn't be using any local
-        ! coord information
-        local_coord = huge(0.0)
+         assert(.not. present(coordsz))
+         allocate(coords(1, size(coordsx)))
+         coords(1, :) = coordsx
       end if
-    end if
 
-  end subroutine picker_inquire_single_position
+      call picker_inquire(positions, coords, eles, local_coords = local_coords, global=global)
 
-  subroutine picker_inquire_multiple_positions_xyz(positions, coordsx, coordsy, coordsz, eles, local_coords, global)
-    !!< Find the owning elements in positions of the supplied coordinates
+      deallocate(coords)
 
-    type(vector_field), intent(inout) :: positions
-    real, dimension(:), intent(in) :: coordsx
-    real, dimension(size(coordsx)), optional, intent(in) :: coordsy
-    real, dimension(size(coordsx)), optional, intent(in) :: coordsz
-    integer, dimension(size(coordsx)), intent(out) :: eles
-    !! The local coordinates of the coordinates in the owning elements
-    real, dimension(positions%dim+1, size(coordsx)), optional, intent(out) :: local_coords
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+   end subroutine picker_inquire_multiple_positions_xyz
 
-    real, dimension(:, :), allocatable :: coords
+   subroutine picker_inquire_multiple_positions(positions, coords, eles, local_coords, global)
+      !!< Find the owning elements in positions of the supplied coordinates
 
-    if(present(coordsy)) then
-      if(present(coordsz)) then
-        allocate(coords(3, size(coordsx)))
-        coords(1, :) = coordsx
-        coords(2, :) = coordsy
-        coords(3, :) = coordsz
+      type(vector_field), intent(inout) :: positions
+      real, dimension(:, :), intent(in) :: coords
+      integer, dimension(size(coords, 2)), intent(out) :: eles
+      !! The local coordinates of the coordinates in the owning elements
+      real, dimension(positions%dim+1, size(coords, 2)), optional, intent(out) :: local_coords
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
+
+      integer :: i
+
+      assert(size(coords, 1) == positions%dim)
+
+      call initialise_picker(positions)
+
+      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, global = global)
+      if(present(local_coords)) then
+         do i = 1, size(coords, 2)
+            if(eles(i) > 0) then
+               local_coords(:, i) = local_coords_interpolation(positions, eles(i), coords(:, i))
+            else
+               ! If we don't own this node then we really shouldn't be using any
+               ! local coord information
+               local_coords(:, i) = huge(0.0)
+            end if
+         end do
+      end if
+
+   end subroutine picker_inquire_multiple_positions
+
+   subroutine picker_inquire_single_position_tolerance(positions, coord, ele, ownership_tolerance)
+      !!< Find the owning elements in positions of the supplied coordinate
+      !!< using an ownership tolerance. This performs a strictly local (this
+      !!< process) ownership test.
+
+      type(vector_field), intent(inout) :: positions
+      real, dimension(positions%dim), intent(in) :: coord
+      type(integer_set), intent(out) :: ele
+      real, intent(in) :: ownership_tolerance
+
+      call initialise_picker(positions)
+      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, ownership_tolerance = ownership_tolerance)
+
+   end subroutine picker_inquire_single_position_tolerance
+
+   subroutine picker_inquire_multiple_positions_tolerance(positions, coords, eles, ownership_tolerance)
+      !!< Find the owning elements in positions of the supplied coordinates
+      !!< using an ownership tolerance. This performs a strictly local (this
+      !!< process) ownership test.
+
+      type(vector_field), intent(inout) :: positions
+      real, dimension(:, :), intent(in) :: coords
+      type(integer_set), dimension(size(coords, 2)), intent(out) :: eles
+      real, intent(in) :: ownership_tolerance
+
+      assert(size(coords, 1) == positions%dim)
+
+      call initialise_picker(positions)
+      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, ownership_tolerance = ownership_tolerance)
+
+   end subroutine picker_inquire_multiple_positions_tolerance
+
+   subroutine picker_inquire_node(positions_a, positions_b, ele_a, node_b, local_coord, global)
+      !!< Find the owning element in positions_a of a node in positions_b
+
+      type(vector_field), intent(inout) :: positions_a
+      type(vector_field), intent(in) :: positions_b
+      integer, intent(out) :: ele_a
+      integer, intent(in) :: node_b
+      !! The local coordinates of the node in the owning element
+      real, dimension(positions_a%dim+1), optional, intent(out) :: local_coord
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
+
+      assert(positions_a%dim == positions_b%dim)
+
+      if(present(local_coord)) then
+         call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global = global)
       else
-        allocate(coords(2, size(coordsx)))
-        coords(1, :) = coordsx
-        coords(2, :) = coordsy
+         call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global = global)
       end if
-    else
-      assert(.not. present(coordsz))
-      allocate(coords(1, size(coordsx)))
-      coords(1, :) = coordsx
-    end if
 
-    call picker_inquire(positions, coords, eles, local_coords = local_coords, global = global)
+   end subroutine picker_inquire_node
 
-    deallocate(coords)
+   subroutine picker_inquire_nodes(positions_a, positions_b, ele_as, local_coords, global)
+      !!< Find the owning elements in positions_a of the nodes in positions_b
 
-  end subroutine picker_inquire_multiple_positions_xyz
+      type(vector_field), intent(inout) :: positions_a
+      type(vector_field), intent(in) :: positions_b
+      integer, dimension(node_count(positions_b)), intent(out) :: ele_as
+      !! The local coordinates of the nodes in the owning elements
+      real, dimension(positions_a%dim+1, node_count(positions_b)), optional, intent(out) :: local_coords
+      !! If present and .false., do not perform a global inquiry across all
+      !! processes
+      logical, optional, intent(in) :: global
 
-  subroutine picker_inquire_multiple_positions(positions, coords, eles, local_coords, global)
-    !!< Find the owning elements in positions of the supplied coordinates
+      integer :: i
+      real, dimension(:, :), allocatable :: lpositions
 
-    type(vector_field), intent(inout) :: positions
-    real, dimension(:, :), intent(in) :: coords
-    integer, dimension(size(coords, 2)), intent(out) :: eles
-    !! The local coordinates of the coordinates in the owning elements
-    real, dimension(positions%dim+1, size(coords, 2)), optional, intent(out) :: local_coords
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+      assert(positions_a%dim == positions_b%dim)
 
-    integer :: i
-
-    assert(size(coords, 1) == positions%dim)
-
-    call initialise_picker(positions)
-
-    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, global = global)
-    if(present(local_coords)) then
-      do i = 1, size(coords, 2)
-        if(eles(i) > 0) then
-          local_coords(:, i) = local_coords_interpolation(positions, eles(i), coords(:, i))
-        else
-          ! If we don't own this node then we really shouldn't be using any
-          ! local coord information
-          local_coords(:, i) = huge(0.0)
-        end if
+      allocate(lpositions(positions_b%dim, node_count(positions_b)))
+      do i = 1, node_count(positions_b)
+         lpositions(:, i) = node_val(positions_b, i)
       end do
-    end if
 
-  end subroutine picker_inquire_multiple_positions
+      if(present(local_coords)) then
+         call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global = global)
+      else
+         call picker_inquire(positions_a, lpositions, ele_as, global = global)
+      end if
 
-  subroutine picker_inquire_single_position_tolerance(positions, coord, ele, ownership_tolerance)
-    !!< Find the owning elements in positions of the supplied coordinate
-    !!< using an ownership tolerance. This performs a strictly local (this
-    !!< process) ownership test.
+      deallocate(lpositions)
 
-    type(vector_field), intent(inout) :: positions
-    real, dimension(positions%dim), intent(in) :: coord
-    type(integer_set), intent(out) :: ele
-    real, intent(in) :: ownership_tolerance
+   end subroutine picker_inquire_nodes
 
-    call initialise_picker(positions)
-    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, ownership_tolerance = ownership_tolerance)
+   subroutine picker_inquire_node_tolerance(positions_a, positions_b, ele_a, node_b, ownership_tolerance)
+      !!< Find the owning element in positions_a of a node in positions_b
+      !!< using an ownership tolerance. This performs a strictly local (this
+      !!< process) ownership test.
 
-  end subroutine picker_inquire_single_position_tolerance
+      type(vector_field), intent(inout) :: positions_a
+      type(vector_field), intent(in) :: positions_b
+      type(integer_set), intent(out) :: ele_a
+      integer, intent(in) :: node_b
+      real, intent(in) :: ownership_tolerance
 
-  subroutine picker_inquire_multiple_positions_tolerance(positions, coords, eles, ownership_tolerance)
-    !!< Find the owning elements in positions of the supplied coordinates
-    !!< using an ownership tolerance. This performs a strictly local (this
-    !!< process) ownership test.
+      assert(positions_a%dim == positions_b%dim)
 
-    type(vector_field), intent(inout) :: positions
-    real, dimension(:, :), intent(in) :: coords
-    type(integer_set), dimension(size(coords, 2)), intent(out) :: eles
-    real, intent(in) :: ownership_tolerance
+      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, ownership_tolerance = ownership_tolerance)
 
-    assert(size(coords, 1) == positions%dim)
+   end subroutine picker_inquire_node_tolerance
 
-    call initialise_picker(positions)
-    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, ownership_tolerance = ownership_tolerance)
+   subroutine picker_inquire_nodes_tolerance(positions_a, positions_b, ele_as, ownership_tolerance)
+      !!< Find the owning elements in positions_a of the nodes in positions_b
+      !!< using an ownership tolerance. This performs a strictly local (this
+      !!< process) ownership test.
 
-  end subroutine picker_inquire_multiple_positions_tolerance
+      type(vector_field), intent(inout) :: positions_a
+      type(vector_field), intent(in) :: positions_b
+      type(integer_set), dimension(node_count(positions_b)), intent(out) :: ele_as
+      real, intent(in) :: ownership_tolerance
 
-  subroutine picker_inquire_node(positions_a, positions_b, ele_a, node_b, local_coord, global)
-    !!< Find the owning element in positions_a of a node in positions_b
+      integer :: i
+      real, dimension(:, :), allocatable :: lpositions
 
-    type(vector_field), intent(inout) :: positions_a
-    type(vector_field), intent(in) :: positions_b
-    integer, intent(out) :: ele_a
-    integer, intent(in) :: node_b
-    !! The local coordinates of the node in the owning element
-    real, dimension(positions_a%dim+1), optional, intent(out) :: local_coord
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+      assert(positions_a%dim == positions_b%dim)
 
-    assert(positions_a%dim == positions_b%dim)
+      allocate(lpositions(positions_b%dim, node_count(positions_b)))
+      do i = 1, node_count(positions_b)
+         lpositions(:, i) = node_val(positions_b, i)
+      end do
 
-    if(present(local_coord)) then
-      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global=global)
-    else
-      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global=global)
-    end if
+      call picker_inquire(positions_a, lpositions, ele_as, ownership_tolerance = ownership_tolerance)
 
-  end subroutine picker_inquire_node
+      deallocate(lpositions)
 
-  subroutine picker_inquire_nodes(positions_a, positions_b, ele_as, local_coords, global)
-    !!< Find the owning elements in positions_a of the nodes in positions_b
+   end subroutine picker_inquire_nodes_tolerance
 
-    type(vector_field), intent(inout) :: positions_a
-    type(vector_field), intent(in) :: positions_b
-    integer, dimension(node_count(positions_b)), intent(out) :: ele_as
-    !! The local coordinates of the nodes in the owning elements
-    real, dimension(positions_a%dim+1, node_count(positions_b)), optional, intent(out) :: local_coords
-    !! If present and .false., do not perform a global inquiry across all
-    !! processes
-    logical, optional, intent(in) :: global
+   subroutine search_for_detectors(detectors, positions)
+      !!< This subroutine establishes on which processor, in which element and at
+      !!< which local coordinates each detector is to be found. A negative element
+      !!< value indicates that no element could be found for that node.
+      !!< Detectors are assumed to be local.
 
-    integer :: i
-    real, dimension(:, :), allocatable :: lpositions
+      !!< NOTE: This routine does not check whether all detectors have been found. "Lost" detectors
+      !!< are marked with a %element = -1. Therefore this routine should be followed by a call to
+      !!< distribute_detectors() to globally search for these, or if we know that this shouldn't occur
+      !!< a test that indeed all detectors have been found.
 
-    assert(positions_a%dim == positions_b%dim)
+      type(vector_field), intent(inout) :: positions
+      type(detector_linked_list), intent(inout) :: detectors
+      type(detector_type), pointer :: node
 
-    allocate(lpositions(positions_b%dim, node_count(positions_b)))
-    do i = 1, node_count(positions_b)
-      lpositions(:, i) = node_val(positions_b, i)
-    end do
+      integer :: i
+      real, dimension(:, :), allocatable :: coords, l_coords
+      integer, dimension(:), allocatable :: ele
 
-    if(present(local_coords)) then
-      call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global=global)
-    else
-      call picker_inquire(positions_a, lpositions, ele_as, global=global)
-    end if
+      call initialise_picker(positions)
+      assert(ele_numbering_family(positions, 1) == FAMILY_SIMPLEX)
 
-    deallocate(lpositions)
+      allocate(coords(positions%dim, detectors%length))
+      allocate(l_coords(positions%dim+1, detectors%length))
+      allocate(ele(detectors%length))
 
-  end subroutine picker_inquire_nodes
+      node => detectors%first
+      do i = 1, detectors%length
+         coords(:, i) = node%position
+         node => node%next
+      end do
 
-  subroutine picker_inquire_node_tolerance(positions_a, positions_b, ele_a, node_b, ownership_tolerance)
-    !!< Find the owning element in positions_a of a node in positions_b
-    !!< using an ownership tolerance. This performs a strictly local (this
-    !!< process) ownership test.
+      ! First check locally
+      if (detectors%length > 0) then
+         call picker_inquire(positions, coords(:,:), ele(:), local_coords = l_coords(:,:), global = .false.)
+      end if
 
-    type(vector_field), intent(inout) :: positions_a
-    type(vector_field), intent(in) :: positions_b
-    type(integer_set), intent(out) :: ele_a
-    integer, intent(in) :: node_b
-    real, intent(in) :: ownership_tolerance
+      node => detectors%first
+      do i = 1, detectors%length
+         node%local_coords = l_coords(:, i)
+         node%element = ele(i)
+         node => node%next
+      end do
 
-    assert(positions_a%dim == positions_b%dim)
+      deallocate(coords)
+      deallocate(l_coords)
+      deallocate(ele)
 
-    call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, ownership_tolerance = ownership_tolerance)
-
-  end subroutine picker_inquire_node_tolerance
-
-  subroutine picker_inquire_nodes_tolerance(positions_a, positions_b, ele_as, ownership_tolerance)
-    !!< Find the owning elements in positions_a of the nodes in positions_b
-    !!< using an ownership tolerance. This performs a strictly local (this
-    !!< process) ownership test.
-
-    type(vector_field), intent(inout) :: positions_a
-    type(vector_field), intent(in) :: positions_b
-    type(integer_set), dimension(node_count(positions_b)), intent(out) :: ele_as
-    real, intent(in) :: ownership_tolerance
-
-    integer :: i
-    real, dimension(:, :), allocatable :: lpositions
-
-    assert(positions_a%dim == positions_b%dim)
-
-    allocate(lpositions(positions_b%dim, node_count(positions_b)))
-    do i = 1, node_count(positions_b)
-      lpositions(:, i) = node_val(positions_b, i)
-    end do
-
-    call picker_inquire(positions_a, lpositions, ele_as, ownership_tolerance = ownership_tolerance)
-
-    deallocate(lpositions)
-
-  end subroutine picker_inquire_nodes_tolerance
-
-  subroutine search_for_detectors(detectors, positions)
-    !!< This subroutine establishes on which processor, in which element and at
-    !!< which local coordinates each detector is to be found. A negative element
-    !!< value indicates that no element could be found for that node.
-    !!< Detectors are assumed to be local.
-
-    !!< NOTE: This routine does not check whether all detectors have been found. "Lost" detectors
-    !!< are marked with a %element = -1. Therefore this routine should be followed by a call to
-    !!< distribute_detectors() to globally search for these, or if we know that this shouldn't occur
-    !!< a test that indeed all detectors have been found.
-
-    type(vector_field), intent(inout) :: positions
-    type(detector_linked_list), intent(inout) :: detectors
-    type(detector_type), pointer :: node
-
-    integer :: i
-    real, dimension(:, :), allocatable :: coords, l_coords
-    integer, dimension(:), allocatable :: ele
-
-    call initialise_picker(positions)
-    assert(ele_numbering_family(positions, 1) == FAMILY_SIMPLEX)
-
-    allocate(coords(positions%dim, detectors%length))
-    allocate(l_coords(positions%dim+1, detectors%length))
-    allocate(ele(detectors%length))
-
-    node => detectors%first
-    do i = 1, detectors%length
-      coords(:, i) = node%position
-      node => node%next
-    end do
-
-    ! First check locally
-    if (detectors%length > 0) then
-       call picker_inquire(positions, coords(:,:), ele(:), local_coords = l_coords(:,:), global = .false.)
-    end if
-
-    node => detectors%first
-    do i = 1, detectors%length
-      node%local_coords = l_coords(:, i)
-      node%element = ele(i)
-      node => node%next
-    end do
-
-    deallocate(coords)
-    deallocate(l_coords)
-    deallocate(ele)
-
-  end subroutine search_for_detectors
+   end subroutine search_for_detectors
 
 end module pickers_inquire

--- a/femtools/Pickers_Inquire.F90
+++ b/femtools/Pickers_Inquire.F90
@@ -29,351 +29,351 @@
 
 module pickers_inquire
 
-   use fldebug
-   use data_structures
-   use element_numbering, only: FAMILY_SIMPLEX
-   use parallel_tools
-   use detector_data_types
-   use picker_data_types
-   use pickers_base
-   use transform_elements
-   use fields
-   use node_owner_finder
-   use pickers_allocates
+  use fldebug
+  use data_structures
+  use element_numbering, only: FAMILY_SIMPLEX
+  use parallel_tools
+  use detector_data_types
+  use picker_data_types
+  use pickers_base
+  use transform_elements
+  use fields
+  use node_owner_finder
+  use pickers_allocates
 
-   implicit none
+  implicit none
 
-   interface picker_inquire
-      module procedure picker_inquire_single_position, &
+  interface picker_inquire
+    module procedure picker_inquire_single_position, &
       & picker_inquire_single_position_xyz, picker_inquire_multiple_positions, &
       & picker_inquire_single_position_tolerance, &
       & picker_inquire_multiple_positions_tolerance, &
       & picker_inquire_multiple_positions_xyz, picker_inquire_node, &
       & picker_inquire_nodes, picker_inquire_node_tolerance, &
       & picker_inquire_nodes_tolerance
-   end interface picker_inquire
+  end interface picker_inquire
 
-   real, parameter, public :: max_picker_ownership_tolerance = rtree_tolerance
+  real, parameter, public :: max_picker_ownership_tolerance = rtree_tolerance
 
-   public :: picker_inquire, search_for_detectors
+  public :: picker_inquire, search_for_detectors
 
-   private
+  private
 
 contains
 
-   subroutine picker_inquire_single_position_xyz(positions, coordx, coordy, coordz, ele, local_coord, global)
-      !!< Find the owning elements in positions of the supplied coordinate
+  subroutine picker_inquire_single_position_xyz(positions, coordx, coordy, coordz, ele, local_coord, global)
+    !!< Find the owning elements in positions of the supplied coordinate
 
-      type(vector_field), intent(inout) :: positions
-      real, intent(in) :: coordx
-      real, optional, intent(in) :: coordy
-      real, optional, intent(in) :: coordz
-      integer, intent(out) :: ele
-      !! The local coordinates of the coordinate in the owning element
-      real, dimension(positions%dim+1), optional, intent(out) :: local_coord
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
+    type(vector_field), intent(inout) :: positions
+    real, intent(in) :: coordx
+    real, optional, intent(in) :: coordy
+    real, optional, intent(in) :: coordz
+    integer, intent(out) :: ele
+    !! The local coordinates of the coordinate in the owning element
+    real, dimension(positions%dim+1), optional, intent(out) :: local_coord
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-      real, dimension(:), allocatable :: coord
+    real, dimension(:), allocatable :: coord
 
-      if(present(coordy)) then
-         if(present(coordz)) then
-            allocate(coord(3))
-            coord = (/coordx, coordy, coordz/)
-         else
-            allocate(coord(2))
-            coord = (/coordx, coordy/)
-         end if
+    if(present(coordy)) then
+      if(present(coordz)) then
+        allocate(coord(3))
+        coord = (/coordx, coordy, coordz/)
       else
-         assert(.not. present(coordz))
-         allocate(coord(1))
-         coord = (/coordx/)
+        allocate(coord(2))
+        coord = (/coordx, coordy/)
       end if
+    else
+      assert(.not. present(coordz))
+      allocate(coord(1))
+      coord = (/coordx/)
+    end if
 
-      call picker_inquire(positions, coord, ele, local_coord = local_coord, global = global)
+    call picker_inquire(positions, coord, ele, local_coord = local_coord, global = global)
 
-      deallocate(coord)
+    deallocate(coord)
 
-   end subroutine picker_inquire_single_position_xyz
+  end subroutine picker_inquire_single_position_xyz
 
-   subroutine picker_inquire_single_position(positions, coord, ele, local_coord, global)
-      !!< Find the owning elements in positions of the supplied coordinate
+  subroutine picker_inquire_single_position(positions, coord, ele, local_coord, global)
+    !!< Find the owning elements in positions of the supplied coordinate
 
-      type(vector_field), intent(inout) :: positions
-      real, dimension(positions%dim), intent(in) :: coord
-      integer, intent(out) :: ele
-      !! The local coordinates of the coordinate in the owning element
-      real, dimension(positions%dim+1), optional, intent(out) :: local_coord
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
+    type(vector_field), intent(inout) :: positions
+    real, dimension(positions%dim), intent(in) :: coord
+    integer, intent(out) :: ele
+    !! The local coordinates of the coordinate in the owning element
+    real, dimension(positions%dim+1), optional, intent(out) :: local_coord
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-      call initialise_picker(positions)
+    call initialise_picker(positions)
 
-      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, global=global)
-      if(present(local_coord)) then
-         if(ele > 0) then
-            local_coord = local_coords(positions, ele, coord)
-         else
-            ! If we don't own this node then we really shouldn't be using any local
-            ! coord information
-            local_coord = huge(0.0)
-         end if
-      end if
-
-   end subroutine picker_inquire_single_position
-
-   subroutine picker_inquire_multiple_positions_xyz(positions, coordsx, coordsy, coordsz, eles, local_coords, global)
-      !!< Find the owning elements in positions of the supplied coordinates
-
-      type(vector_field), intent(inout) :: positions
-      real, dimension(:), intent(in) :: coordsx
-      real, dimension(size(coordsx)), optional, intent(in) :: coordsy
-      real, dimension(size(coordsx)), optional, intent(in) :: coordsz
-      integer, dimension(size(coordsx)), intent(out) :: eles
-      !! The local coordinates of the coordinates in the owning elements
-      real, dimension(positions%dim+1, size(coordsx)), optional, intent(out) :: local_coords
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
-
-      real, dimension(:, :), allocatable :: coords
-
-      if(present(coordsy)) then
-         if(present(coordsz)) then
-            allocate(coords(3, size(coordsx)))
-            coords(1, :) = coordsx
-            coords(2, :) = coordsy
-            coords(3, :) = coordsz
-         else
-            allocate(coords(2, size(coordsx)))
-            coords(1, :) = coordsx
-            coords(2, :) = coordsy
-         end if
+    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, global = global)
+    if(present(local_coord)) then
+      if(ele > 0) then
+        local_coord = local_coords(positions, ele, coord)
       else
-         assert(.not. present(coordsz))
-         allocate(coords(1, size(coordsx)))
-         coords(1, :) = coordsx
+        ! If we don't own this node then we really shouldn't be using any local
+        ! coord information
+        local_coord = huge(0.0)
       end if
+    end if
 
-      call picker_inquire(positions, coords, eles, local_coords = local_coords, global=global)
+  end subroutine picker_inquire_single_position
 
-      deallocate(coords)
+  subroutine picker_inquire_multiple_positions_xyz(positions, coordsx, coordsy, coordsz, eles, local_coords, global)
+    !!< Find the owning elements in positions of the supplied coordinates
 
-   end subroutine picker_inquire_multiple_positions_xyz
+    type(vector_field), intent(inout) :: positions
+    real, dimension(:), intent(in) :: coordsx
+    real, dimension(size(coordsx)), optional, intent(in) :: coordsy
+    real, dimension(size(coordsx)), optional, intent(in) :: coordsz
+    integer, dimension(size(coordsx)), intent(out) :: eles
+    !! The local coordinates of the coordinates in the owning elements
+    real, dimension(positions%dim+1, size(coordsx)), optional, intent(out) :: local_coords
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-   subroutine picker_inquire_multiple_positions(positions, coords, eles, local_coords, global)
-      !!< Find the owning elements in positions of the supplied coordinates
+    real, dimension(:, :), allocatable :: coords
 
-      type(vector_field), intent(inout) :: positions
-      real, dimension(:, :), intent(in) :: coords
-      integer, dimension(size(coords, 2)), intent(out) :: eles
-      !! The local coordinates of the coordinates in the owning elements
-      real, dimension(positions%dim+1, size(coords, 2)), optional, intent(out) :: local_coords
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
-
-      integer :: i
-
-      assert(size(coords, 1) == positions%dim)
-
-      call initialise_picker(positions)
-
-      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, global = global)
-      if(present(local_coords)) then
-         do i = 1, size(coords, 2)
-            if(eles(i) > 0) then
-               local_coords(:, i) = local_coords_interpolation(positions, eles(i), coords(:, i))
-            else
-               ! If we don't own this node then we really shouldn't be using any
-               ! local coord information
-               local_coords(:, i) = huge(0.0)
-            end if
-         end do
-      end if
-
-   end subroutine picker_inquire_multiple_positions
-
-   subroutine picker_inquire_single_position_tolerance(positions, coord, ele, ownership_tolerance)
-      !!< Find the owning elements in positions of the supplied coordinate
-      !!< using an ownership tolerance. This performs a strictly local (this
-      !!< process) ownership test.
-
-      type(vector_field), intent(inout) :: positions
-      real, dimension(positions%dim), intent(in) :: coord
-      type(integer_set), intent(out) :: ele
-      real, intent(in) :: ownership_tolerance
-
-      call initialise_picker(positions)
-      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, ownership_tolerance = ownership_tolerance)
-
-   end subroutine picker_inquire_single_position_tolerance
-
-   subroutine picker_inquire_multiple_positions_tolerance(positions, coords, eles, ownership_tolerance)
-      !!< Find the owning elements in positions of the supplied coordinates
-      !!< using an ownership tolerance. This performs a strictly local (this
-      !!< process) ownership test.
-
-      type(vector_field), intent(inout) :: positions
-      real, dimension(:, :), intent(in) :: coords
-      type(integer_set), dimension(size(coords, 2)), intent(out) :: eles
-      real, intent(in) :: ownership_tolerance
-
-      assert(size(coords, 1) == positions%dim)
-
-      call initialise_picker(positions)
-      call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, ownership_tolerance = ownership_tolerance)
-
-   end subroutine picker_inquire_multiple_positions_tolerance
-
-   subroutine picker_inquire_node(positions_a, positions_b, ele_a, node_b, local_coord, global)
-      !!< Find the owning element in positions_a of a node in positions_b
-
-      type(vector_field), intent(inout) :: positions_a
-      type(vector_field), intent(in) :: positions_b
-      integer, intent(out) :: ele_a
-      integer, intent(in) :: node_b
-      !! The local coordinates of the node in the owning element
-      real, dimension(positions_a%dim+1), optional, intent(out) :: local_coord
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
-
-      assert(positions_a%dim == positions_b%dim)
-
-      if(present(local_coord)) then
-         call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global = global)
+    if(present(coordsy)) then
+      if(present(coordsz)) then
+        allocate(coords(3, size(coordsx)))
+        coords(1, :) = coordsx
+        coords(2, :) = coordsy
+        coords(3, :) = coordsz
       else
-         call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global = global)
+        allocate(coords(2, size(coordsx)))
+        coords(1, :) = coordsx
+        coords(2, :) = coordsy
       end if
+    else
+      assert(.not. present(coordsz))
+      allocate(coords(1, size(coordsx)))
+      coords(1, :) = coordsx
+    end if
 
-   end subroutine picker_inquire_node
+    call picker_inquire(positions, coords, eles, local_coords = local_coords, global = global)
 
-   subroutine picker_inquire_nodes(positions_a, positions_b, ele_as, local_coords, global)
-      !!< Find the owning elements in positions_a of the nodes in positions_b
+    deallocate(coords)
 
-      type(vector_field), intent(inout) :: positions_a
-      type(vector_field), intent(in) :: positions_b
-      integer, dimension(node_count(positions_b)), intent(out) :: ele_as
-      !! The local coordinates of the nodes in the owning elements
-      real, dimension(positions_a%dim+1, node_count(positions_b)), optional, intent(out) :: local_coords
-      !! If present and .false., do not perform a global inquiry across all
-      !! processes
-      logical, optional, intent(in) :: global
+  end subroutine picker_inquire_multiple_positions_xyz
 
-      integer :: i
-      real, dimension(:, :), allocatable :: lpositions
+  subroutine picker_inquire_multiple_positions(positions, coords, eles, local_coords, global)
+    !!< Find the owning elements in positions of the supplied coordinates
 
-      assert(positions_a%dim == positions_b%dim)
+    type(vector_field), intent(inout) :: positions
+    real, dimension(:, :), intent(in) :: coords
+    integer, dimension(size(coords, 2)), intent(out) :: eles
+    !! The local coordinates of the coordinates in the owning elements
+    real, dimension(positions%dim+1, size(coords, 2)), optional, intent(out) :: local_coords
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-      allocate(lpositions(positions_b%dim, node_count(positions_b)))
-      do i = 1, node_count(positions_b)
-         lpositions(:, i) = node_val(positions_b, i)
+    integer :: i
+
+    assert(size(coords, 1) == positions%dim)
+
+    call initialise_picker(positions)
+
+    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, global = global)
+    if(present(local_coords)) then
+      do i = 1, size(coords, 2)
+        if(eles(i) > 0) then
+          local_coords(:, i) = local_coords_interpolation(positions, eles(i), coords(:, i))
+        else
+          ! If we don't own this node then we really shouldn't be using any
+          ! local coord information
+          local_coords(:, i) = huge(0.0)
+        end if
       end do
+    end if
 
-      if(present(local_coords)) then
-         call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global = global)
-      else
-         call picker_inquire(positions_a, lpositions, ele_as, global = global)
-      end if
+  end subroutine picker_inquire_multiple_positions
 
-      deallocate(lpositions)
+  subroutine picker_inquire_single_position_tolerance(positions, coord, ele, ownership_tolerance)
+    !!< Find the owning elements in positions of the supplied coordinate
+    !!< using an ownership tolerance. This performs a strictly local (this
+    !!< process) ownership test.
 
-   end subroutine picker_inquire_nodes
+    type(vector_field), intent(inout) :: positions
+    real, dimension(positions%dim), intent(in) :: coord
+    type(integer_set), intent(out) :: ele
+    real, intent(in) :: ownership_tolerance
 
-   subroutine picker_inquire_node_tolerance(positions_a, positions_b, ele_a, node_b, ownership_tolerance)
-      !!< Find the owning element in positions_a of a node in positions_b
-      !!< using an ownership tolerance. This performs a strictly local (this
-      !!< process) ownership test.
+    call initialise_picker(positions)
+    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coord, ele, ownership_tolerance = ownership_tolerance)
 
-      type(vector_field), intent(inout) :: positions_a
-      type(vector_field), intent(in) :: positions_b
-      type(integer_set), intent(out) :: ele_a
-      integer, intent(in) :: node_b
-      real, intent(in) :: ownership_tolerance
+  end subroutine picker_inquire_single_position_tolerance
 
-      assert(positions_a%dim == positions_b%dim)
+  subroutine picker_inquire_multiple_positions_tolerance(positions, coords, eles, ownership_tolerance)
+    !!< Find the owning elements in positions of the supplied coordinates
+    !!< using an ownership tolerance. This performs a strictly local (this
+    !!< process) ownership test.
 
-      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, ownership_tolerance = ownership_tolerance)
+    type(vector_field), intent(inout) :: positions
+    real, dimension(:, :), intent(in) :: coords
+    type(integer_set), dimension(size(coords, 2)), intent(out) :: eles
+    real, intent(in) :: ownership_tolerance
 
-   end subroutine picker_inquire_node_tolerance
+    assert(size(coords, 1) == positions%dim)
 
-   subroutine picker_inquire_nodes_tolerance(positions_a, positions_b, ele_as, ownership_tolerance)
-      !!< Find the owning elements in positions_a of the nodes in positions_b
-      !!< using an ownership tolerance. This performs a strictly local (this
-      !!< process) ownership test.
+    call initialise_picker(positions)
+    call node_owner_finder_find(positions%picker%ptr%picker_id, positions, coords, eles, ownership_tolerance = ownership_tolerance)
 
-      type(vector_field), intent(inout) :: positions_a
-      type(vector_field), intent(in) :: positions_b
-      type(integer_set), dimension(node_count(positions_b)), intent(out) :: ele_as
-      real, intent(in) :: ownership_tolerance
+  end subroutine picker_inquire_multiple_positions_tolerance
 
-      integer :: i
-      real, dimension(:, :), allocatable :: lpositions
+  subroutine picker_inquire_node(positions_a, positions_b, ele_a, node_b, local_coord, global)
+    !!< Find the owning element in positions_a of a node in positions_b
 
-      assert(positions_a%dim == positions_b%dim)
+    type(vector_field), intent(inout) :: positions_a
+    type(vector_field), intent(in) :: positions_b
+    integer, intent(out) :: ele_a
+    integer, intent(in) :: node_b
+    !! The local coordinates of the node in the owning element
+    real, dimension(positions_a%dim+1), optional, intent(out) :: local_coord
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-      allocate(lpositions(positions_b%dim, node_count(positions_b)))
-      do i = 1, node_count(positions_b)
-         lpositions(:, i) = node_val(positions_b, i)
-      end do
+    assert(positions_a%dim == positions_b%dim)
 
-      call picker_inquire(positions_a, lpositions, ele_as, ownership_tolerance = ownership_tolerance)
+    if(present(local_coord)) then
+      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global = global)
+    else
+      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global = global)
+    end if
 
-      deallocate(lpositions)
+  end subroutine picker_inquire_node
 
-   end subroutine picker_inquire_nodes_tolerance
+  subroutine picker_inquire_nodes(positions_a, positions_b, ele_as, local_coords, global)
+    !!< Find the owning elements in positions_a of the nodes in positions_b
 
-   subroutine search_for_detectors(detectors, positions)
-      !!< This subroutine establishes on which processor, in which element and at
-      !!< which local coordinates each detector is to be found. A negative element
-      !!< value indicates that no element could be found for that node.
-      !!< Detectors are assumed to be local.
+    type(vector_field), intent(inout) :: positions_a
+    type(vector_field), intent(in) :: positions_b
+    integer, dimension(node_count(positions_b)), intent(out) :: ele_as
+    !! The local coordinates of the nodes in the owning elements
+    real, dimension(positions_a%dim+1, node_count(positions_b)), optional, intent(out) :: local_coords
+    !! If present and .false., do not perform a global inquiry across all
+    !! processes
+    logical, optional, intent(in) :: global
 
-      !!< NOTE: This routine does not check whether all detectors have been found. "Lost" detectors
-      !!< are marked with a %element = -1. Therefore this routine should be followed by a call to
-      !!< distribute_detectors() to globally search for these, or if we know that this shouldn't occur
-      !!< a test that indeed all detectors have been found.
+    integer :: i
+    real, dimension(:, :), allocatable :: lpositions
 
-      type(vector_field), intent(inout) :: positions
-      type(detector_linked_list), intent(inout) :: detectors
-      type(detector_type), pointer :: node
+    assert(positions_a%dim == positions_b%dim)
 
-      integer :: i
-      real, dimension(:, :), allocatable :: coords, l_coords
-      integer, dimension(:), allocatable :: ele
+    allocate(lpositions(positions_b%dim, node_count(positions_b)))
+    do i = 1, node_count(positions_b)
+      lpositions(:, i) = node_val(positions_b, i)
+    end do
 
-      call initialise_picker(positions)
-      assert(ele_numbering_family(positions, 1) == FAMILY_SIMPLEX)
+    if(present(local_coords)) then
+      call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global = global)
+    else
+      call picker_inquire(positions_a, lpositions, ele_as, global = global)
+    end if
 
-      allocate(coords(positions%dim, detectors%length))
-      allocate(l_coords(positions%dim+1, detectors%length))
-      allocate(ele(detectors%length))
+    deallocate(lpositions)
 
-      node => detectors%first
-      do i = 1, detectors%length
-         coords(:, i) = node%position
-         node => node%next
-      end do
+  end subroutine picker_inquire_nodes
 
-      ! First check locally
-      if (detectors%length > 0) then
-         call picker_inquire(positions, coords(:,:), ele(:), local_coords = l_coords(:,:), global = .false.)
-      end if
+  subroutine picker_inquire_node_tolerance(positions_a, positions_b, ele_a, node_b, ownership_tolerance)
+    !!< Find the owning element in positions_a of a node in positions_b
+    !!< using an ownership tolerance. This performs a strictly local (this
+    !!< process) ownership test.
 
-      node => detectors%first
-      do i = 1, detectors%length
-         node%local_coords = l_coords(:, i)
-         node%element = ele(i)
-         node => node%next
-      end do
+    type(vector_field), intent(inout) :: positions_a
+    type(vector_field), intent(in) :: positions_b
+    type(integer_set), intent(out) :: ele_a
+    integer, intent(in) :: node_b
+    real, intent(in) :: ownership_tolerance
 
-      deallocate(coords)
-      deallocate(l_coords)
-      deallocate(ele)
+    assert(positions_a%dim == positions_b%dim)
 
-   end subroutine search_for_detectors
+    call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, ownership_tolerance = ownership_tolerance)
+
+  end subroutine picker_inquire_node_tolerance
+
+  subroutine picker_inquire_nodes_tolerance(positions_a, positions_b, ele_as, ownership_tolerance)
+    !!< Find the owning elements in positions_a of the nodes in positions_b
+    !!< using an ownership tolerance. This performs a strictly local (this
+    !!< process) ownership test.
+
+    type(vector_field), intent(inout) :: positions_a
+    type(vector_field), intent(in) :: positions_b
+    type(integer_set), dimension(node_count(positions_b)), intent(out) :: ele_as
+    real, intent(in) :: ownership_tolerance
+
+    integer :: i
+    real, dimension(:, :), allocatable :: lpositions
+
+    assert(positions_a%dim == positions_b%dim)
+
+    allocate(lpositions(positions_b%dim, node_count(positions_b)))
+    do i = 1, node_count(positions_b)
+      lpositions(:, i) = node_val(positions_b, i)
+    end do
+
+    call picker_inquire(positions_a, lpositions, ele_as, ownership_tolerance = ownership_tolerance)
+
+    deallocate(lpositions)
+
+  end subroutine picker_inquire_nodes_tolerance
+
+  subroutine search_for_detectors(detectors, positions)
+    !!< This subroutine establishes on which processor, in which element and at
+    !!< which local coordinates each detector is to be found. A negative element
+    !!< value indicates that no element could be found for that node.
+    !!< Detectors are assumed to be local.
+
+    !!< NOTE: This routine does not check whether all detectors have been found. "Lost" detectors
+    !!< are marked with a %element = -1. Therefore this routine should be followed by a call to
+    !!< distribute_detectors() to globally search for these, or if we know that this shouldn't occur
+    !!< a test that indeed all detectors have been found.
+
+    type(vector_field), intent(inout) :: positions
+    type(detector_linked_list), intent(inout) :: detectors
+    type(detector_type), pointer :: node
+
+    integer :: i
+    real, dimension(:, :), allocatable :: coords, l_coords
+    integer, dimension(:), allocatable :: ele
+
+    call initialise_picker(positions)
+    assert(ele_numbering_family(positions, 1) == FAMILY_SIMPLEX)
+
+    allocate(coords(positions%dim, detectors%length))
+    allocate(l_coords(positions%dim+1, detectors%length))
+    allocate(ele(detectors%length))
+
+    node => detectors%first
+    do i = 1, detectors%length
+      coords(:, i) = node%position
+      node => node%next
+    end do
+
+    ! First check locally
+    if (detectors%length > 0) then
+       call picker_inquire(positions, coords(:,:), ele(:), local_coords = l_coords(:,:), global = .false.)
+    end if
+
+    node => detectors%first
+    do i = 1, detectors%length
+      node%local_coords = l_coords(:, i)
+      node%element = ele(i)
+      node => node%next
+    end do
+
+    deallocate(coords)
+    deallocate(l_coords)
+    deallocate(ele)
+
+  end subroutine search_for_detectors
 
 end module pickers_inquire

--- a/femtools/Pickers_Inquire.F90
+++ b/femtools/Pickers_Inquire.F90
@@ -91,7 +91,11 @@ contains
       coord = (/coordx/)
     end if
 
+<<<<<<< HEAD
     call picker_inquire(positions, coord, ele, local_coord = local_coord, global = global)
+=======
+    call picker_inquire(positions, coord, ele, local_coord = local_coord, global=global)
+>>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
 
     deallocate(coord)
 
@@ -244,9 +248,9 @@ contains
     assert(positions_a%dim == positions_b%dim)
 
     if(present(local_coord)) then
-      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global = global)
+      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, local_coord = local_coord, global=global)
     else
-      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global = global)
+      call picker_inquire(positions_a, node_val(positions_b, node_b), ele_a, global=global)
     end if
 
   end subroutine picker_inquire_node
@@ -274,9 +278,9 @@ contains
     end do
 
     if(present(local_coords)) then
-      call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global = global)
+      call picker_inquire(positions_a, lpositions, ele_as, local_coords = local_coords, global=global)
     else
-      call picker_inquire(positions_a, lpositions, ele_as, global = global)
+      call picker_inquire(positions_a, lpositions, ele_as, global=global)
     end if
 
     deallocate(lpositions)

--- a/main/Fluids.F90
+++ b/main/Fluids.F90
@@ -747,7 +747,7 @@ contains
        ! Call move and write particles
        call move_particles(state, dt)
        call particle_cv_check(state)
-       call update_particle_attributes_and_fields(state, current_time, dt)
+       call update_particle_attributes_and_fields(state, current_time, dt, initial=.false.)
        call initialise_particles_during_simulation(state, current_time, dt)
        call calculate_particle_material_fields(state)
        call calculate_diagnostic_fields_from_particles(state)

--- a/main/Fluids.F90
+++ b/main/Fluids.F90
@@ -350,7 +350,7 @@ contains
     call calculate_diagnostic_variables_new(state)
 
     ! Initialise particle attributes and dependent fields
-    call update_particle_attributes_and_fields(state, current_time, dt)
+    call update_particle_attributes_and_fields(state, current_time, dt, initial=.true.)
     call calculate_diagnostic_fields_from_particles(state)
 
     ! This is mostly to ensure that the photosynthetic radiation
@@ -746,9 +746,9 @@ contains
 
        ! Call move and write particles
        call move_particles(state, dt)
-       call initialise_particles_during_simulation(state, current_time)
        call particle_cv_check(state)
        call update_particle_attributes_and_fields(state, current_time, dt)
+       call initialise_particles_during_simulation(state, current_time, dt)
        call calculate_particle_material_fields(state)
        call calculate_diagnostic_fields_from_particles(state)
        call write_particles_loop(state, timestep, current_time)

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -441,12 +441,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_scalar_particle_attribute_choice
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_scalar_particle_attribute_choice
                                  }
                               }|
@@ -460,12 +461,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_scalar_particle_attribute_array
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_scalar_particle_attribute_array
                                  }
                               }|
@@ -476,12 +478,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_vector_particle_attribute_choice
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_vector_particle_attribute_choice
                                  }
                               }|
@@ -495,12 +498,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_vector_particle_attribute_array
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_vector_particle_attribute_array
                                  }
                               }|
@@ -511,12 +515,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_tensor_particle_attribute_choice
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_tensor_particle_attribute_choice
                                  }
                               }|
@@ -530,12 +535,13 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_initialisation {
+                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 element initial_attribute_value {
                                     generic_tensor_particle_attribute_array
                                  }?,
-                                 ## Attribute value at each timestep after advection occurs
-                                 element value_on_advection {
+                                 ## This field sets the attribute value at each time step.
+                                 element attribute_value {
                                     generic_tensor_particle_attribute_array
                                  }
                               }
@@ -3884,8 +3890,8 @@ generic_scalar_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
@@ -3934,8 +3940,8 @@ generic_vector_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
@@ -3993,8 +3999,8 @@ generic_tensor_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
@@ -4051,8 +4057,8 @@ generic_scalar_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
@@ -4105,8 +4111,8 @@ generic_vector_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
@@ -4168,8 +4174,8 @@ generic_tensor_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_initialisation".
+         ## Enable storing the current attribute value. It will be available in the next time step.
+         ## This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -441,8 +441,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_scalar_particle_attribute_choice
                                  }?,
@@ -461,8 +470,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_scalar_particle_attribute_array
                                  }?,
@@ -478,8 +496,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_vector_particle_attribute_choice
                                  }?,
@@ -498,8 +525,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_vector_particle_attribute_array
                                  }?,
@@ -515,8 +551,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_tensor_particle_attribute_choice
                                  }?,
@@ -535,8 +580,17 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 ## This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-                                 ## This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.
+                                 ##  This field sets the attribute value either at the
+                                 ##beginning of the simulation or while
+                                 ##"initialise_during_simulation". It is not called upon
+                                 ##simulation restart from a checkpoint if an H5Part
+                                 ##file is provided in "initial_position".
+                                 ##  This field should only be strictly required in
+                                 ##conjunction with "initialise_during_simulation" when
+                                 ##the calculation of the initial attribute value must
+                                 ##be distinguished from that later on during the
+                                 ##simulation, as is the case for an initial-value
+                                 ##problem.
                                  element initial_attribute_value {
                                     generic_tensor_particle_attribute_array
                                  }?,
@@ -3890,15 +3944,12 @@ generic_scalar_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string }
       }
    )
 
@@ -3940,21 +3991,12 @@ generic_vector_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string },
-         ## The format of the input file containing field data.
-         element format {
-            element string_value {
-               "binary"
-            }
-         }
       }
    )
 
@@ -3999,21 +4041,12 @@ generic_tensor_particle_attribute_choice =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string },
-         ## The format of the input file containing field data.
-         element format {
-            element string_value {
-               "binary"
-            }
-         }
       }
    )
 
@@ -4057,15 +4090,12 @@ generic_scalar_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string }
       }
    )
 
@@ -4111,21 +4141,12 @@ generic_vector_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string },
-         ## The format of the input file containing field data.
-         element format {
-            element string_value {
-               "binary"
-            }
-         }
       }
    )
 
@@ -4174,21 +4195,12 @@ generic_tensor_particle_attribute_array =
       ## if the store_old_attribute or store_old_field options are enabled.
       element python_fields {
          python_code,
-         ## Enable storing the current attribute value. It will be available in the next time step.
-         ## This field only has an effect if set under "attribute_value".
+         ##  Enable storing the current attribute value. It will be available in the
+         ##next time step.
+         ##  This field only has an effect if set under "attribute_value".
          element store_old_attribute {
             comment
          }?
-      }|
-      ## File containing the particle attributes in binary form
-      element from_checkpoint_file {
-         attribute file_name { xsd:string },
-         ## The format of the input file containing field data.
-         element format {
-            element string_value {
-               "binary"
-            }
-         }
       }
    )
 

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -442,7 +442,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_scalar_particle_attribute_choice
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -461,7 +461,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_scalar_particle_attribute_array
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -477,7 +477,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_vector_particle_attribute_choice
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -496,7 +496,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_vector_particle_attribute_array
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -512,7 +512,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_tensor_particle_attribute_choice
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -531,7 +531,7 @@ start =
                                     empty
                                  }?,
                                  ## Attribute value on particle spawn (at the beginning of, or during the simulation)
-                                 element value_on_spawn {
+                                 element value_on_initialisation {
                                     generic_tensor_particle_attribute_array
                                  }?,
                                  ## Attribute value at each timestep after advection occurs
@@ -3885,7 +3885,7 @@ generic_scalar_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?
@@ -3935,7 +3935,7 @@ generic_vector_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?
@@ -3994,7 +3994,7 @@ generic_tensor_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?
@@ -4052,7 +4052,7 @@ generic_scalar_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?
@@ -4106,7 +4106,7 @@ generic_vector_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?
@@ -4169,7 +4169,7 @@ generic_tensor_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
-         ## Irrelevant for "value_on_spawn".
+         ## Irrelevant for "value_on_initialisation".
          element store_old_attribute {
             comment
          }?

--- a/schemas/fluidity_options.rnc
+++ b/schemas/fluidity_options.rnc
@@ -440,8 +440,15 @@ start =
                                  ## Do not output this attribute to file
                                  element exclude_from_output {
                                     empty
-                                  }?,
-                                 generic_scalar_particle_attribute_choice
+                                 }?,
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_scalar_particle_attribute_choice
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_scalar_particle_attribute_choice
+                                 }
                               }|
                               ##Scalar particle attribute array.
                               element scalar_attribute_array {
@@ -452,8 +459,15 @@ start =
                                  ## Do not output this attribute to file
                                  element exclude_from_output {
                                     empty
-                                  }?,
-                                 generic_scalar_particle_attribute_array
+                                 }?,
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_scalar_particle_attribute_array
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_scalar_particle_attribute_array
+                                 }
                               }|
                               ##Vector particle attribute.
                               element vector_attribute {
@@ -462,7 +476,14 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 generic_vector_particle_attribute_choice
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_vector_particle_attribute_choice
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_vector_particle_attribute_choice
+                                 }
                               }|
                               ##Vector particle attribute array.
                               element vector_attribute_array {
@@ -474,7 +495,14 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 generic_vector_particle_attribute_array
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_vector_particle_attribute_array
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_vector_particle_attribute_array
+                                 }
                               }|
                               ##Tensor particle attribute.
                               element tensor_attribute {
@@ -483,7 +511,14 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 generic_tensor_particle_attribute_choice
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_tensor_particle_attribute_choice
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_tensor_particle_attribute_choice
+                                 }
                               }|
                               ##Tensor particle attribute array.
                               element tensor_attribute_array {
@@ -495,7 +530,14 @@ start =
                                  element exclude_from_output {
                                     empty
                                  }?,
-                                 generic_tensor_particle_attribute_array
+                                 ## Attribute value on particle spawn (at the beginning of, or during the simulation)
+                                 element value_on_spawn {
+                                    generic_tensor_particle_attribute_array
+                                 }?,
+                                 ## Attribute value at each timestep after advection occurs
+                                 element value_on_advection {
+                                    generic_tensor_particle_attribute_array
+                                 }
                               }
                            )+
                         }?
@@ -3843,6 +3885,7 @@ generic_scalar_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?
@@ -3892,6 +3935,7 @@ generic_vector_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?
@@ -3950,6 +3994,7 @@ generic_tensor_particle_attribute_choice =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?
@@ -4007,6 +4052,7 @@ generic_scalar_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?
@@ -4060,6 +4106,7 @@ generic_vector_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?
@@ -4122,6 +4169,7 @@ generic_tensor_particle_attribute_array =
       element python_fields {
          python_code,
          ## Store attribute values from previous timestep on particles.
+         ## Irrelevant for "value_on_spawn".
          element store_old_attribute {
             comment
          }?

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -537,7 +537,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_choice"/>
                                 </element>
@@ -562,7 +562,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_array"/>
                                 </element>
@@ -584,7 +584,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_vector_particle_attribute_choice"/>
                                 </element>
@@ -609,7 +609,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_vector_particle_attribute_array"/>
                                 </element>
@@ -631,7 +631,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_choice"/>
                                 </element>
@@ -656,7 +656,7 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_spawn">
+                                <element name="value_on_initialisation">
                                   <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_array"/>
                                 </element>
@@ -4999,7 +4999,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5053,7 +5053,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5116,7 +5116,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5178,7 +5178,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5236,7 +5236,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5303,7 +5303,7 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <optional>
           <element name="store_old_attribute">
             <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_spawn".</a:documentation>
+Irrelevant for "value_on_initialisation".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -538,8 +538,14 @@ This function will only be called after simulation start. To initialise starting
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_choice"/>
                                 </element>
                               </optional>
@@ -564,8 +570,14 @@ This field should only be strictly required in conjunction with "initialise_duri
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_array"/>
                                 </element>
                               </optional>
@@ -587,8 +599,14 @@ This field should only be strictly required in conjunction with "initialise_duri
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_vector_particle_attribute_choice"/>
                                 </element>
                               </optional>
@@ -613,8 +631,14 @@ This field should only be strictly required in conjunction with "initialise_duri
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_vector_particle_attribute_array"/>
                                 </element>
                               </optional>
@@ -636,8 +660,14 @@ This field should only be strictly required in conjunction with "initialise_duri
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_choice"/>
                                 </element>
                               </optional>
@@ -662,8 +692,14 @@ This field should only be strictly required in conjunction with "initialise_duri
                               </optional>
                               <optional>
                                 <element name="initial_attribute_value">
-                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
-This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
+                                  <a:documentation>  This field sets the attribute value
+either at the beginning of the simulation or while "initialise_during_simulation". It is
+not called upon simulation restart from a checkpoint if an H5Part file is provided in
+"initial_position".
+  This field should only be strictly required in conjunction with
+"initialise_during_simulation" when the calculation of the initial attribute value must
+be distinguished from that later on during the simulation, as is the case for an
+initial-value problem.</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_array"/>
                                 </element>
                               </optional>
@@ -5004,17 +5040,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
       </element>
     </choice>
   </define>
@@ -5058,23 +5089,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing of the current attribute value and make it available at the next timestep.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
-        <element name="format">
-          <a:documentation>The format of the input file containing field data.</a:documentation>
-          <element name="string_value">
-            <value>binary</value>
-          </element>
-        </element>
       </element>
     </choice>
   </define>
@@ -5121,23 +5141,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
-        <element name="format">
-          <a:documentation>The format of the input file containing field data.</a:documentation>
-          <element name="string_value">
-            <value>binary</value>
-          </element>
-        </element>
       </element>
     </choice>
   </define>
@@ -5183,17 +5192,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
       </element>
     </choice>
   </define>
@@ -5241,23 +5245,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
-        <element name="format">
-          <a:documentation>The format of the input file containing field data.</a:documentation>
-          <element name="string_value">
-            <value>binary</value>
-          </element>
-        </element>
       </element>
     </choice>
   </define>
@@ -5308,23 +5301,12 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
-This field only has an effect if set under "attribute_value".</a:documentation>
+            <a:documentation>  Enable storing the current attribute value. It will be
+available in the next time step.
+  This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
-      </element>
-      <element name="from_checkpoint_file">
-        <a:documentation>File containing the particle attributes in binary form</a:documentation>
-        <attribute name="file_name">
-          <data type="string"/>
-        </attribute>
-        <element name="format">
-          <a:documentation>The format of the input file containing field data.</a:documentation>
-          <element name="string_value">
-            <value>binary</value>
-          </element>
-        </element>
       </element>
     </choice>
   </define>

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -537,13 +537,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_choice"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_scalar_particle_attribute_choice"/>
                               </element>
                             </element>
@@ -562,13 +563,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_scalar_particle_attribute_array"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_scalar_particle_attribute_array"/>
                               </element>
                             </element>
@@ -584,13 +586,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_vector_particle_attribute_choice"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_vector_particle_attribute_choice"/>
                               </element>
                             </element>
@@ -609,13 +612,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_vector_particle_attribute_array"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_vector_particle_attribute_array"/>
                               </element>
                             </element>
@@ -631,13 +635,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_choice"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_tensor_particle_attribute_choice"/>
                               </element>
                             </element>
@@ -656,13 +661,14 @@ This function will only be called after simulation start. To initialise starting
                                 </element>
                               </optional>
                               <optional>
-                                <element name="value_on_initialisation">
-                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                <element name="initial_attribute_value">
+                                  <a:documentation>This field sets the attribute value either at the beginning of the simulation or while "initialise_during_simulation". It is not called upon simulation restart from a checkpoint if an H5Part file is provided in "initial_position".
+This field should only be strictly required in conjunction with "initialise_during_simulation" when the calculation of the initial attribute value must be distinguished from that later on during the simulation, as is the case for an initial-value problem.</a:documentation>
                                   <ref name="generic_tensor_particle_attribute_array"/>
                                 </element>
                               </optional>
-                              <element name="value_on_advection">
-                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                              <element name="attribute_value">
+                                <a:documentation>This field sets the attribute value at each time step.</a:documentation>
                                 <ref name="generic_tensor_particle_attribute_array"/>
                               </element>
                             </element>
@@ -4998,8 +5004,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5052,8 +5058,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing of the current attribute value and make it available at the next timestep.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5115,8 +5121,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5177,8 +5183,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5235,8 +5241,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5302,8 +5308,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.
-Irrelevant for "value_on_initialisation".</a:documentation>
+            <a:documentation>Enable storing the current attribute value. It will be available in the next time step.
+This field only has an effect if set under "attribute_value".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-  xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <include href="spud_base.rng"/>
   <include href="adaptivity_options.rng"/>
   <include href="diagnostic_algorithms.rng"/>
@@ -74,7 +73,7 @@ A value of 0.0 indicates that there would be a dump at every timestep.</a:docume
     # Function code
     return # Return value
 
-                </a:documentation>
+</a:documentation>
                 <ref name="python_code"/>
               </element>
             </choice>
@@ -95,7 +94,7 @@ A value of 0 indicates a dump at every timestep.</a:documentation>
     # Function code
     return # Return value
 
-                </a:documentation>
+</a:documentation>
                 <ref name="python_code"/>
               </element>
             </choice>
@@ -314,7 +313,7 @@ Note that the main option to control the log output is given on the command line
 -v1  also give "navigational information", to indicate where in the code we currently are
 
 -v2  also give any additional information (mins and maxes of fields, etc.)
-            </a:documentation>
+</a:documentation>
             <optional>
               <element name="memory_diagnostics">
                 <a:documentation>Log all allocates and deallocates done for meshes, fields, sparsities and matrices.
@@ -360,7 +359,7 @@ calculations and spawning and deleting options.</a:documentation>
  def val(t):
     # Function code
     return # Return value
-                              </a:documentation>
+</a:documentation>
                               <ref name="python_code"/>
                             </element>
                           </choice>
@@ -377,7 +376,7 @@ calculations and spawning and deleting options.</a:documentation>
  def val(t):
     # Function code
     return # Return value
-                              </a:documentation>
+</a:documentation>
                               <ref name="python_code"/>
                             </element>
                           </choice>
@@ -3444,7 +3443,9 @@ parts.</a:documentation>
         </element>
       </choice>
       <element name="conservative_advection">
-        <a:documentation>Conservative discretisation of field advection equation TBETA=1. -- conservative (divergence form) TBETA=0. -- non-conservative
+        <a:documentation>Conservative discretisation of field advection equation
+ TBETA=1. -- conservative (divergence form)
+ TBETA=0. -- non-conservative
  0. &lt; TBETA &lt; 1.</a:documentation>
         <ref name="real"/>
       </element>
@@ -4277,7 +4278,8 @@ this requires a Density field!</a:documentation>
           <optional>
             <element name="external_density">
               <a:documentation>When selected a hydrostatic pressure distribution on the outside is assumed
-using the specified density, i.e. instead of applying p=0 (resp. normal_stress=0) we apply p=p_external (resp. normal_stress=p_external) where p_external is determined by dp_external/dz=external_density*g</a:documentation>
+using the specified density, i.e. instead of applying p=0 (resp.
+normal_stress=0) we apply p=p_external (resp. normal_stress=p_external) where p_external is determined by dp_external/dz=external_density*g</a:documentation>
               <ref name="input_choice_real_plus_field"/>
             </element>
           </optional>
@@ -6707,7 +6709,7 @@ Uses the gravity field direction to determine the horizontal plane.</a:documenta
         <a:documentation>Velocity divergence:
 
 div velocity
-        </a:documentation>
+</a:documentation>
         <attribute name="rank">
           <value>0</value>
         </attribute>
@@ -7240,68 +7242,64 @@ Sums up the divergence of each phase's apparent velocity, i.e. \sum{ div(vfrac*u
             <element name="test_with_cv_dual">
               <a:documentation>Test the divergence operator with the CV dual function space.
 This is useful if the pressure is solved with a CV discretisation
-                <<<<<<< HEAD
 or with a CG but with the continuity tested with the CV dual.</a:documentation>
-=======
-or with a CG but with the continuity tested with the CV dual. </a:documentation>
->>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
               <ref name="comment"/>
-              </element>
-            </optional>
-            <ref name="diagnostic_scalar_field_no_adapt"/>
-            <element name="solver">
-              <ref name="linear_solver_options_sym"/>
             </element>
+          </optional>
+          <ref name="diagnostic_scalar_field_no_adapt"/>
+          <element name="solver">
+            <ref name="linear_solver_options_sym"/>
           </element>
         </element>
-        <element name="scalar_field">
-          <a:documentation>CompressibleContinuityResidual
+      </element>
+      <element name="scalar_field">
+        <a:documentation>CompressibleContinuityResidual
 
 Computes the residual of the continuity equation used in compressible multiphase flow simulations
 i.e. vfrac_c*d(rho_c)/dt + div(rho_c*vfrac_c*u_c) + \sum_i{ rho_c*div(vfrac_i*u_i) }
 where _c and _i denote the compressible and incompressible phases respectively.</a:documentation>
-          <attribute name="rank">
-            <value>0</value>
-          </attribute>
-          <attribute name="name">
-            <value>CompressibleContinuityResidual</value>
-          </attribute>
-          <element name="diagnostic">
-            <ref name="velocity_mesh_choice"/>
-            <ref name="internal_algorithm"/>
-            <ref name="diagnostic_scalar_field_no_adapt"/>
-            <element name="solver">
-              <ref name="linear_solver_options_sym"/>
-            </element>
+        <attribute name="rank">
+          <value>0</value>
+        </attribute>
+        <attribute name="name">
+          <value>CompressibleContinuityResidual</value>
+        </attribute>
+        <element name="diagnostic">
+          <ref name="velocity_mesh_choice"/>
+          <ref name="internal_algorithm"/>
+          <ref name="diagnostic_scalar_field_no_adapt"/>
+          <element name="solver">
+            <ref name="linear_solver_options_sym"/>
           </element>
         </element>
-        <element name="scalar_field">
-          <a:documentation>DGLESScalarEddyViscosity
+      </element>
+      <element name="scalar_field">
+        <a:documentation>DGLESScalarEddyViscosity
 
 Outputs the calculated (isotropic) eddy viscosity term
 for a discontinuous velocity field. The subgridscale viscosity
 follows that of the Smagorinsky–Lilly model. Requires that both a discontinous
 representation of velocity and an les model have been selected.</a:documentation>
-          <attribute name="rank">
-            <value>0</value>
-          </attribute>
-          <attribute name="name">
-            <value>DGLESScalarEddyViscosity</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_scalar_field"/>
-            </element>
-            <element name="prescribed">
-              <ref name="velocity_mesh_choice"/>
-              <ref name="prescribed_scalar_field"/>
-            </element>
-          </choice>
-        </element>
-      </choice>
-      <!--
+        <attribute name="rank">
+          <value>0</value>
+        </attribute>
+        <attribute name="name">
+          <value>DGLESScalarEddyViscosity</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_scalar_field"/>
+          </element>
+          <element name="prescribed">
+            <ref name="velocity_mesh_choice"/>
+            <ref name="prescribed_scalar_field"/>
+          </element>
+        </choice>
+      </element>
+    </choice>
+    <!--
       Insert new diagnostic scalar fields here using the template:
              element scalar_field {
                  attribute rank { "0" },
@@ -7318,97 +7316,97 @@ representation of velocity and an les model have been selected.</a:documentation
                  )
              }
     -->
-    </define>
-    <!-- This is the choice of additional vector field to be solved for -->
-    <define name="vector_field_choice">
-      <!--
+  </define>
+  <!-- This is the choice of additional vector field to be solved for -->
+  <define name="vector_field_choice">
+    <!--
       The first is a generic field, which may be used for any user-defined field
       that FLUIDITY knows nothing about, or a generic diagnostic
       Prognostic vector fields are not possible (other than velocity and those known fields below).
     -->
-      <choice>
-        <element name="vector_field">
-          <a:documentation>Generic field variable (vector)</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <data type="string"/>
-          </attribute>
-          <choice>
-            <a:documentation>Field type</a:documentation>
-            <element name="prescribed">
-              <ref name="mesh_choice"/>
-              <ref name="prescribed_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-            <element name="diagnostic">
-              <ref name="vector_diagnostic_algorithms"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-          </choice>
-        </element>
-        <!--
+    <choice>
+      <element name="vector_field">
+        <a:documentation>Generic field variable (vector)</a:documentation>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <data type="string"/>
+        </attribute>
+        <choice>
+          <a:documentation>Field type</a:documentation>
+          <element name="prescribed">
+            <ref name="mesh_choice"/>
+            <ref name="prescribed_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+          <element name="diagnostic">
+            <ref name="vector_diagnostic_algorithms"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
+        </choice>
+      </element>
+      <!--
 
         - - List of fields that are primarily prognostic,
            but can be aliased.
         - - The list is in order of most frequently used.
 
       -->
-        <element name="___Prognostic_fields_below___">
-          <a:documentation>Prescribed vector fields below this</a:documentation>
-          <empty/>
-        </element>
-        <element name="vector_field">
-          <a:documentation>As HydrostaticPressure, but solves for the gradient of the pressure
+      <element name="___Prognostic_fields_below___">
+        <a:documentation>Prescribed vector fields below this</a:documentation>
+        <empty/>
+      </element>
+      <element name="vector_field">
+        <a:documentation>As HydrostaticPressure, but solves for the gradient of the pressure
 associated with buoyancy. Requires a discontinuous mesh.</a:documentation>
-          <attribute name="rank">
-            <value>0</value>
-          </attribute>
-          <attribute name="name">
-            <value>HydrostaticPressureGradient</value>
-          </attribute>
-          <element name="prognostic">
-            <ref name="mesh_choice"/>
-            <ref name="prognostic_hydrostatic_pressure_gradient_field"/>
-          </element>
+        <attribute name="rank">
+          <value>0</value>
+        </attribute>
+        <attribute name="name">
+          <value>HydrostaticPressureGradient</value>
+        </attribute>
+        <element name="prognostic">
+          <ref name="mesh_choice"/>
+          <ref name="prognostic_hydrostatic_pressure_gradient_field"/>
         </element>
-        <!--
+      </element>
+      <!--
 
         - - List of fields that are primarily prescribed,
            but can be aliased.
         - - The list is in order of most frequently used.
 
       -->
-        <element name="___Prescribed_fields_below___">
-          <a:documentation>Prescribed vector fields below this</a:documentation>
-          <empty/>
-        </element>
-        <element name="vector_field">
-          <a:documentation>MaterialVelocity field.  Used to impose a velocity on a material
+      <element name="___Prescribed_fields_below___">
+        <a:documentation>Prescribed vector fields below this</a:documentation>
+        <empty/>
+      </element>
+      <element name="vector_field">
+        <a:documentation>MaterialVelocity field.  Used to impose a velocity on a material
 in combination with the imposed_material_velocity_absorption_algorithm
 for VelocityAbsorption and imposed_material_velocity_source_algorithm
 for VelocitySource.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>MaterialVelocity</value>
-          </attribute>
-          <choice>
-            <element name="prescribed">
-              <ref name="mesh_choice"/>
-              <ref name="prescribed_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <!--
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>MaterialVelocity</value>
+        </attribute>
+        <choice>
+          <element name="prescribed">
+            <ref name="mesh_choice"/>
+            <ref name="prescribed_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <!--
 
         Insert new prescribed vector fields here using the template:
                element vector_field {
@@ -7430,439 +7428,439 @@ for VelocitySource.</a:documentation>
         - - The list is in order of most frequently used.
 
       -->
-        <element name="___Diagnostic_Fields_Below___">
-          <a:documentation>Diagnostic vector fields below this</a:documentation>
-          <empty/>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Gradient of a scalar field evaluated using the C gradient
+      <element name="___Diagnostic_Fields_Below___">
+        <a:documentation>Diagnostic vector fields below this</a:documentation>
+        <empty/>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Gradient of a scalar field evaluated using the C gradient
 matrix constructed using finite elements.
 Field must be in this material_phase.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>FiniteElementGradient</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <attribute name="field_name">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <ref name="mesh_choice"/>
-              <optional>
-                <element name="integrate_gradient_by_parts">
-                  <empty/>
-                </element>
-              </optional>
-              <ref name="diagnostic_gradient_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Gradient of a scalar field evaluated using the transpose
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>FiniteElementGradient</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <attribute name="field_name">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <ref name="mesh_choice"/>
+            <optional>
+              <element name="integrate_gradient_by_parts">
+                <empty/>
+              </element>
+            </optional>
+            <ref name="diagnostic_gradient_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Gradient of a scalar field evaluated using the transpose
 of the C^T divergence matrix constructed using finite
 elements.
 Field must be in this material_phase.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>FiniteElementDivergenceTransposed</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="legacy_internal_algorithm"/>
-              <attribute name="field_name">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <ref name="mesh_choice"/>
-              <optional>
-                <element name="integrate_divergence_by_parts">
-                  <empty/>
-                </element>
-              </optional>
-              <ref name="diagnostic_gradient_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Foam Velocity field.
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>FiniteElementDivergenceTransposed</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="legacy_internal_algorithm"/>
+            <attribute name="field_name">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <ref name="mesh_choice"/>
+            <optional>
+              <element name="integrate_divergence_by_parts">
+                <empty/>
+              </element>
+            </optional>
+            <ref name="diagnostic_gradient_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Foam Velocity field.
 Required for simulations of foam flow and liquid drainage in foams.
 If diagnostic, a FoamVelocityPotential field is required,
 and the Foam Velocity is obtained by taking its gradient.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>FoamVelocity</value>
-          </attribute>
-          <choice>
-            <element name="prescribed">
-              <ref name="velocity_mesh_choice"/>
-              <ref name="prescribed_vector_field_no_adapt"/>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>FoamVelocity</value>
+        </attribute>
+        <choice>
+          <element name="prescribed">
+            <ref name="velocity_mesh_choice"/>
+            <ref name="prescribed_vector_field_no_adapt"/>
+          </element>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="mesh_choice"/>
+            <element name="solver">
+              <ref name="linear_solver_options_sym"/>
             </element>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="mesh_choice"/>
-              <element name="solver">
-                <ref name="linear_solver_options_sym"/>
-              </element>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Foam Liquid Content times Velocity field.
+            <ref name="diagnostic_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Foam Liquid Content times Velocity field.
 Its surface integral gives the liquid
 volumetric flow in the flowing foam</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>FoamLiquidContentVelocity</value>
-          </attribute>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>FoamLiquidContentVelocity</value>
+        </attribute>
+        <element name="diagnostic">
+          <ref name="internal_algorithm"/>
+          <ref name="velocity_mesh_choice"/>
+          <ref name="diagnostic_vector_field"/>
+        </element>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Relative vorticity field - curl of the velocity field</a:documentation>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>Vorticity</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="vorticity_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Planetary vorticity
+
+Limitations:
+ - Requires geometry dimension of 3.</a:documentation>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>PlanetaryVorticity</value>
+        </attribute>
+        <choice>
           <element name="diagnostic">
             <ref name="internal_algorithm"/>
             <ref name="velocity_mesh_choice"/>
             <ref name="diagnostic_vector_field"/>
           </element>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Relative vorticity field - curl of the velocity field</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>Vorticity</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="vorticity_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Planetary vorticity
-
-Limitations:
- - Requires geometry dimension of 3.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>PlanetaryVorticity</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Absolute vorticity:
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Absolute vorticity:
 
   f + curl u
 
 Limitations:
  - Requires a geometry dimension of 3.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>AbsoluteVorticity</value>
-          </attribute>
-          <attribute name="depends">
-            <value>Velocity</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Gradient of a scalar field evaluated using the transpose
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>AbsoluteVorticity</value>
+        </attribute>
+        <attribute name="depends">
+          <value>Velocity</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Gradient of a scalar field evaluated using the transpose
 of the C^T matrix constructed using control volumes.
 Field must be in this material_phase.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>ControlVolumeDivergenceTransposed</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <attribute name="field_name">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_cv_gradient_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>LinearMomentum field.
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>ControlVolumeDivergenceTransposed</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <attribute name="field_name">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_cv_gradient_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>LinearMomentum field.
  p = \rho*u
 (where p is the linear momentum, \rho the density and u the velocity)</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>LinearMomentum</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Absolute Difference between two vector fields.
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>LinearMomentum</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Absolute Difference between two vector fields.
 
 Both fields must be in this material_phase.
 Assumes both fields are on the same mesh as the AbsoluteDifference field.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>AbsoluteDifference</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <attribute name="field_name_a">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <attribute name="field_name_b">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <ref name="mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-              <optional>
-                <element name="relative_to_average">
-                  <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Absolute Difference between two vector fields.
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>AbsoluteDifference</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <attribute name="field_name_a">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <attribute name="field_name_b">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <ref name="mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+            <optional>
+              <element name="relative_to_average">
+                <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Absolute Difference between two vector fields.
 
 Both fields must be in this material_phase.
 Assumes both fields are on the same mesh as the AbsoluteDifference field.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>VectorAbsoluteDifference</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <attribute name="field_name_a">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <attribute name="field_name_b">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <ref name="mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-              <optional>
-                <element name="relative_to_average">
-                  <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Bed Shear Stress
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>VectorAbsoluteDifference</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <attribute name="field_name_a">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <attribute name="field_name_b">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <ref name="mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+            <optional>
+              <element name="relative_to_average">
+                <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Bed Shear Stress
 
 This diagnostic vector field is only calculated over surface elements/nodes,
 interior nodes will have zero value.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>BedShearStress</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="internal_algorithm"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_vector_field_bed_shear_stress"/>
-            </element>
-            <element name="prescribed">
-              <ref name="velocity_mesh_choice"/>
-              <ref name="prescribed_vector_field_no_adapt"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Max Bed Shear Stress.
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>BedShearStress</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field_bed_shear_stress"/>
+          </element>
+          <element name="prescribed">
+            <ref name="velocity_mesh_choice"/>
+            <ref name="prescribed_vector_field_no_adapt"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Max Bed Shear Stress.
 
 Note that you need BedShearStress turned on for this to work.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>MaxBedShearStress</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <group>
-                <ref name="internal_algorithm"/>
-                <ref name="velocity_mesh_choice"/>
-              </group>
-              <!-- diagnostic_vector_field_max_bed_shear_stress -->
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-          <element name="spin_up_time">
-            <a:documentation>This is the time after which the max operator is
-applied to the bed shear stress.</a:documentation>
-            <ref name="real"/>
-          </element>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Coordinate field remapped to the mesh of your choice.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>DiagnosticCoordinate</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>MaxBedShearStress</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <group>
               <ref name="internal_algorithm"/>
-              <ref name="mesh_choice"/>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
+              <ref name="velocity_mesh_choice"/>
+            </group>
+            <!-- diagnostic_vector_field_max_bed_shear_stress -->
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+        <element name="spin_up_time">
+          <a:documentation>This is the time after which the max operator is
+applied to the bed shear stress.</a:documentation>
+          <ref name="real"/>
         </element>
-        <element name="vector_field">
-          <a:documentation>Galerkin projection of one field onto another mesh.
+      </element>
+      <element name="vector_field">
+        <a:documentation>Coordinate field remapped to the mesh of your choice.</a:documentation>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>DiagnosticCoordinate</value>
+        </attribute>
+        <choice>
+          <element name="diagnostic">
+            <ref name="internal_algorithm"/>
+            <ref name="mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Galerkin projection of one field onto another mesh.
 
 The field must be in this material_phase.
 
 NOTE: you need the solver options if the mesh
 of this field is continuous.</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>GalerkinProjection</value>
-          </attribute>
-          <choice>
-            <element name="diagnostic">
-              <ref name="legacy_internal_algorithm"/>
-              <element name="source_field_name">
-                <data type="string" datatypeLibrary=""/>
-              </element>
-              <ref name="mesh_choice"/>
-              <optional>
-                <element name="lump_mass">
-                  <a:documentation>Lump the mass matrix of the galerkin projection
-less accurate but faster and might give smoother result.</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-              <optional>
-                <element name="solver">
-                  <ref name="linear_solver_options_sym"/>
-                </element>
-              </optional>
-              <ref name="diagnostic_vector_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <element name="vector_field">
-          <a:documentation>Computes the buoyancy term</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>Buoyancy</value>
-          </attribute>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>GalerkinProjection</value>
+        </attribute>
+        <choice>
           <element name="diagnostic">
-            <ref name="buoyancy_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
+            <ref name="legacy_internal_algorithm"/>
+            <element name="source_field_name">
+              <data type="string" datatypeLibrary=""/>
+            </element>
+            <ref name="mesh_choice"/>
+            <optional>
+              <element name="lump_mass">
+                <a:documentation>Lump the mass matrix of the galerkin projection
+less accurate but faster and might give smoother result.</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="solver">
+                <ref name="linear_solver_options_sym"/>
+              </element>
+            </optional>
             <ref name="diagnostic_vector_field"/>
           </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <element name="vector_field">
+        <a:documentation>Computes the buoyancy term</a:documentation>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>Buoyancy</value>
+        </attribute>
+        <element name="diagnostic">
+          <ref name="buoyancy_algorithm"/>
+          <ref name="velocity_mesh_choice"/>
+          <ref name="diagnostic_vector_field"/>
         </element>
-        <element name="vector_field">
-          <a:documentation>Projects the Coriolis term onto the mesh of this diagnostic field.
+      </element>
+      <element name="vector_field">
+        <a:documentation>Projects the Coriolis term onto the mesh of this diagnostic field.
 Note that multiple projection methods are available (under the
 algorithm option).</a:documentation>
-          <attribute name="rank">
-            <value>1</value>
-          </attribute>
-          <attribute name="name">
-            <value>Coriolis</value>
-          </attribute>
-          <element name="diagnostic">
-            <ref name="coriolis_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-          </element>
+        <attribute name="rank">
+          <value>1</value>
+        </attribute>
+        <attribute name="name">
+          <value>Coriolis</value>
+        </attribute>
+        <element name="diagnostic">
+          <ref name="coriolis_algorithm"/>
+          <ref name="velocity_mesh_choice"/>
+          <ref name="diagnostic_vector_field"/>
         </element>
-      </choice>
-      <!--
+      </element>
+    </choice>
+    <!--
       Insert new diagnostic vector field here using the template:
              element vector_field {
                  attribute rank { "1" },
@@ -7879,78 +7877,78 @@ algorithm option).</a:documentation>
                  )
              }
     -->
-    </define>
-    <!-- This is the choice of additional tensor fields -->
-    <define name="tensor_field_choice">
-      <!--
+  </define>
+  <!-- This is the choice of additional tensor fields -->
+  <define name="tensor_field_choice">
+    <!--
       The first is a generic field, which may be used for any user-defined field
       that FLUIDITY knows nothing about, or a generic diagnostic
       Prognostic tensor fields are not possible.
     -->
-      <choice>
-        <element name="tensor_field">
-          <a:documentation>Generic field variable (tensor)</a:documentation>
-          <attribute name="rank">
-            <value>2</value>
-          </attribute>
-          <attribute name="name">
-            <data type="string"/>
-          </attribute>
-          <choice>
-            <a:documentation>Field type</a:documentation>
-            <element name="prescribed">
-              <ref name="mesh_choice"/>
-              <ref name="prescribed_tensor_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-            <element name="diagnostic">
-              <ref name="tensor_diagnostic_algorithms"/>
-              <ref name="velocity_mesh_choice"/>
-              <ref name="diagnostic_tensor_field"/>
-            </element>
-          </choice>
-        </element>
-        <!--
+    <choice>
+      <element name="tensor_field">
+        <a:documentation>Generic field variable (tensor)</a:documentation>
+        <attribute name="rank">
+          <value>2</value>
+        </attribute>
+        <attribute name="name">
+          <data type="string"/>
+        </attribute>
+        <choice>
+          <a:documentation>Field type</a:documentation>
+          <element name="prescribed">
+            <ref name="mesh_choice"/>
+            <ref name="prescribed_tensor_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+          <element name="diagnostic">
+            <ref name="tensor_diagnostic_algorithms"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_tensor_field"/>
+          </element>
+        </choice>
+      </element>
+      <!--
 
         - - Second is a list of tensor fields that are primarily prescribed,
            but can be aliased.
         - - The list is in order of most frequently used.
 
       -->
-        <element name="___Prescribed_fields_below___">
-          <a:documentation>Prescribed scalar fields below this</a:documentation>
-          <empty/>
-        </element>
-        <element name="tensor_field">
-          <a:documentation>MaterialViscosity field:
+      <element name="___Prescribed_fields_below___">
+        <a:documentation>Prescribed scalar fields below this</a:documentation>
+        <empty/>
+      </element>
+      <element name="tensor_field">
+        <a:documentation>MaterialViscosity field:
 
 Field for the viscosity of this material.
 Required if using a diagnostic bulk viscosity
 in a multimaterial simulation.</a:documentation>
-          <attribute name="rank">
-            <value>2</value>
-          </attribute>
-          <attribute name="name">
-            <value>MaterialViscosity</value>
-          </attribute>
-          <choice>
-            <element name="prescribed">
-              <ref name="mesh_choice"/>
-              <ref name="prescribed_tensor_field"/>
-            </element>
-            <element name="diagnostic">
-              <ref name="mesh_choice"/>
-              <ref name="tensor_python_diagnostic_algorithm"/>
-              <ref name="diagnostic_tensor_field"/>
-            </element>
-            <element name="aliased">
-              <ref name="generic_aliased_field"/>
-            </element>
-          </choice>
-        </element>
-        <!--
+        <attribute name="rank">
+          <value>2</value>
+        </attribute>
+        <attribute name="name">
+          <value>MaterialViscosity</value>
+        </attribute>
+        <choice>
+          <element name="prescribed">
+            <ref name="mesh_choice"/>
+            <ref name="prescribed_tensor_field"/>
+          </element>
+          <element name="diagnostic">
+            <ref name="mesh_choice"/>
+            <ref name="tensor_python_diagnostic_algorithm"/>
+            <ref name="diagnostic_tensor_field"/>
+          </element>
+          <element name="aliased">
+            <ref name="generic_aliased_field"/>
+          </element>
+        </choice>
+      </element>
+      <!--
 
         Insert new prescribed tensor fields here using the template:
                element tensor_field {
@@ -7972,12 +7970,12 @@ in a multimaterial simulation.</a:documentation>
         - - The list is in order of most frequently used.
 
       -->
-        <element name="___Diagnostic_Fields_Below___">
-          <a:documentation>Diagnostic tensor fields below this</a:documentation>
-          <empty/>
-        </element>
-      </choice>
-      <!--
+      <element name="___Diagnostic_Fields_Below___">
+        <a:documentation>Diagnostic tensor fields below this</a:documentation>
+        <empty/>
+      </element>
+    </choice>
+    <!--
       Insert new diagnostic tensor field here using the template:
              element tensor_field {
                  attribute name { "NewFieldName" },
@@ -7993,130 +7991,130 @@ in a multimaterial simulation.</a:documentation>
                  )
              }
     -->
-    </define>
-    <define name="cap_option">
-      <element name="cap_values">
-        <a:documentation>Cap the min and max values of this field when using
+  </define>
+  <define name="cap_option">
+    <element name="cap_values">
+      <a:documentation>Cap the min and max values of this field when using
 it as a volume fraction to work out bulk material
 properties.
 No capping used if not selected.</a:documentation>
-        <optional>
-          <element name="upper_cap">
-            <a:documentation>Set the upper bound on the field.
+      <optional>
+        <element name="upper_cap">
+          <a:documentation>Set the upper bound on the field.
 Defaults to huge(0.0)*epsilon(0.0) if not set.</a:documentation>
-            <ref name="real"/>
-          </element>
-        </optional>
-        <optional>
-          <element name="lower_cap">
-            <a:documentation>Set the lower bound on the field.
-Defaults to -huge(0.0)*epsilon(0.0) if not set.</a:documentation>
-            <ref name="real"/>
-          </element>
-        </optional>
-      </element>
-    </define>
-    <define name="surface_tension_option">
-      <element name="surface_tension">
-        <element name="surface_tension_coefficient">
-          <a:documentation>Surface tension coefficient</a:documentation>
           <ref name="real"/>
         </element>
-        <optional>
-          <element name="equilibrium_contact_angle">
-            <a:documentation>The equilibrium contact angle (in radians) with the boundaries identified by the surface ids</a:documentation>
-            <ref name="real"/>
-            <element name="surface_ids">
-              <a:documentation>Surface ids:</a:documentation>
-              <ref name="integer_vector"/>
-            </element>
-          </element>
-        </optional>
+      </optional>
+      <optional>
+        <element name="lower_cap">
+          <a:documentation>Set the lower bound on the field.
+Defaults to -huge(0.0)*epsilon(0.0) if not set.</a:documentation>
+          <ref name="real"/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="surface_tension_option">
+    <element name="surface_tension">
+      <element name="surface_tension_coefficient">
+        <a:documentation>Surface tension coefficient</a:documentation>
+        <ref name="real"/>
       </element>
-    </define>
-    <define name="limiter_options">
-      <choice>
-        <element name="limit_face_value">
-          <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
-          <choice>
-            <ref name="sweby_limiter"/>
-            <ref name="ultimate_limiter"/>
-          </choice>
+      <optional>
+        <element name="equilibrium_contact_angle">
+          <a:documentation>The equilibrium contact angle (in radians) with the boundaries identified by the surface ids</a:documentation>
+          <ref name="real"/>
+          <element name="surface_ids">
+            <a:documentation>Surface ids:</a:documentation>
+            <ref name="integer_vector"/>
+          </element>
         </element>
-        <element name="do_not_limit_face_value">
-          <a:documentation>Do not limit the face value</a:documentation>
-          <empty/>
-        </element>
-      </choice>
-    </define>
-    <!--
+      </optional>
+    </element>
+  </define>
+  <define name="limiter_options">
+    <choice>
+      <element name="limit_face_value">
+        <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
+        <choice>
+          <ref name="sweby_limiter"/>
+          <ref name="ultimate_limiter"/>
+        </choice>
+      </element>
+      <element name="do_not_limit_face_value">
+        <a:documentation>Do not limit the face value</a:documentation>
+        <empty/>
+      </element>
+    </choice>
+  </define>
+  <!--
     cv limiter options that
     have NO reliance on any CFL field.
   -->
-    <define name="limiter_options_excluding_cfl">
-      <choice>
-        <element name="limit_face_value">
-          <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
-          <ref name="sweby_limiter"/>
-        </element>
-        <element name="do_not_limit_face_value">
-          <a:documentation>Do not limit the face value</a:documentation>
-          <empty/>
-        </element>
-      </choice>
-    </define>
-    <define name="sweby_limiter">
-      <element name="limiter">
-        <a:documentation>See "High-Resolution Schemes Using Flux Limiters for
+  <define name="limiter_options_excluding_cfl">
+    <choice>
+      <element name="limit_face_value">
+        <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
+        <ref name="sweby_limiter"/>
+      </element>
+      <element name="do_not_limit_face_value">
+        <a:documentation>Do not limit the face value</a:documentation>
+        <empty/>
+      </element>
+    </choice>
+  </define>
+  <define name="sweby_limiter">
+    <element name="limiter">
+      <a:documentation>See "High-Resolution Schemes Using Flux Limiters for
 Hyperbolic Conservation-Laws", P. K. Sweby, 1984, Siam
 Journal on Numerical Analysis, 21, 995-1011</a:documentation>
-        <attribute name="name">
-          <value>Sweby</value>
-        </attribute>
-        <optional>
-          <ref name="slope_options"/>
-        </optional>
-        <optional>
-          <ref name="upwind_value_options"/>
-        </optional>
-      </element>
-    </define>
-    <define name="ultimate_limiter">
-      <element name="limiter">
-        <a:documentation>See "The Ultimate Conservative Difference Scheme Applied
+      <attribute name="name">
+        <value>Sweby</value>
+      </attribute>
+      <optional>
+        <ref name="slope_options"/>
+      </optional>
+      <optional>
+        <ref name="upwind_value_options"/>
+      </optional>
+    </element>
+  </define>
+  <define name="ultimate_limiter">
+    <element name="limiter">
+      <a:documentation>See "The Ultimate Conservative Difference Scheme Applied
 to Unsteady One-Dimensional Advection", B. P. Leonard,
 1991, Computer Methods in Applied Mechanics and
 Engineering, 88, 17-74</a:documentation>
-        <attribute name="name">
-          <value>Ultimate</value>
-        </attribute>
-        <ref name="field_based_cfl_number_options"/>
-        <optional>
-          <ref name="upwind_value_options"/>
-        </optional>
-      </element>
-    </define>
-    <define name="slope_options">
-      <element name="slopes">
-        <a:documentation>Control the upper and lower slopes of the NVD limiter</a:documentation>
-        <optional>
-          <element name="lower">
-            <a:documentation>Defaults to Sweby, 1984 limiter (= 1.0) if unselected</a:documentation>
-            <ref name="real"/>
-          </element>
-        </optional>
-        <optional>
-          <element name="upper">
-            <a:documentation>Defaults to Sweby, 1984 limiter (= 2.0) if unselected</a:documentation>
-            <ref name="real"/>
-          </element>
-        </optional>
-      </element>
-    </define>
-    <define name="upwind_value_options">
-      <choice>
-        <element name="project_upwind_value_from_point">
-          <a:documentation>Select the method to be used for calculating the upwind value.
+      <attribute name="name">
+        <value>Ultimate</value>
+      </attribute>
+      <ref name="field_based_cfl_number_options"/>
+      <optional>
+        <ref name="upwind_value_options"/>
+      </optional>
+    </element>
+  </define>
+  <define name="slope_options">
+    <element name="slopes">
+      <a:documentation>Control the upper and lower slopes of the NVD limiter</a:documentation>
+      <optional>
+        <element name="lower">
+          <a:documentation>Defaults to Sweby, 1984 limiter (= 1.0) if unselected</a:documentation>
+          <ref name="real"/>
+        </element>
+      </optional>
+      <optional>
+        <element name="upper">
+          <a:documentation>Defaults to Sweby, 1984 limiter (= 2.0) if unselected</a:documentation>
+          <ref name="real"/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="upwind_value_options">
+    <choice>
+      <element name="project_upwind_value_from_point">
+        <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8126,30 +8124,30 @@ upwind of the node pair straddling the face.  It is otherwise known as
 anisotropic limiting.
 This is only available on simplex meshes as it involes a search around
 the donor node to find the upwind element.</a:documentation>
-          <optional>
-            <element name="reflect_off_domain_boundaries">
-              <a:documentation>When the donor node is on a domain boundary reflect the projection
+        <optional>
+          <element name="reflect_off_domain_boundaries">
+            <a:documentation>When the donor node is on a domain boundary reflect the projection
 back into the mesh.</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="bound_projected_value_locally">
-              <a:documentation>Constrain the projected value to be between the min and max of the
+            <empty/>
+          </element>
+        </optional>
+        <optional>
+          <element name="bound_projected_value_locally">
+            <a:documentation>Constrain the projected value to be between the min and max of the
 element values which it was found from.</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="store_upwind_elements">
-              <a:documentation>Store the locations of the elements where the upwind values
+            <empty/>
+          </element>
+        </optional>
+        <optional>
+          <element name="store_upwind_elements">
+            <a:documentation>Store the locations of the elements where the upwind values
 are projected from for each node pair.
 This inserts an integer csr matrix into state so is memory expensive but
 saves a significant amount of time (searching around the neighbouring elements).
 This is unsafe for moving meshes but should be ok for adaptive meshes.</a:documentation>
-              <optional>
-                <element name="store_upwind_quadrature">
-                  <a:documentation>Store the quadrature locations within the elements
+            <optional>
+              <element name="store_upwind_quadrature">
+                <a:documentation>Store the quadrature locations within the elements
 where the upwind values
 are projected from for each node pair.
 This inserts a real block csr matrix into state so is even more memory
@@ -8158,14 +8156,14 @@ only saves a comparitively
 marginal amount of time (as actually searching the
 neighbouring elements is the
 slowest bit, finding the quadrature is relatively easy).</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-            </element>
-          </optional>
-        </element>
-        <element name="project_upwind_value_from_gradient">
-          <a:documentation>Select the method to be used for calculating the upwind value.
+                <empty/>
+              </element>
+            </optional>
+          </element>
+        </optional>
+      </element>
+      <element name="project_upwind_value_from_gradient">
+        <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8175,49 +8173,49 @@ using the interpolated gradient at the donor node in the
 direction of the vector
 connecting the node pair straddling the face.
 This is available on all meshes (except if bounding the values).</a:documentation>
-          <choice>
-            <element name="project_from_downwind_value">
-              <a:documentation>Select which node to project from:
+        <choice>
+          <element name="project_from_downwind_value">
+            <a:documentation>Select which node to project from:
 Project from the downwind node (Jasak et al., 1999) so that:
 upwind_value = downwind_value - 2*gradient.vector</a:documentation>
-              <ref name="comment"/>
-            </element>
-            <element name="project_from_donor_value">
-              <a:documentation>Select which node to project from:
+            <ref name="comment"/>
+          </element>
+          <element name="project_from_donor_value">
+            <a:documentation>Select which node to project from:
 Project from the donor node so that:
 upwind_value = donor_value - gradient.vector</a:documentation>
-              <ref name="comment"/>
-            </element>
-          </choice>
-          <optional>
-            <element name="reflect_off_domain_boundaries">
-              <a:documentation>When the donor node is on a domain boundary reflect the projection
+            <ref name="comment"/>
+          </element>
+        </choice>
+        <optional>
+          <element name="reflect_off_domain_boundaries">
+            <a:documentation>When the donor node is on a domain boundary reflect the projection
 back into the mesh.</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="bound_projected_value_locally">
-              <a:documentation>Constrain the projected value to be between the min and max of the
+            <empty/>
+          </element>
+        </optional>
+        <optional>
+          <element name="bound_projected_value_locally">
+            <a:documentation>Constrain the projected value to be between the min and max of the
 element values which surround it.
 This is only available on simplex meshes as it involes a search around
 the donor node to find the upwind element.</a:documentation>
-              <optional>
-                <element name="store_upwind_elements">
-                  <a:documentation>Store the locations of the elements closest to the project value.
+            <optional>
+              <element name="store_upwind_elements">
+                <a:documentation>Store the locations of the elements closest to the project value.
 This inserts an integer csr matrix into state so is
 memory expensive but
 saves a significant amount of time (searching around
 the neighbouring elements).
 This is unsafe for moving meshes but should be ok for adaptive meshes.</a:documentation>
-                  <ref name="comment"/>
-                </element>
-              </optional>
-            </element>
-          </optional>
-        </element>
-        <element name="locally_bound_upwind_value">
-          <a:documentation>Select the method to be used for calculating the upwind value.
+                <ref name="comment"/>
+              </element>
+            </optional>
+          </element>
+        </optional>
+      </element>
+      <element name="locally_bound_upwind_value">
+        <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8226,10 +8224,10 @@ Chooses an upwind value by selecting the maximum or minimum of the neighbouring
 nodes depending on the local slope of the donor and downwind values.
 Otherwise known as isotropic limiting.
 This is available on all meshes except periodic domains.</a:documentation>
-          <empty/>
-        </element>
-        <element name="pseudo_structured_upwind_value">
-          <a:documentation>Select the method to be used for calculating the upwind value.
+        <empty/>
+      </element>
+      <element name="pseudo_structured_upwind_value">
+        <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8237,770 +8235,767 @@ element meshes.
 Chooses an upwind value by selecting the value at the node most directy
 upwind from the vector connecting the donor and downwind nodes.
 This is available on all meshes.</a:documentation>
-          <empty/>
-        </element>
-      </choice>
-    </define>
-    <define name="field_based_cfl_number_options">
-      <choice>
-        <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used.
+        <empty/>
+      </element>
+    </choice>
+  </define>
+  <define name="field_based_cfl_number_options">
+    <choice>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used.
 
 This uses the control volume definition of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>ControlVolumeCFLNumber</value>
-          </attribute>
-          <empty/>
-        </element>
-        <element name="courant_number">
-          <a:documentation>***UNDER TESTING***
+        <attribute name="name">
+          <value>ControlVolumeCFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used.
 
 This uses the control volume definition of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>CVMaterialDensityCFLNumber</value>
-          </attribute>
-          <empty/>
-        </element>
-        <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used.
+        <attribute name="name">
+          <value>CVMaterialDensityCFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used.
 
 This uses the finite element approximation of the CFL Number.</a:documentation>
+        <attribute name="name">
+          <value>CFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used.</a:documentation>
+        <attribute name="name">
+          <data type="string" datatypeLibrary=""/>
+        </attribute>
+        <empty/>
+      </element>
+    </choice>
+  </define>
+  <define name="dg_field_based_cfl_number_options">
+    <optional>
+      <choice>
+        <element name="courant_number">
+          <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+
+Select the Courant Number definition to be used.
+
+This uses the DG finite element approximation of the CFL Number.</a:documentation>
           <attribute name="name">
-            <value>CFLNumber</value>
+            <value>DG_CourantNumber</value>
           </attribute>
           <empty/>
         </element>
         <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used.</a:documentation>
+          <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+
+Select the Courant Number definition to be used.</a:documentation>
           <attribute name="name">
             <data type="string" datatypeLibrary=""/>
           </attribute>
           <empty/>
         </element>
       </choice>
-    </define>
-    <define name="dg_field_based_cfl_number_options">
-      <optional>
-        <choice>
-          <element name="courant_number">
-            <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
-
-Select the Courant Number definition to be used.
-
-This uses the DG finite element approximation of the CFL Number.</a:documentation>
-            <attribute name="name">
-              <value>DG_CourantNumber</value>
-            </attribute>
-            <empty/>
-          </element>
-          <element name="courant_number">
-            <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
-
-Select the Courant Number definition to be used.</a:documentation>
-            <attribute name="name">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <empty/>
-          </element>
-        </choice>
-      </optional>
-    </define>
-    <define name="cv_face_cfl_number_options">
-      <choice>
-        <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used in the slope of
+    </optional>
+  </define>
+  <define name="cv_face_cfl_number_options">
+    <choice>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses the control volume definition of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>ControlVolumeCFLNumber</value>
-          </attribute>
-          <empty/>
-        </element>
-        <element name="courant_number">
-          <a:documentation>***UNDER TESTING***
+        <attribute name="name">
+          <value>ControlVolumeCFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses a control volume definition of the CFL Number
 that incorporates the MaterialDensity.
 Requires a MaterialDensity field in this material_phase!</a:documentation>
-          <attribute name="name">
-            <value>CVMaterialDensityCFLNumber</value>
-          </attribute>
-          <empty/>
-        </element>
-        <element name="courant_number">
-          <a:documentation>***UNDER TESTING***
+        <attribute name="name">
+          <value>CVMaterialDensityCFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses the finite element approximation of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>CFLNumber</value>
-          </attribute>
-          <empty/>
-        </element>
-        <element name="courant_number">
-          <a:documentation>***UNDER TESTING***
+        <attribute name="name">
+          <value>CFLNumber</value>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="courant_number">
+        <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.</a:documentation>
-          <attribute name="name">
-            <data type="string" datatypeLibrary=""/>
-          </attribute>
-          <empty/>
-        </element>
-      </choice>
-    </define>
-    <define name="timestep_cfl_number_options">
-      <choice>
-        <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
+        <attribute name="name">
+          <data type="string" datatypeLibrary=""/>
+        </attribute>
+        <empty/>
+      </element>
+    </choice>
+  </define>
+  <define name="timestep_cfl_number_options">
+    <choice>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
 This uses the finite element approximation of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>CFLNumber</value>
-          </attribute>
-          <ref name="velocity_mesh_choice">
-            <a:documentation>Select the mesh on which you wish to evaluate the CFLNumber.</a:documentation>
-          </ref>
-        </element>
-        <element name="courant_number">
-          <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
+        <attribute name="name">
+          <value>CFLNumber</value>
+        </attribute>
+        <ref name="velocity_mesh_choice">
+          <a:documentation>Select the mesh on which you wish to evaluate the CFLNumber.</a:documentation>
+        </ref>
+      </element>
+      <element name="courant_number">
+        <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
 This uses the control volume definition of the CFL Number.</a:documentation>
-          <attribute name="name">
-            <value>ControlVolumeCFLNumber</value>
-          </attribute>
-          <ref name="velocity_mesh_choice">
-            <a:documentation>Select the mesh on which you wish to evaluate the ControlVolumeCFLNumber.</a:documentation>
-          </ref>
-        </element>
-      </choice>
-    </define>
-    <define name="mixing_stats">
-      <element name="include_mixing_stats">
-        <a:documentation>Enable to include in the .stat file the fractions of the
+        <attribute name="name">
+          <value>ControlVolumeCFLNumber</value>
+        </attribute>
+        <ref name="velocity_mesh_choice">
+          <a:documentation>Select the mesh on which you wish to evaluate the ControlVolumeCFLNumber.</a:documentation>
+        </ref>
+      </element>
+    </choice>
+  </define>
+  <define name="mixing_stats">
+    <element name="include_mixing_stats">
+      <a:documentation>Enable to include in the .stat file the fractions of the
 scalar field contained in
 bins specified by the user. This allows mixing of the field to be quantified.
 Replaces and expands upon the old heaviside.dat file</a:documentation>
-        <attribute name="name">
-          <data type="string"/>
-        </attribute>
-        <choice>
-          <element name="continuous_galerkin">
-            <a:documentation>Select whether to evaluate the volume fraction over the finite element
+      <attribute name="name">
+        <data type="string"/>
+      </attribute>
+      <choice>
+        <element name="continuous_galerkin">
+          <a:documentation>Select whether to evaluate the volume fraction over the finite element
 (continuous galerkin) or within the control volume (control_volumes).
 
 NOTE: continuous_galerkin only works with linear tets
 
 NOTE: continuous_galerkin is not fully validated yet</a:documentation>
-            <optional>
-              <element name="normalise">
-                <a:documentation>if select normalise the volume fractions will be
+          <optional>
+            <element name="normalise">
+              <a:documentation>if select normalise the volume fractions will be
 divided by the total volume of the domain</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-          <element name="control_volumes">
-            <a:documentation>Select whether to evaluate the volume fraction over the finite element
-(continuous galerkin) or within the control volume (control_volumes).</a:documentation>
-            <optional>
-              <element name="normalise">
-                <a:documentation>if select normalise the volume fractions will be divided by the total volume of the domain</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-        </choice>
-        <element name="mixing_bin_bounds">
-          <a:documentation>The values of the bounds of the bins
-e.g. the values -1.5 0.0 1.5 2.0 will return 4 bins
-and the fraction of the field in each bin with, -1.5&lt;=field&lt;0.0, 0.0&lt;=field&lt;1.5, 1.5&lt;=field&lt;2.0, 2.0&lt;=field,
-            <<<<<<< HEAD
-will be calculated.</a:documentation>
-=======
-will be calculated.  </a:documentation>
->>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
-        <choice>
-<element name="constant">
-              <a:documentation>list of bin bounds</a:documentation>
-              <ref name="real_vector"/>
+              <empty/>
             </element>
-            <element name="python">
-              <a:documentation>Python function prescribing bin bounds. Functions should be of the form:
+          </optional>
+        </element>
+        <element name="control_volumes">
+          <a:documentation>Select whether to evaluate the volume fraction over the finite element
+(continuous galerkin) or within the control volume (control_volumes).</a:documentation>
+          <optional>
+            <element name="normalise">
+              <a:documentation>if select normalise the volume fractions will be divided by the total volume of the domain</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+        </element>
+      </choice>
+      <element name="mixing_bin_bounds">
+        <a:documentation>The values of the bounds of the bins
+e.g. the values -1.5 0.0 1.5 2.0 will return 4 bins
+and the fraction of the field in each bin with,
+-1.5&lt;=field&lt;0.0, 0.0&lt;=field&lt;1.5, 1.5&lt;=field&lt;2.0, 2.0&lt;=field,
+will be calculated.</a:documentation>
+        <choice>
+          <element name="constant">
+            <a:documentation>list of bin bounds</a:documentation>
+            <ref name="real_vector"/>
+          </element>
+          <element name="python">
+            <a:documentation>Python function prescribing bin bounds. Functions should be of the form:
 
  def val(t):
     # Function code
     return # Return value that should be an array of reals
 
-              </a:documentation>
-              <ref name="python_code"/>
-            </element>
-          </choice>
-        </element>
-        <optional>
-          <element name="tolerance">
-            <a:documentation>Define the tolerance beneath the specified bins that should be included.
-Defaults to zero at machine tolerance (epsilon(0.0)) if not selected.</a:documentation>
-            <ref name="real"/>
+</a:documentation>
+            <ref name="python_code"/>
           </element>
-        </optional>
+        </choice>
       </element>
-    </define>
-    <define name="cv_stats">
-      <element name="include_cv_stats">
-        <a:documentation>Include statistics evaluated on the control volume mesh.</a:documentation>
-        <empty/>
-      </element>
-    </define>
-    <!-- Options for inclusion of calculations of surface integrals in the .stat file -->
-    <define name="surface_integral_stats_base.surface_integral">
-      <attribute name="name">
-        <data type="string"/>
-      </attribute>
       <optional>
-        <element name="surface_ids">
-          <a:documentation>Surface IDs defining the surface over which to integrate. If disabled, integrates over the whole surface.</a:documentation>
-          <ref name="integer_vector"/>
+        <element name="tolerance">
+          <a:documentation>Define the tolerance beneath the specified bins that should be included.
+Defaults to zero at machine tolerance (epsilon(0.0)) if not selected.</a:documentation>
+          <ref name="real"/>
         </element>
       </optional>
-      <optional>
-        <element name="normalise">
-          <a:documentation>Enable to normalise the integral by dividing by the surface area</a:documentation>
-          <ref name="comment"/>
-        </element>
-      </optional>
-    </define>
-    <define name="surface_integral_stats_scalar">
-      <element name="surface_integral">
-        <a:documentation>Surface integral calculations. The following integral types are available:
+    </element>
+  </define>
+  <define name="cv_stats">
+    <element name="include_cv_stats">
+      <a:documentation>Include statistics evaluated on the control volume mesh.</a:documentation>
+      <empty/>
+    </element>
+  </define>
+  <!-- Options for inclusion of calculations of surface integrals in the .stat file -->
+  <define name="surface_integral_stats_base.surface_integral">
+    <attribute name="name">
+      <data type="string"/>
+    </attribute>
+    <optional>
+      <element name="surface_ids">
+        <a:documentation>Surface IDs defining the surface over which to integrate. If disabled, integrates over the whole surface.</a:documentation>
+        <ref name="integer_vector"/>
+      </element>
+    </optional>
+    <optional>
+      <element name="normalise">
+        <a:documentation>Enable to normalise the integral by dividing by the surface area</a:documentation>
+        <ref name="comment"/>
+      </element>
+    </optional>
+  </define>
+  <define name="surface_integral_stats_scalar">
+    <element name="surface_integral">
+      <a:documentation>Surface integral calculations. The following integral types are available:
  value: Integrates the field
  gradient_normal: Integrates the normal component of the gradient of the field</a:documentation>
-        <ref name="surface_integral_stats_scalar.surface_integral"/>
-      </element>
-    </define>
-    <define name="surface_integral_stats_scalar.surface_integral">
-      <ref name="surface_integral_stats_base.surface_integral"/>
-    </define>
-    <define name="surface_integral_stats_scalar.surface_integral" combine="interleave">
-      <attribute name="type">
-        <choice>
-          <value>value</value>
-          <value>gradient_normal</value>
-        </choice>
-      </attribute>
-    </define>
-    <define name="surface_integral_stats_vector">
-      <element name="surface_integral">
-        <a:documentation>Surface integral calculations. The following integral types are available:
+      <ref name="surface_integral_stats_scalar.surface_integral"/>
+    </element>
+  </define>
+  <define name="surface_integral_stats_scalar.surface_integral">
+    <ref name="surface_integral_stats_base.surface_integral"/>
+  </define>
+  <define name="surface_integral_stats_scalar.surface_integral" combine="interleave">
+    <attribute name="type">
+      <choice>
+        <value>value</value>
+        <value>gradient_normal</value>
+      </choice>
+    </attribute>
+  </define>
+  <define name="surface_integral_stats_vector">
+    <element name="surface_integral">
+      <a:documentation>Surface integral calculations. The following integral types are available:
  normal: Integrates the normal component of the field</a:documentation>
-        <ref name="surface_integral_stats_vector.surface_integral"/>
-      </element>
-    </define>
-    <define name="surface_integral_stats_vector.surface_integral">
+      <ref name="surface_integral_stats_vector.surface_integral"/>
+    </element>
+  </define>
+  <define name="surface_integral_stats_vector.surface_integral">
+    <ref name="surface_integral_stats_base.surface_integral"/>
+  </define>
+  <define name="surface_integral_stats_vector.surface_integral" combine="interleave">
+    <attribute name="type">
+      <value>normal</value>
+    </attribute>
+  </define>
+  <define name="surface_l2norm_stats">
+    <element name="surface_l2norm">
+      <a:documentation>Calculate L2-norm of field over the specified surface</a:documentation>
       <ref name="surface_integral_stats_base.surface_integral"/>
-    </define>
-    <define name="surface_integral_stats_vector.surface_integral" combine="interleave">
-      <attribute name="type">
-        <value>normal</value>
-      </attribute>
-    </define>
-    <define name="surface_l2norm_stats">
-      <element name="surface_l2norm">
-        <a:documentation>Calculate L2-norm of field over the specified surface</a:documentation>
-        <ref name="surface_integral_stats_base.surface_integral"/>
-      </element>
-    </define>
-    <define name="forcing">
-      <element name="ocean_forcing">
-        <a:documentation>Force the boundary conditions of various fields in ocean simulations</a:documentation>
-        <optional>
-          <element name="iceshelf_meltrate">
-            <optional>
-              <element name="Holland08">
-                <a:documentation>The type of parameterisation</a:documentation>
-                <element name="c0">
-                  <a:documentation>Specific heat capacity of water [Jkg^{-1}]. Default value 3974.</a:documentation>
-                  <ref name="real"/>
+    </element>
+  </define>
+  <define name="forcing">
+    <element name="ocean_forcing">
+      <a:documentation>Force the boundary conditions of various fields in ocean simulations</a:documentation>
+      <optional>
+        <element name="iceshelf_meltrate">
+          <optional>
+            <element name="Holland08">
+              <a:documentation>The type of parameterisation</a:documentation>
+              <element name="c0">
+                <a:documentation>Specific heat capacity of water [Jkg^{-1}]. Default value 3974.</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="cI">
+                <a:documentation>Specific heat capacity of ice [Jkg^{-1}] Default value 2009.</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="L">
+                <a:documentation>Transfer of heat and salt through the boundary layer [Jkg^{-1}]. Default value 3.35e5</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="TI">
+                <a:documentation>Temperature of ice [C]. Default value -25, pretty cold</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="a">
+                <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value -0.0573C.</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="b">
+                <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value 0.0832C.</a:documentation>
+                <ref name="real"/>
+              </element>
+              <element name="Cd">
+                <a:documentation>Drag coefficient, 1.5e-3, see Holland and Jenkins's(1999) Cd.</a:documentation>
+                <ref name="real"/>
+              </element>
+              <optional>
+                <element name="melt_surfaceID">
+                  <a:documentation>Surface ID for the ice</a:documentation>
+                  <ref name="integer_vector"/>
                 </element>
-                <element name="cI">
-                  <a:documentation>Specific heat capacity of ice [Jkg^{-1}] Default value 2009.</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <element name="L">
-                  <a:documentation>Transfer of heat and salt through the boundary layer [Jkg^{-1}]. Default value 3.35e5</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <element name="TI">
-                  <a:documentation>Temperature of ice [C]. Default value -25, pretty cold</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <element name="a">
-                  <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value -0.0573C.</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <element name="b">
-                  <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value 0.0832C.</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <element name="Cd">
-                  <a:documentation>Drag coefficient, 1.5e-3, see Holland and Jenkins's(1999) Cd.</a:documentation>
-                  <ref name="real"/>
-                </element>
-                <optional>
-                  <element name="melt_surfaceID">
-                    <a:documentation>Surface ID for the ice</a:documentation>
-                    <ref name="integer_vector"/>
+              </optional>
+              <element name="melt_LayerLength">
+                <a:documentation>Distance for the far field</a:documentation>
+                <ref name="real"/>
+              </element>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Meltrate, calculated from the three equations.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>MeltRate</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <element name="melt_LayerLength">
-                  <a:documentation>Distance for the far field</a:documentation>
-                  <ref name="real"/>
                 </element>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Meltrate, calculated from the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>MeltRate</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Temperature of the ice-ocean interface, calculated from the three equations.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Tb</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Temperature of the ice-ocean interface, calculated from the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Tb</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Salinity of the ice-ocean interface, calculated from the three equations.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Sb</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Salinity of the ice-ocean interface, calculated from the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Sb</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Heat flux at the ice-ocean interface.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Heat_flux</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Heat flux at the ice-ocean interface.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Heat_flux</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Salt flux at the ice-ocean interface.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Salt_flux</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Salt flux at the ice-ocean interface.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Salt_flux</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
-                  </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Temperature of the far field, which is "melt_LayerLength" away from the ice.
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Temperature of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Tloc</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Tloc</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Salinity of the far field, which is "melt_LayerLength" away from the ice.
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Salinity of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Sloc</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Sloc</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="scalar_field">
-                    <a:documentation>Pressure used in the three equations.
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <a:documentation>Pressure used in the three equations.
 We need to use the pressure at the ice-ocean interface.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Ploc</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Ploc</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="vector_field">
-                    <a:documentation>Velocity of the far field, which is "melt_LayerLength" away from the ice.
+                </element>
+              </optional>
+              <optional>
+                <element name="vector_field">
+                  <a:documentation>Velocity of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Vloc</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_vector_field"/>
-                    </element>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Vloc</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_vector_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="vector_field">
-                    <a:documentation>Location of your far field, which is "melt_LayerLength" away from the ice.
+                </element>
+              </optional>
+              <optional>
+                <element name="vector_field">
+                  <a:documentation>Location of your far field, which is "melt_LayerLength" away from the ice.
 Location should be perpendicular to the ice-ocean boundary.
 melt_LayerLength = ||Location - Location_org||</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Location</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_vector_field"/>
-                    </element>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Location</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_vector_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="vector_field">
-                    <a:documentation>Location of your ice-ocean boundary.</a:documentation>
-                    <attribute name="rank">
-                      <value>0</value>
-                    </attribute>
-                    <attribute name="name">
-                      <value>Location_org</value>
-                    </attribute>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_vector_field"/>
-                    </element>
+                </element>
+              </optional>
+              <optional>
+                <element name="vector_field">
+                  <a:documentation>Location of your ice-ocean boundary.</a:documentation>
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>Location_org</value>
+                  </attribute>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_vector_field"/>
                   </element>
-                </optional>
-                <optional>
-                  <element name="calculate_boundaries">
-                    <a:documentation>Boundary stuff</a:documentation>
-                    <element name="string_value">
-                      <choice>
-                        <value>neumann</value>
-                        <value>dirichlet</value>
-                      </choice>
-                    </element>
+                </element>
+              </optional>
+              <optional>
+                <element name="calculate_boundaries">
+                  <a:documentation>Boundary stuff</a:documentation>
+                  <element name="string_value">
+                    <choice>
+                      <value>neumann</value>
+                      <value>dirichlet</value>
+                    </choice>
                   </element>
-                </optional>
-              </element>
-            </optional>
-          </element>
-        </optional>
-        <optional>
-          <element name="shelf">
-            <optional>
-              <element name="amplitude">
-                <a:documentation>Multiplying factor on equilibrium pressure</a:documentation>
-                <ref name="real"/>
-              </element>
-            </optional>
-            <optional>
-              <element name="y_sign">
-                <a:documentation>Change sign of depth / perturbation from original eta_0</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="calculate_only">
-                <a:documentation>Only calculate the field, don't add to pressure (RHS of Momentum)</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="salinity_change_constant">
-                <a:documentation>DeltaS for constant change over ocean,
-or the difference between min and max for a linear variation in S</a:documentation>
-                <ref name="real"/>
-              </element>
-            </optional>
-            <optional>
-              <element name="add_pressure_from_ice">
-                <a:documentation>If the ice shelf is not included in the original mesh and a free-surface initial condition is used to generate the shelf, the hydrostatic pressure where the shelf now exists needs to be included</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="include_density_change_of_ice">
-                <a:documentation>If using a linear variation in S, include the associated change in density of the ice shelf
-NOT arranged to work with add_pressure_from_ice - TODO</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-        </optional>
-        <optional>
-          <element name="external_data_boundary_conditions">
-            <a:documentation>Check this option to use an external data set for the t(0)
-and in/out boundary conditions. This sets up NEMO-type forcing.</a:documentation>
-            <element name="input_file">
-              <a:documentation>Path of the file containing the external data set</a:documentation>
-              <attribute name="file_name">
-                <data type="string"/>
-              </attribute>
+                </element>
+              </optional>
             </element>
+          </optional>
+        </element>
+      </optional>
+      <optional>
+        <element name="shelf">
+          <optional>
+            <element name="amplitude">
+              <a:documentation>Multiplying factor on equilibrium pressure</a:documentation>
+              <ref name="real"/>
+            </element>
+          </optional>
+          <optional>
+            <element name="y_sign">
+              <a:documentation>Change sign of depth / perturbation from original eta_0</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="calculate_only">
+              <a:documentation>Only calculate the field, don't add to pressure (RHS of Momentum)</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="salinity_change_constant">
+              <a:documentation>DeltaS for constant change over ocean,
+or the difference between min and max for a linear variation in S</a:documentation>
+              <ref name="real"/>
+            </element>
+          </optional>
+          <optional>
+            <element name="add_pressure_from_ice">
+              <a:documentation>If the ice shelf is not included in the original mesh and a free-surface initial condition is used to generate the shelf, the hydrostatic pressure where the shelf now exists needs to be included</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="include_density_change_of_ice">
+              <a:documentation>If using a linear variation in S, include the associated change in density of the ice shelf
+NOT arranged to work with add_pressure_from_ice - TODO</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+        </element>
+      </optional>
+      <optional>
+        <element name="external_data_boundary_conditions">
+          <a:documentation>Check this option to use an external data set for the t(0)
+and in/out boundary conditions. This sets up NEMO-type forcing.</a:documentation>
+          <element name="input_file">
+            <a:documentation>Path of the file containing the external data set</a:documentation>
+            <attribute name="file_name">
+              <data type="string"/>
+            </attribute>
           </element>
-        </optional>
-        <optional>
-          <element name="bulk_formulae">
-            <a:documentation>Bulk formulae allow the boundary conditions of Temperature, Velocity, Salinty
+        </element>
+      </optional>
+      <optional>
+        <element name="bulk_formulae">
+          <a:documentation>Bulk formulae allow the boundary conditions of Temperature, Velocity, Salinty
 and photosynthetic radiation to be set using data obtained from
 the ERA-40 reanalysis (http://data-portal.ecmwf.int/data/d/era40_daily/)</a:documentation>
-            <optional>
-              <element name="bulk_formulae">
-                <a:documentation>The type of bulk formulae to use. Default is NCAR if no selection is made.</a:documentation>
-                <choice>
-                  <element name="type">
-                    <a:documentation>Bulk formulae from Large and Yeager (2004)
+          <optional>
+            <element name="bulk_formulae">
+              <a:documentation>The type of bulk formulae to use. Default is NCAR if no selection is made.</a:documentation>
+              <choice>
+                <element name="type">
+                  <a:documentation>Bulk formulae from Large and Yeager (2004)
 Large, W. G. &amp; Yeager, S. G. Diurnal to decadal global forcing
 for ocean and sea-ice models: The data sets and flux climatologies. NCAR TR.</a:documentation>
-                    <attribute name="name">
-                      <value>NCAR</value>
-                    </attribute>
-                    <empty/>
-                  </element>
-                  <element name="type">
-                    <a:documentation>Bulk formulae from Fairall et al (2003).
+                  <attribute name="name">
+                    <value>NCAR</value>
+                  </attribute>
+                  <empty/>
+                </element>
+                <element name="type">
+                  <a:documentation>Bulk formulae from Fairall et al (2003).
 Bulk Parameterization of Air–Sea Fluxes: Updates and
 Verification for the COARE Algorithm Journal of Climate, 2003, 16, 571-591</a:documentation>
-                    <attribute name="name">
-                      <value>COARE</value>
-                    </attribute>
-                    <empty/>
-                  </element>
-                  <element name="type">
-                    <a:documentation>Bulk formulae from Kara et al (2005).
+                  <attribute name="name">
+                    <value>COARE</value>
+                  </attribute>
+                  <empty/>
+                </element>
+                <element name="type">
+                  <a:documentation>Bulk formulae from Kara et al (2005).
 Stability-Dependent Exchange Coefficients for Air–Sea Fluxes
 Journal of Atmospheric and Oceanic Technology, 2005, 22, 1080-1094</a:documentation>
-                    <attribute name="name">
-                      <value>Kara</value>
-                    </attribute>
-                    <empty/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-            <element name="input_file">
-              <a:documentation>The netCDF data file downloaded from ERA-40 reanalysis website
-(see above)</a:documentation>
-              <attribute name="file_name">
-                <data type="string"/>
-              </attribute>
+                  <attribute name="name">
+                    <value>Kara</value>
+                  </attribute>
+                  <empty/>
+                </element>
+              </choice>
             </element>
-            <optional>
-              <element name="input_file_type">
-                <choice>
-                  <element name="type">
-                    <a:documentation>What kind of file is this? Currently only ERA40 files are supported</a:documentation>
-                    <attribute name="name">
-                      <value>ERA40</value>
-                    </attribute>
-                    <optional>
-                      <element name="no_accumulation">
-                        <a:documentation>The data from ERA40 website included accumulated values (ppt, ro, ssrd, strd).
+          </optional>
+          <element name="input_file">
+            <a:documentation>The netCDF data file downloaded from ERA-40 reanalysis website
+(see above)</a:documentation>
+            <attribute name="file_name">
+              <data type="string"/>
+            </attribute>
+          </element>
+          <optional>
+            <element name="input_file_type">
+              <choice>
+                <element name="type">
+                  <a:documentation>What kind of file is this? Currently only ERA40 files are supported</a:documentation>
+                  <attribute name="name">
+                    <value>ERA40</value>
+                  </attribute>
+                  <optional>
+                    <element name="no_accumulation">
+                      <a:documentation>The data from ERA40 website included accumulated values (ppt, ro, ssrd, strd).
 If these values have been already ammended to instantaneous values, then switch this
 flag on and the accumulation correction will not be applied.</a:documentation>
-                        <empty/>
-                      </element>
-                    </optional>
-                  </element>
-                  <element name="type">
-                    <attribute name="name">
-                      <value>NSEP</value>
-                    </attribute>
-                    <empty/>
-                  </element>
-                  <element name="type">
-                    <attribute name="name">
-                      <value>ICOM</value>
-                    </attribute>
-                    <empty/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-            <optional>
-              <element name="position">
-                <a:documentation>Adding a latitude and longitude here (specified as two real numbers)
+                      <empty/>
+                    </element>
+                  </optional>
+                </element>
+                <element name="type">
+                  <attribute name="name">
+                    <value>NSEP</value>
+                  </attribute>
+                  <empty/>
+                </element>
+                <element name="type">
+                  <attribute name="name">
+                    <value>ICOM</value>
+                  </attribute>
+                  <empty/>
+                </element>
+              </choice>
+            </element>
+          </optional>
+          <optional>
+            <element name="position">
+              <a:documentation>Adding a latitude and longitude here (specified as two real numbers)
 will obtain data from the forcing file at that location. The
 mesh is not translated nor is the mesh put on the sphere, instead the
 specified lat/long is translated into cartesian coordinates and this is simply
 added to the surface mesh node coordinates when fluxes are calculated.</a:documentation>
-                <ref name="real_vector"/>
-                <optional>
-                  <element name="single_location">
-                    <a:documentation>Turning on this option will cause all nodes on the surface mesh to
+              <ref name="real_vector"/>
+              <optional>
+                <element name="single_location">
+                  <a:documentation>Turning on this option will cause all nodes on the surface mesh to
 experience the same forcing, regardless of position. Only really
 useful for psuedo-1D simulations.</a:documentation>
-                    <empty/>
-                  </element>
-                </optional>
-              </element>
-            </optional>
-            <element name="output_fluxes_diagnostics">
-              <a:documentation>Ouput some extra diagnostic fields for the momentum, temperature and salinity fluxes
-These &lt;b&gt;must&lt;/b&gt; be on the velocity mesh</a:documentation>
-              <optional>
-                <element name="vector_field">
-                  <attribute name="rank">
-                    <value>1</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>MomentumFlux</value>
-                  </attribute>
-                  <choice>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
-                    <element name="aliased">
-                      <ref name="generic_aliased_field"/>
-                    </element>
-                  </choice>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>HeatFlux</value>
-                  </attribute>
-                  <choice>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
-                    <element name="aliased">
-                      <ref name="generic_aliased_field"/>
-                    </element>
-                  </choice>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>SalinityFlux</value>
-                  </attribute>
-                  <choice>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
-                    <element name="aliased">
-                      <ref name="generic_aliased_field"/>
-                    </element>
-                  </choice>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>PhotosyntheticRadiationDownward</value>
-                  </attribute>
-                  <choice>
-                    <element name="diagnostic">
-                      <ref name="internal_algorithm"/>
-                      <ref name="velocity_mesh_choice"/>
-                      <ref name="diagnostic_scalar_field"/>
-                    </element>
-                    <element name="aliased">
-                      <ref name="generic_aliased_field"/>
-                    </element>
-                  </choice>
+                  <empty/>
                 </element>
               </optional>
             </element>
-          </element>
-        </optional>
-        <optional>
-          <element name="tidal_forcing">
-            <a:documentation>Tidal forcing options</a:documentation>
+          </optional>
+          <element name="output_fluxes_diagnostics">
+            <a:documentation>Ouput some extra diagnostic fields for the momentum, temperature and salinity fluxes
+These &lt;b&gt;must&lt;/b&gt; be on the velocity mesh</a:documentation>
             <optional>
-              <element name="M2">
-                <a:documentation>M2</a:documentation>
-                <optional>
-                  <element name="frequency">
-                    <a:documentation>Ancient frequencies:
+              <element name="vector_field">
+                <attribute name="rank">
+                  <value>1</value>
+                </attribute>
+                <attribute name="name">
+                  <value>MomentumFlux</value>
+                </attribute>
+                <choice>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
+                  </element>
+                  <element name="aliased">
+                    <ref name="generic_aliased_field"/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+            <optional>
+              <element name="scalar_field">
+                <attribute name="rank">
+                  <value>0</value>
+                </attribute>
+                <attribute name="name">
+                  <value>HeatFlux</value>
+                </attribute>
+                <choice>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
+                  </element>
+                  <element name="aliased">
+                    <ref name="generic_aliased_field"/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+            <optional>
+              <element name="scalar_field">
+                <attribute name="rank">
+                  <value>0</value>
+                </attribute>
+                <attribute name="name">
+                  <value>SalinityFlux</value>
+                </attribute>
+                <choice>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
+                  </element>
+                  <element name="aliased">
+                    <ref name="generic_aliased_field"/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+            <optional>
+              <element name="scalar_field">
+                <attribute name="rank">
+                  <value>0</value>
+                </attribute>
+                <attribute name="name">
+                  <value>PhotosyntheticRadiationDownward</value>
+                </attribute>
+                <choice>
+                  <element name="diagnostic">
+                    <ref name="internal_algorithm"/>
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="diagnostic_scalar_field"/>
+                  </element>
+                  <element name="aliased">
+                    <ref name="generic_aliased_field"/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+          </element>
+        </element>
+      </optional>
+      <optional>
+        <element name="tidal_forcing">
+          <a:documentation>Tidal forcing options</a:documentation>
+          <optional>
+            <element name="M2">
+              <a:documentation>M2</a:documentation>
+              <optional>
+                <element name="frequency">
+                  <a:documentation>Ancient frequencies:
 
 Ma     Frequency
 
@@ -9027,12 +9022,12 @@ Ma     Frequency
 570    1.469e-4
 
 From Poliakow,2005</a:documentation>
-                    <ref name="real"/>
-                  </element>
-                </optional>
-                <optional>
-                  <element name="amplitude">
-                    <a:documentation>Ma     Amplitude
+                  <ref name="real"/>
+                </element>
+              </optional>
+              <optional>
+                <element name="amplitude">
+                  <a:documentation>Ma     Amplitude
 
 0        0.2423
 
@@ -9057,124 +9052,169 @@ From Poliakow,2005</a:documentation>
 570    0.2560
 
 From Poliakow,2005</a:documentation>
-                    <ref name="real"/>
-                  </element>
-                </optional>
-              </element>
-            </optional>
-            <optional>
-              <element name="S2">
-                <a:documentation>S2</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="N2">
-                <a:documentation>N2</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="K2">
-                <a:documentation>K2</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="K1">
-                <a:documentation>K1</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="O1">
-                <a:documentation>O1</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="P1">
-                <a:documentation>P1</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="Q1">
-                <a:documentation>Q1</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="Mf">
-                <a:documentation>Mf</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="Mm">
-                <a:documentation>Mm</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="Ssa">
-                <a:documentation>Ssa</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="all_tidal_components">
-                <a:documentation>Switch on all tidal components</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="love_number">
-                <a:documentation>Sets a user defined Love number. If not active a value of 1.0 is used.
+                  <ref name="real"/>
+                </element>
+              </optional>
+            </element>
+          </optional>
+          <optional>
+            <element name="S2">
+              <a:documentation>S2</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="N2">
+              <a:documentation>N2</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="K2">
+              <a:documentation>K2</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="K1">
+              <a:documentation>K1</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="O1">
+              <a:documentation>O1</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="P1">
+              <a:documentation>P1</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="Q1">
+              <a:documentation>Q1</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="Mf">
+              <a:documentation>Mf</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="Mm">
+              <a:documentation>Mm</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="Ssa">
+              <a:documentation>Ssa</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="all_tidal_components">
+              <a:documentation>Switch on all tidal components</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="love_number">
+              <a:documentation>Sets a user defined Love number. If not active a value of 1.0 is used.
 Recommended value is 0.693</a:documentation>
-                <element name="value">
-                  <ref name="real"/>
-                </element>
+              <element name="value">
+                <ref name="real"/>
               </element>
-            </optional>
-            <optional>
-              <element name="sal">
-                <a:documentation>Self attraction and loading term (SAL). This is a simple implementation
+            </element>
+          </optional>
+          <optional>
+            <element name="sal">
+              <a:documentation>Self attraction and loading term (SAL). This is a simple implementation
 that uses a constant beta value</a:documentation>
-                <element name="beta">
-                  <ref name="real"/>
-                </element>
+              <element name="beta">
+                <ref name="real"/>
               </element>
-            </optional>
-            <optional>
-              <element name="chi">
-                <a:documentation>Add the CHI term to the harmonics. You probably only want to do this is you're simulating a specific time</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-        </optional>
-      </element>
-    </define>
-    <define name="biology">
-      <element name="ocean_biology">
-        <a:documentation>Model of biological processes in the ocean.</a:documentation>
-        <choice>
-          <element name="pznd">
-            <a:documentation>A simple model of phytoplankton, zooplankton, general nutrient and detritus.</a:documentation>
-            <choice>
-              <element name="source_and_sink_algorithm">
-                <a:documentation>Python code specifying the source and sink relationships
+            </element>
+          </optional>
+          <optional>
+            <element name="chi">
+              <a:documentation>Add the CHI term to the harmonics. You probably only want to do this is you're simulating a specific time</a:documentation>
+              <empty/>
+            </element>
+          </optional>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="biology">
+    <element name="ocean_biology">
+      <a:documentation>Model of biological processes in the ocean.</a:documentation>
+      <choice>
+        <element name="pznd">
+          <a:documentation>A simple model of phytoplankton, zooplankton, general nutrient and detritus.</a:documentation>
+          <choice>
+            <element name="source_and_sink_algorithm">
+              <a:documentation>Python code specifying the source and sink relationships
 between the biological tracers. This is usually achieved by
 importing fluidity.ocean_biology and calling a scheme from there.</a:documentation>
-                <ref name="python_code"/>
-              </element>
-              <element name="disable_sources_and_sinks">
-                <a:documentation>Do not calculate sources and sinks.
+              <ref name="python_code"/>
+            </element>
+            <element name="disable_sources_and_sinks">
+              <a:documentation>Do not calculate sources and sinks.
 This option is generally only useful for testing.</a:documentation>
-                <empty/>
+              <empty/>
+            </element>
+          </choice>
+          <element name="scalar_field">
+            <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
+            <attribute name="rank">
+              <value>0</value>
+            </attribute>
+            <attribute name="name">
+              <value>PhotosyntheticRadiation</value>
+            </attribute>
+            <choice>
+              <element name="prognostic">
+                <ref name="velocity_mesh_choice"/>
+                <ref name="prognostic_photosynthetic_radiation"/>
+              </element>
+              <element name="prescribed">
+                <ref name="velocity_mesh_choice"/>
+                <ref name="prescribed_scalar_field"/>
               </element>
             </choice>
+          </element>
+        </element>
+        <element name="six_component">
+          <a:documentation>6 component biology model, which models Nitrates, Ammonium,
+Phytoplankton, Zooplankton, Detritus and Chlorophyll.
+
+These fields must be enabled in the material phase
+
+Based on the equations in
+Popova, E. E.; Coward, A. C.; Nurser, G. A.; de Cuevas, B.; Fasham, M. J. R. &amp; Anderson, T. R.
+Mechanisms controlling primary and new production in a global ecosystem model - Part I:
+Validation of the biological simulation Ocean Science, 2006, 2, 249-266.
+DOI: 10.5194/os-2-249-2006</a:documentation>
+          <choice>
+            <element name="source_and_sink_algorithm">
+              <a:documentation>Python code specifying the biology model. This takes
+in velocity and light and outputs Phytoplankton, if
+those fields exist.</a:documentation>
+              <ref name="python_code"/>
+            </element>
+            <element name="disable_sources_and_sinks">
+              <a:documentation>Do not calculate biology
+This option is generally only useful for testing.</a:documentation>
+              <empty/>
+            </element>
+          </choice>
+          <optional>
             <element name="scalar_field">
               <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
               <attribute name="rank">
@@ -9194,165 +9234,120 @@ This option is generally only useful for testing.</a:documentation>
                 </element>
               </choice>
             </element>
-          </element>
-          <element name="six_component">
-            <a:documentation>6 component biology model, which models Nitrates, Ammonium,
-Phytoplankton, Zooplankton, Detritus and Chlorophyll.
-
-These fields must be enabled in the material phase
-
-Based on the equations in
-Popova, E. E.; Coward, A. C.; Nurser, G. A.; de Cuevas, B.; Fasham, M. J. R. &amp; Anderson, T. R.
-Mechanisms controlling primary and new production in a global ecosystem model - Part I:
-Validation of the biological simulation Ocean Science, 2006, 2, 249-266.
-DOI: 10.5194/os-2-249-2006</a:documentation>
-            <choice>
-              <element name="source_and_sink_algorithm">
-                <a:documentation>Python code specifying the biology model. This takes
-in velocity and light and outputs Phytoplankton, if
-those fields exist.</a:documentation>
-                <ref name="python_code"/>
-              </element>
-              <element name="disable_sources_and_sinks">
-                <a:documentation>Do not calculate biology
-This option is generally only useful for testing.</a:documentation>
-                <empty/>
-              </element>
-            </choice>
-            <optional>
-              <element name="scalar_field">
-                <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
-                <attribute name="rank">
-                  <value>0</value>
-                </attribute>
-                <attribute name="name">
-                  <value>PhotosyntheticRadiation</value>
-                </attribute>
-                <choice>
-                  <element name="prognostic">
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="prognostic_photosynthetic_radiation"/>
-                  </element>
-                  <element name="prescribed">
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="prescribed_scalar_field"/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-          </element>
-        </choice>
-      </element>
-    </define>
-    <define name="prognostic_photosynthetic_radiation">
-      <element name="equation">
-        <a:documentation>PAR equation.</a:documentation>
-        <attribute name="name">
-          <value>PhotosyntheticRadiation</value>
-        </attribute>
-      </element>
-      <element name="spatial_discretisation">
-        <a:documentation>Spatial discretisation options</a:documentation>
-        <element name="discontinuous_galerkin">
-          <a:documentation>Discontinuous galerkin formulation. You can also use this
+          </optional>
+        </element>
+      </choice>
+    </element>
+  </define>
+  <define name="prognostic_photosynthetic_radiation">
+    <element name="equation">
+      <a:documentation>PAR equation.</a:documentation>
+      <attribute name="name">
+        <value>PhotosyntheticRadiation</value>
+      </attribute>
+    </element>
+    <element name="spatial_discretisation">
+      <a:documentation>Spatial discretisation options</a:documentation>
+      <element name="discontinuous_galerkin">
+        <a:documentation>Discontinuous galerkin formulation. You can also use this
 formulation with a continuous field in which case a simple
 galerkin formulation will result.</a:documentation>
-          <empty/>
-        </element>
+        <empty/>
       </element>
-      <element name="solver">
-        <a:documentation>Solver</a:documentation>
-        <ref name="linear_solver_options_asym_scalar"/>
-      </element>
-      <!-- Alas, no initial_condition either, so we'd better not checkpoint it... -->
-      <element name="exclude_from_checkpointing">
-        <a:documentation>Disables checkpointing of this field</a:documentation>
-        <ref name="comment"/>
-      </element>
-      <element name="absorption_coefficients">
-        <a:documentation>Coefficients of absorption of photosynthetically active
+    </element>
+    <element name="solver">
+      <a:documentation>Solver</a:documentation>
+      <ref name="linear_solver_options_asym_scalar"/>
+    </element>
+    <!-- Alas, no initial_condition either, so we'd better not checkpoint it... -->
+    <element name="exclude_from_checkpointing">
+      <a:documentation>Disables checkpointing of this field</a:documentation>
+      <ref name="comment"/>
+    </element>
+    <element name="absorption_coefficients">
+      <a:documentation>Coefficients of absorption of photosynthetically active
 radiation for water and phytoplankton.</a:documentation>
-        <element name="water">
-          <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
-          <ref name="real"/>
-        </element>
-        <element name="phytoplankton">
-          <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
-          <ref name="real"/>
-        </element>
+      <element name="water">
+        <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
+        <ref name="real"/>
       </element>
-      <optional>
-        <element name="boundary_conditions">
-          <a:documentation>Boundary conditions</a:documentation>
-          <attribute name="name">
-            <data type="string" datatypeLibrary=""/>
-          </attribute>
-          <element name="surface_ids">
-            <a:documentation>Surface id:</a:documentation>
-            <ref name="integer_vector"/>
-          </element>
-          <choice>
-            <a:documentation>Type</a:documentation>
-            <element name="type">
-              <attribute name="name">
-                <value>dirichlet</value>
-              </attribute>
-              <element name="apply_weakly">
-                <a:documentation>Apply the dirichlet bc weakly.  Only available with
+      <element name="phytoplankton">
+        <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
+        <ref name="real"/>
+      </element>
+    </element>
+    <optional>
+      <element name="boundary_conditions">
+        <a:documentation>Boundary conditions</a:documentation>
+        <attribute name="name">
+          <data type="string" datatypeLibrary=""/>
+        </attribute>
+        <element name="surface_ids">
+          <a:documentation>Surface id:</a:documentation>
+          <ref name="integer_vector"/>
+        </element>
+        <choice>
+          <a:documentation>Type</a:documentation>
+          <element name="type">
+            <attribute name="name">
+              <value>dirichlet</value>
+            </attribute>
+            <element name="apply_weakly">
+              <a:documentation>Apply the dirichlet bc weakly.  Only available with
 discontinuous_galerkin and control_volume
 spatial_discretisations.
 
 If not selected boundary conditions are applied strongly.</a:documentation>
-                <empty/>
-              </element>
-              <ref name="input_choice_real"/>
-            </element>
-            <element name="type">
-              <attribute name="name">
-                <value>bulk_formulae</value>
-              </attribute>
               <empty/>
             </element>
-            <element name="type">
-              <attribute name="name">
-                <value>neumann</value>
-              </attribute>
-              <ref name="input_choice_real"/>
-            </element>
-          </choice>
-        </element>
-      </optional>
-      <ref name="prognostic_scalar_output_options"/>
-      <ref name="prognostic_scalar_stat_options"/>
-      <ref name="scalar_convergence_options"/>
-      <ref name="prognostic_detector_options"/>
-      <ref name="scalar_steady_state_options"/>
-      <ref name="adaptivity_options_scalar_field"/>
-      <optional>
-        <element name="priority">
-          <a:documentation>Set the priority of this field
+            <ref name="input_choice_real"/>
+          </element>
+          <element name="type">
+            <attribute name="name">
+              <value>bulk_formulae</value>
+            </attribute>
+            <empty/>
+          </element>
+          <element name="type">
+            <attribute name="name">
+              <value>neumann</value>
+            </attribute>
+            <ref name="input_choice_real"/>
+          </element>
+        </choice>
+      </element>
+    </optional>
+    <ref name="prognostic_scalar_output_options"/>
+    <ref name="prognostic_scalar_stat_options"/>
+    <ref name="scalar_convergence_options"/>
+    <ref name="prognostic_detector_options"/>
+    <ref name="scalar_steady_state_options"/>
+    <ref name="adaptivity_options_scalar_field"/>
+    <optional>
+      <element name="priority">
+        <a:documentation>Set the priority of this field
 This determines the order in which scalar_fields are solved for:
  - higher numbers have the highest priority
  - lower numbers (including negative) have the lowest priority
  - default if not set is 0</a:documentation>
-          <ref name="integer"/>
-        </element>
-      </optional>
-    </define>
-    <define name="recalculation_options">
-      <element name="do_not_recalculate">
-        <a:documentation>Prevent this field from being recalculated at every timestep.
-This is cheaper especially if you are enforcing discrete properties on the field.</a:documentation>
-        <empty/>
+        <ref name="integer"/>
       </element>
-    </define>
-    <define name="discrete_properties_algorithm_scalar">
-      <element name="enforce_discrete_properties">
-        <a:documentation>Select discrete properties to enforce on the field
+    </optional>
+  </define>
+  <define name="recalculation_options">
+    <element name="do_not_recalculate">
+      <a:documentation>Prevent this field from being recalculated at every timestep.
+This is cheaper especially if you are enforcing discrete properties on the field.</a:documentation>
+      <empty/>
+    </element>
+  </define>
+  <define name="discrete_properties_algorithm_scalar">
+    <element name="enforce_discrete_properties">
+      <a:documentation>Select discrete properties to enforce on the field
 either after being prescribed or interpolated</a:documentation>
-        <optional>
-          <element name="solenoidal_lagrange_update">
-            <a:documentation>Update this field using the lagrangian multiplier
+      <optional>
+        <element name="solenoidal_lagrange_update">
+          <a:documentation>Update this field using the lagrangian multiplier
 calculated in the solenoidal projection of a
 scalar field.
 
@@ -9361,23 +9356,23 @@ underneath that vector field too.
 
 Note also this only really makes sense for coupled
 fields like velocity and pressure.</a:documentation>
-            <empty/>
-          </element>
-        </optional>
-      </element>
-    </define>
-    <define name="discrete_properties_algorithm_vector">
-      <element name="enforce_discrete_properties">
-        <a:documentation>Select discrete properties to enforce on the field
+          <empty/>
+        </element>
+      </optional>
+    </element>
+  </define>
+  <define name="discrete_properties_algorithm_vector">
+    <element name="enforce_discrete_properties">
+      <a:documentation>Select discrete properties to enforce on the field
 either after being prescribed or interpolated</a:documentation>
-        <optional>
-          <ref name="solenoidal_options"/>
-        </optional>
-      </element>
-    </define>
-    <define name="solenoidal_options">
-      <element name="solenoidal">
-        <a:documentation>Constrained divergence-free projection.
+      <optional>
+        <ref name="solenoidal_options"/>
+      </optional>
+    </element>
+  </define>
+  <define name="solenoidal_options">
+    <element name="solenoidal">
+      <a:documentation>Constrained divergence-free projection.
 This adds an additional constraint that ensures that the field
 is solenoidal, i.e. divergence-free.
 This is equivalent in cost to a pressure solve.
@@ -9386,94 +9381,108 @@ needed.
 
 Note well: this only makes sense for nondivergent
 vector fields, such as incompressible velocity!</a:documentation>
-        <element name="interpolated_field">
-          <a:documentation>Options for the mass matrix of the field being interpolated</a:documentation>
-          <choice>
-            <element name="continuous">
-              <element name="lump_mass_matrix">
-                <a:documentation>Lump the mass matrix for the assembly of the projection matrix
+      <element name="interpolated_field">
+        <a:documentation>Options for the mass matrix of the field being interpolated</a:documentation>
+        <choice>
+          <element name="continuous">
+            <element name="lump_mass_matrix">
+              <a:documentation>Lump the mass matrix for the assembly of the projection matrix
 (not for the initial galerkin projection)
 
 Required when using interpolating continuous fields</a:documentation>
-                <optional>
-                  <element name="use_submesh">
-                    <a:documentation>Lump on the submesh.
+              <optional>
+                <element name="use_submesh">
+                  <a:documentation>Lump on the submesh.
 This only works for simplex meshes and is only
 strictly valid on 2d meshes.</a:documentation>
-                    <empty/>
-                  </element>
-                </optional>
-              </element>
-            </element>
-            <element name="discontinuous">
-              <optional>
-                <element name="lump_mass_matrix">
-                  <a:documentation>Lump the mass matrix for the assembly of the projection matrix
-(not for the initial galerkin projection)</a:documentation>
                   <empty/>
                 </element>
               </optional>
             </element>
-          </choice>
-        </element>
-        <element name="lagrange_multiplier">
-          <a:documentation>Options for the lagrange multiplier
+          </element>
+          <element name="discontinuous">
+            <optional>
+              <element name="lump_mass_matrix">
+                <a:documentation>Lump the mass matrix for the assembly of the projection matrix
+(not for the initial galerkin projection)</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+        </choice>
+      </element>
+      <element name="lagrange_multiplier">
+        <a:documentation>Options for the lagrange multiplier
 
 Must be on a continuous mesh!</a:documentation>
-          <ref name="pressure_mesh_choice"/>
-          <element name="spatial_discretisation">
-            <choice>
-              <element name="continuous_galerkin">
-                <optional>
-                  <element name="remove_stabilisation_term">
-                    <a:documentation>Remove the stabilisation term from the projection operator.
+        <ref name="pressure_mesh_choice"/>
+        <element name="spatial_discretisation">
+          <choice>
+            <element name="continuous_galerkin">
+              <optional>
+                <element name="remove_stabilisation_term">
+                  <a:documentation>Remove the stabilisation term from the projection operator.
 
 Automatic when not using P1P1.</a:documentation>
-                    <empty/>
-                  </element>
-                </optional>
-                <optional>
-                  <element name="integrate_divergence_by_parts">
-                    <a:documentation>Integrate the divergence operator by parts.
+                  <empty/>
+                </element>
+              </optional>
+              <optional>
+                <element name="integrate_divergence_by_parts">
+                  <a:documentation>Integrate the divergence operator by parts.
 
 Automatic when projecting a discontinuous field</a:documentation>
-                    <empty/>
-                  </element>
-                </optional>
-                <optional>
-                  <element name="test_divergence_with_cv_dual">
-                    <a:documentation>Test the divergence equation with the control volume dual mesh
+                  <empty/>
+                </element>
+              </optional>
+              <optional>
+                <element name="test_divergence_with_cv_dual">
+                  <a:documentation>Test the divergence equation with the control volume dual mesh
 of the finite element lagrange multiplier mesh.
 This will make the lagrange multiplier matrix non symmetric which must be
 considered when selecting the lagrange multiplier  solver options.</a:documentation>
-                    <ref name="comment"/>
-                  </element>
-                </optional>
-              </element>
-              <element name="control_volumes">
-                <empty/>
-              </element>
-            </choice>
-          </element>
-          <optional>
-            <element name="reference_node">
-              <ref name="integer"/>
+                  <ref name="comment"/>
+                </element>
+              </optional>
             </element>
-          </optional>
-          <optional>
-            <element name="repair_stiff_nodes">
-              <a:documentation>**UNDER DEVELOPMENT**
+            <element name="control_volumes">
+              <empty/>
+            </element>
+          </choice>
+        </element>
+        <optional>
+          <element name="reference_node">
+            <ref name="integer"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="repair_stiff_nodes">
+            <a:documentation>**UNDER DEVELOPMENT**
 This searches the CMC matrix diagonal looking for nodes that are less than the maximum value time epsilon(0.0) (i.e. nodes that are effectively zero).
 It then zeros that row and column and places a one on the diagonal and a zero on the rhs.
 At a debug level of 2 it also prints out the value and the sum of the row values.
 This is useful as a debugging tool if PETSc complains about zeros on the diagonal (i.e. if you have a stiff node in your mesh) but doesn't necessary produce nice answers at the end.</a:documentation>
+            <empty/>
+          </element>
+        </optional>
+        <optional>
+          <choice>
+            <element name="update_scalar_field">
+              <a:documentation>Update a scalar field using the lagrange multiplier from
+the divergence free projection of this field.  The selected
+scalar field must have solenoidal selected in its interpolation
+options too and it must be on the same mesh as used for the
+solenoidal projection above.
+
+Note well: this only really makes sense for scalar fields linked to nondivergent
+vector fields, such as pressure to incompressible velocity!</a:documentation>
+              <attribute name="name">
+                <value>Pressure</value>
+              </attribute>
               <empty/>
             </element>
-          </optional>
-          <optional>
-            <choice>
-              <element name="update_scalar_field">
-                <a:documentation>Update a scalar field using the lagrange multiplier from
+            <element name="update_scalar_field">
+              <a:documentation>Update a scalar field using the lagrange multiplier from
 the divergence free projection of this field.  The selected
 scalar field must have solenoidal selected in its interpolation
 options too and it must be on the same mesh as used for the
@@ -9481,41 +9490,27 @@ solenoidal projection above.
 
 Note well: this only really makes sense for scalar fields linked to nondivergent
 vector fields, such as pressure to incompressible velocity!</a:documentation>
-                <attribute name="name">
-                  <value>Pressure</value>
-                </attribute>
-                <empty/>
-              </element>
-              <element name="update_scalar_field">
-                <a:documentation>Update a scalar field using the lagrange multiplier from
-the divergence free projection of this field.  The selected
-scalar field must have solenoidal selected in its interpolation
-options too and it must be on the same mesh as used for the
-solenoidal projection above.
-
-Note well: this only really makes sense for scalar fields linked to nondivergent
-vector fields, such as pressure to incompressible velocity!</a:documentation>
-                <attribute name="name">
-                  <data type="string" datatypeLibrary=""/>
-                </attribute>
-                <empty/>
-              </element>
-            </choice>
-          </optional>
-          <element name="solver">
-            <a:documentation>Solver options for the linear solve.
+              <attribute name="name">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <empty/>
+            </element>
+          </choice>
+        </optional>
+        <element name="solver">
+          <a:documentation>Solver options for the linear solve.
 This method requires the inversion of a projection matrix.</a:documentation>
-            <ref name="linear_solver_options_sym"/>
-          </element>
+          <ref name="linear_solver_options_sym"/>
         </element>
       </element>
-    </define>
-    <define name="represcribe_before_interpolation">
-      <element name="represcribe_before_interpolation">
-        <a:documentation>Represcribe the field before interpolation.
+    </element>
+  </define>
+  <define name="represcribe_before_interpolation">
+    <element name="represcribe_before_interpolation">
+      <a:documentation>Represcribe the field before interpolation.
 
 This means the interpolation will not be conservative from the previous mesh so be careful what you're trying to achieve!</a:documentation>
-        <empty/>
-      </element>
-    </define>
-  </grammar>
+      <empty/>
+    </element>
+  </define>
+</grammar>

--- a/schemas/fluidity_options.rng
+++ b/schemas/fluidity_options.rng
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+  xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <include href="spud_base.rng"/>
   <include href="adaptivity_options.rng"/>
   <include href="diagnostic_algorithms.rng"/>
@@ -73,7 +74,7 @@ A value of 0.0 indicates that there would be a dump at every timestep.</a:docume
     # Function code
     return # Return value
 
-</a:documentation>
+                </a:documentation>
                 <ref name="python_code"/>
               </element>
             </choice>
@@ -94,7 +95,7 @@ A value of 0 indicates a dump at every timestep.</a:documentation>
     # Function code
     return # Return value
 
-</a:documentation>
+                </a:documentation>
                 <ref name="python_code"/>
               </element>
             </choice>
@@ -313,7 +314,7 @@ Note that the main option to control the log output is given on the command line
 -v1  also give "navigational information", to indicate where in the code we currently are
 
 -v2  also give any additional information (mins and maxes of fields, etc.)
-</a:documentation>
+            </a:documentation>
             <optional>
               <element name="memory_diagnostics">
                 <a:documentation>Log all allocates and deallocates done for meshes, fields, sparsities and matrices.
@@ -359,7 +360,7 @@ calculations and spawning and deleting options.</a:documentation>
  def val(t):
     # Function code
     return # Return value
-</a:documentation>
+                              </a:documentation>
                               <ref name="python_code"/>
                             </element>
                           </choice>
@@ -376,7 +377,7 @@ calculations and spawning and deleting options.</a:documentation>
  def val(t):
     # Function code
     return # Return value
-</a:documentation>
+                              </a:documentation>
                               <ref name="python_code"/>
                             </element>
                           </choice>
@@ -535,7 +536,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_scalar_particle_attribute_choice"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_scalar_particle_attribute_choice"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_scalar_particle_attribute_choice"/>
+                              </element>
                             </element>
                             <element name="scalar_attribute_array">
                               <a:documentation>Scalar particle attribute array.</a:documentation>
@@ -551,7 +561,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_scalar_particle_attribute_array"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_scalar_particle_attribute_array"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_scalar_particle_attribute_array"/>
+                              </element>
                             </element>
                             <element name="vector_attribute">
                               <a:documentation>Vector particle attribute.</a:documentation>
@@ -564,7 +583,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_vector_particle_attribute_choice"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_vector_particle_attribute_choice"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_vector_particle_attribute_choice"/>
+                              </element>
                             </element>
                             <element name="vector_attribute_array">
                               <a:documentation>Vector particle attribute array.</a:documentation>
@@ -580,7 +608,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_vector_particle_attribute_array"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_vector_particle_attribute_array"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_vector_particle_attribute_array"/>
+                              </element>
                             </element>
                             <element name="tensor_attribute">
                               <a:documentation>Tensor particle attribute.</a:documentation>
@@ -593,7 +630,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_tensor_particle_attribute_choice"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_tensor_particle_attribute_choice"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_tensor_particle_attribute_choice"/>
+                              </element>
                             </element>
                             <element name="tensor_attribute_array">
                               <a:documentation>Tensor particle attribute array.</a:documentation>
@@ -609,7 +655,16 @@ This function will only be called after simulation start. To initialise starting
                                   <empty/>
                                 </element>
                               </optional>
-                              <ref name="generic_tensor_particle_attribute_array"/>
+                              <optional>
+                                <element name="value_on_spawn">
+                                  <a:documentation>Attribute value on particle spawn (at the beginning of, or during the simulation)</a:documentation>
+                                  <ref name="generic_tensor_particle_attribute_array"/>
+                                </element>
+                              </optional>
+                              <element name="value_on_advection">
+                                <a:documentation>Attribute value at each timestep after advection occurs</a:documentation>
+                                <ref name="generic_tensor_particle_attribute_array"/>
+                              </element>
                             </element>
                           </choice>
                         </oneOrMore>
@@ -3347,9 +3402,7 @@ parts.</a:documentation>
         </element>
       </choice>
       <element name="conservative_advection">
-        <a:documentation>Conservative discretisation of field advection equation
- TBETA=1. -- conservative (divergence form)
- TBETA=0. -- non-conservative
+        <a:documentation>Conservative discretisation of field advection equation TBETA=1. -- conservative (divergence form) TBETA=0. -- non-conservative
  0. &lt; TBETA &lt; 1.</a:documentation>
         <ref name="real"/>
       </element>
@@ -4182,8 +4235,7 @@ this requires a Density field!</a:documentation>
           <optional>
             <element name="external_density">
               <a:documentation>When selected a hydrostatic pressure distribution on the outside is assumed
-using the specified density, i.e. instead of applying p=0 (resp.
-normal_stress=0) we apply p=p_external (resp. normal_stress=p_external) where p_external is determined by dp_external/dz=external_density*g</a:documentation>
+using the specified density, i.e. instead of applying p=0 (resp. normal_stress=0) we apply p=p_external (resp. normal_stress=p_external) where p_external is determined by dp_external/dz=external_density*g</a:documentation>
               <ref name="input_choice_real_plus_field"/>
             </element>
           </optional>
@@ -4946,7 +4998,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -4999,7 +5052,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5061,7 +5115,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5122,7 +5177,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5179,7 +5235,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -5245,7 +5302,8 @@ if the store_old_attribute or store_old_field options are enabled.</a:documentat
         <ref name="python_code"/>
         <optional>
           <element name="store_old_attribute">
-            <a:documentation>Store attribute values from previous timestep on particles.</a:documentation>
+            <a:documentation>Store attribute values from previous timestep on particles.
+Irrelevant for "value_on_spawn".</a:documentation>
             <ref name="comment"/>
           </element>
         </optional>
@@ -6075,7 +6133,7 @@ lambda = 1.71/(bubble_radius)^2</a:documentation>
         </choice>
       </element>
       <!--
-        
+
         Insert new prescribed scalar fields here using the template:
                element scalar_field {
                    attribute rank { "0" },
@@ -6090,11 +6148,11 @@ lambda = 1.71/(bubble_radius)^2</a:documentation>
                       }
                    )
                }
-        
+
         - - Last is a list of fields that are primarily diagnostic,
            but can be aliased. An example is Tidal Range.
         - - The list is in order of most frequently used.
-        
+
       -->
       <element name="___Diagnostic_Fields_Below___">
         <a:documentation>Diagnostic scalar fields below this</a:documentation>
@@ -6661,7 +6719,7 @@ Uses the gravity field direction to determine the horizontal plane.</a:documenta
         <a:documentation>Velocity divergence:
 
 div velocity
-</a:documentation>
+        </a:documentation>
         <attribute name="rank">
           <value>0</value>
         </attribute>
@@ -7194,64 +7252,68 @@ Sums up the divergence of each phase's apparent velocity, i.e. \sum{ div(vfrac*u
             <element name="test_with_cv_dual">
               <a:documentation>Test the divergence operator with the CV dual function space.
 This is useful if the pressure is solved with a CV discretisation
+                <<<<<<< HEAD
 or with a CG but with the continuity tested with the CV dual.</a:documentation>
+=======
+or with a CG but with the continuity tested with the CV dual. </a:documentation>
+>>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
               <ref name="comment"/>
+              </element>
+            </optional>
+            <ref name="diagnostic_scalar_field_no_adapt"/>
+            <element name="solver">
+              <ref name="linear_solver_options_sym"/>
             </element>
-          </optional>
-          <ref name="diagnostic_scalar_field_no_adapt"/>
-          <element name="solver">
-            <ref name="linear_solver_options_sym"/>
           </element>
         </element>
-      </element>
-      <element name="scalar_field">
-        <a:documentation>CompressibleContinuityResidual
+        <element name="scalar_field">
+          <a:documentation>CompressibleContinuityResidual
 
 Computes the residual of the continuity equation used in compressible multiphase flow simulations
 i.e. vfrac_c*d(rho_c)/dt + div(rho_c*vfrac_c*u_c) + \sum_i{ rho_c*div(vfrac_i*u_i) }
 where _c and _i denote the compressible and incompressible phases respectively.</a:documentation>
-        <attribute name="rank">
-          <value>0</value>
-        </attribute>
-        <attribute name="name">
-          <value>CompressibleContinuityResidual</value>
-        </attribute>
-        <element name="diagnostic">
-          <ref name="velocity_mesh_choice"/>
-          <ref name="internal_algorithm"/>
-          <ref name="diagnostic_scalar_field_no_adapt"/>
-          <element name="solver">
-            <ref name="linear_solver_options_sym"/>
+          <attribute name="rank">
+            <value>0</value>
+          </attribute>
+          <attribute name="name">
+            <value>CompressibleContinuityResidual</value>
+          </attribute>
+          <element name="diagnostic">
+            <ref name="velocity_mesh_choice"/>
+            <ref name="internal_algorithm"/>
+            <ref name="diagnostic_scalar_field_no_adapt"/>
+            <element name="solver">
+              <ref name="linear_solver_options_sym"/>
+            </element>
           </element>
         </element>
-      </element>
-      <element name="scalar_field">
-        <a:documentation>DGLESScalarEddyViscosity
+        <element name="scalar_field">
+          <a:documentation>DGLESScalarEddyViscosity
 
 Outputs the calculated (isotropic) eddy viscosity term
 for a discontinuous velocity field. The subgridscale viscosity
 follows that of the Smagorinsky–Lilly model. Requires that both a discontinous
 representation of velocity and an les model have been selected.</a:documentation>
-        <attribute name="rank">
-          <value>0</value>
-        </attribute>
-        <attribute name="name">
-          <value>DGLESScalarEddyViscosity</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_scalar_field"/>
-          </element>
-          <element name="prescribed">
-            <ref name="velocity_mesh_choice"/>
-            <ref name="prescribed_scalar_field"/>
-          </element>
-        </choice>
-      </element>
-    </choice>
-    <!--
+          <attribute name="rank">
+            <value>0</value>
+          </attribute>
+          <attribute name="name">
+            <value>DGLESScalarEddyViscosity</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_scalar_field"/>
+            </element>
+            <element name="prescribed">
+              <ref name="velocity_mesh_choice"/>
+              <ref name="prescribed_scalar_field"/>
+            </element>
+          </choice>
+        </element>
+      </choice>
+      <!--
       Insert new diagnostic scalar fields here using the template:
              element scalar_field {
                  attribute rank { "0" },
@@ -7268,98 +7330,98 @@ representation of velocity and an les model have been selected.</a:documentation
                  )
              }
     -->
-  </define>
-  <!-- This is the choice of additional vector field to be solved for -->
-  <define name="vector_field_choice">
-    <!--
+    </define>
+    <!-- This is the choice of additional vector field to be solved for -->
+    <define name="vector_field_choice">
+      <!--
       The first is a generic field, which may be used for any user-defined field
       that FLUIDITY knows nothing about, or a generic diagnostic
       Prognostic vector fields are not possible (other than velocity and those known fields below).
     -->
-    <choice>
-      <element name="vector_field">
-        <a:documentation>Generic field variable (vector)</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <data type="string"/>
-        </attribute>
-        <choice>
-          <a:documentation>Field type</a:documentation>
-          <element name="prescribed">
-            <ref name="mesh_choice"/>
-            <ref name="prescribed_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-          <element name="diagnostic">
-            <ref name="vector_diagnostic_algorithms"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-          </element>
-        </choice>
-      </element>
-      <!--
-        
+      <choice>
+        <element name="vector_field">
+          <a:documentation>Generic field variable (vector)</a:documentation>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <data type="string"/>
+          </attribute>
+          <choice>
+            <a:documentation>Field type</a:documentation>
+            <element name="prescribed">
+              <ref name="mesh_choice"/>
+              <ref name="prescribed_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+            <element name="diagnostic">
+              <ref name="vector_diagnostic_algorithms"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+          </choice>
+        </element>
+        <!--
+
         - - List of fields that are primarily prognostic,
            but can be aliased.
         - - The list is in order of most frequently used.
-        
+
       -->
-      <element name="___Prognostic_fields_below___">
-        <a:documentation>Prescribed vector fields below this</a:documentation>
-        <empty/>
-      </element>
-      <element name="vector_field">
-        <a:documentation>As HydrostaticPressure, but solves for the gradient of the pressure
-associated with buoyancy. Requires a discontinuous mesh.</a:documentation>
-        <attribute name="rank">
-          <value>0</value>
-        </attribute>
-        <attribute name="name">
-          <value>HydrostaticPressureGradient</value>
-        </attribute>
-        <element name="prognostic">
-          <ref name="mesh_choice"/>
-          <ref name="prognostic_hydrostatic_pressure_gradient_field"/>
+        <element name="___Prognostic_fields_below___">
+          <a:documentation>Prescribed vector fields below this</a:documentation>
+          <empty/>
         </element>
-      </element>
-      <!--
-        
+        <element name="vector_field">
+          <a:documentation>As HydrostaticPressure, but solves for the gradient of the pressure
+associated with buoyancy. Requires a discontinuous mesh.</a:documentation>
+          <attribute name="rank">
+            <value>0</value>
+          </attribute>
+          <attribute name="name">
+            <value>HydrostaticPressureGradient</value>
+          </attribute>
+          <element name="prognostic">
+            <ref name="mesh_choice"/>
+            <ref name="prognostic_hydrostatic_pressure_gradient_field"/>
+          </element>
+        </element>
+        <!--
+
         - - List of fields that are primarily prescribed,
            but can be aliased.
         - - The list is in order of most frequently used.
-        
+
       -->
-      <element name="___Prescribed_fields_below___">
-        <a:documentation>Prescribed vector fields below this</a:documentation>
-        <empty/>
-      </element>
-      <element name="vector_field">
-        <a:documentation>MaterialVelocity field.  Used to impose a velocity on a material
+        <element name="___Prescribed_fields_below___">
+          <a:documentation>Prescribed vector fields below this</a:documentation>
+          <empty/>
+        </element>
+        <element name="vector_field">
+          <a:documentation>MaterialVelocity field.  Used to impose a velocity on a material
 in combination with the imposed_material_velocity_absorption_algorithm
 for VelocityAbsorption and imposed_material_velocity_source_algorithm
 for VelocitySource.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>MaterialVelocity</value>
-        </attribute>
-        <choice>
-          <element name="prescribed">
-            <ref name="mesh_choice"/>
-            <ref name="prescribed_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <!--
-        
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>MaterialVelocity</value>
+          </attribute>
+          <choice>
+            <element name="prescribed">
+              <ref name="mesh_choice"/>
+              <ref name="prescribed_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <!--
+
         Insert new prescribed vector fields here using the template:
                element vector_field {
                    attribute rank { "1" },
@@ -7374,445 +7436,445 @@ for VelocitySource.</a:documentation>
                       }
                    )
                }
-        
+
         - - Last is a list of fields that are primarily diagnostic,
            but can be aliased. An example is Tidal Range.
         - - The list is in order of most frequently used.
-        
+
       -->
-      <element name="___Diagnostic_Fields_Below___">
-        <a:documentation>Diagnostic vector fields below this</a:documentation>
-        <empty/>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Gradient of a scalar field evaluated using the C gradient
+        <element name="___Diagnostic_Fields_Below___">
+          <a:documentation>Diagnostic vector fields below this</a:documentation>
+          <empty/>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Gradient of a scalar field evaluated using the C gradient
 matrix constructed using finite elements.
 Field must be in this material_phase.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>FiniteElementGradient</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <attribute name="field_name">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <ref name="mesh_choice"/>
-            <optional>
-              <element name="integrate_gradient_by_parts">
-                <empty/>
-              </element>
-            </optional>
-            <ref name="diagnostic_gradient_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Gradient of a scalar field evaluated using the transpose
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>FiniteElementGradient</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <attribute name="field_name">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <ref name="mesh_choice"/>
+              <optional>
+                <element name="integrate_gradient_by_parts">
+                  <empty/>
+                </element>
+              </optional>
+              <ref name="diagnostic_gradient_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Gradient of a scalar field evaluated using the transpose
 of the C^T divergence matrix constructed using finite
 elements.
 Field must be in this material_phase.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>FiniteElementDivergenceTransposed</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="legacy_internal_algorithm"/>
-            <attribute name="field_name">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <ref name="mesh_choice"/>
-            <optional>
-              <element name="integrate_divergence_by_parts">
-                <empty/>
-              </element>
-            </optional>
-            <ref name="diagnostic_gradient_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Foam Velocity field.
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>FiniteElementDivergenceTransposed</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="legacy_internal_algorithm"/>
+              <attribute name="field_name">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <ref name="mesh_choice"/>
+              <optional>
+                <element name="integrate_divergence_by_parts">
+                  <empty/>
+                </element>
+              </optional>
+              <ref name="diagnostic_gradient_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Foam Velocity field.
 Required for simulations of foam flow and liquid drainage in foams.
 If diagnostic, a FoamVelocityPotential field is required,
 and the Foam Velocity is obtained by taking its gradient.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>FoamVelocity</value>
-        </attribute>
-        <choice>
-          <element name="prescribed">
-            <ref name="velocity_mesh_choice"/>
-            <ref name="prescribed_vector_field_no_adapt"/>
-          </element>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="mesh_choice"/>
-            <element name="solver">
-              <ref name="linear_solver_options_sym"/>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>FoamVelocity</value>
+          </attribute>
+          <choice>
+            <element name="prescribed">
+              <ref name="velocity_mesh_choice"/>
+              <ref name="prescribed_vector_field_no_adapt"/>
             </element>
-            <ref name="diagnostic_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Foam Liquid Content times Velocity field.
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="mesh_choice"/>
+              <element name="solver">
+                <ref name="linear_solver_options_sym"/>
+              </element>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Foam Liquid Content times Velocity field.
 Its surface integral gives the liquid
 volumetric flow in the flowing foam</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>FoamLiquidContentVelocity</value>
-        </attribute>
-        <element name="diagnostic">
-          <ref name="internal_algorithm"/>
-          <ref name="velocity_mesh_choice"/>
-          <ref name="diagnostic_vector_field"/>
-        </element>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Relative vorticity field - curl of the velocity field</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>Vorticity</value>
-        </attribute>
-        <choice>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>FoamLiquidContentVelocity</value>
+          </attribute>
           <element name="diagnostic">
-            <ref name="vorticity_algorithm"/>
+            <ref name="internal_algorithm"/>
             <ref name="velocity_mesh_choice"/>
             <ref name="diagnostic_vector_field"/>
           </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Planetary vorticity
+        </element>
+        <element name="vector_field">
+          <a:documentation>Relative vorticity field - curl of the velocity field</a:documentation>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>Vorticity</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="vorticity_algorithm"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Planetary vorticity
 
 Limitations:
  - Requires geometry dimension of 3.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>PlanetaryVorticity</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Absolute vorticity:
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>PlanetaryVorticity</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Absolute vorticity:
 
   f + curl u
 
 Limitations:
  - Requires a geometry dimension of 3.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>AbsoluteVorticity</value>
-        </attribute>
-        <attribute name="depends">
-          <value>Velocity</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Gradient of a scalar field evaluated using the transpose
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>AbsoluteVorticity</value>
+          </attribute>
+          <attribute name="depends">
+            <value>Velocity</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Gradient of a scalar field evaluated using the transpose
 of the C^T matrix constructed using control volumes.
 Field must be in this material_phase.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>ControlVolumeDivergenceTransposed</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <attribute name="field_name">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_cv_gradient_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>LinearMomentum field.
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>ControlVolumeDivergenceTransposed</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <attribute name="field_name">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_cv_gradient_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>LinearMomentum field.
  p = \rho*u
 (where p is the linear momentum, \rho the density and u the velocity)</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>LinearMomentum</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Absolute Difference between two vector fields.
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>LinearMomentum</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Absolute Difference between two vector fields.
 
 Both fields must be in this material_phase.
 Assumes both fields are on the same mesh as the AbsoluteDifference field.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>AbsoluteDifference</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <attribute name="field_name_a">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <attribute name="field_name_b">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <ref name="mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-            <optional>
-              <element name="relative_to_average">
-                <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Absolute Difference between two vector fields.
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>AbsoluteDifference</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <attribute name="field_name_a">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <attribute name="field_name_b">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <ref name="mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+              <optional>
+                <element name="relative_to_average">
+                  <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
+                  <empty/>
+                </element>
+              </optional>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Absolute Difference between two vector fields.
 
 Both fields must be in this material_phase.
 Assumes both fields are on the same mesh as the AbsoluteDifference field.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>VectorAbsoluteDifference</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <attribute name="field_name_a">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <attribute name="field_name_b">
-              <data type="string" datatypeLibrary=""/>
-            </attribute>
-            <ref name="mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
-            <optional>
-              <element name="relative_to_average">
-                <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Bed Shear Stress
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>VectorAbsoluteDifference</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <attribute name="field_name_a">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <attribute name="field_name_b">
+                <data type="string" datatypeLibrary=""/>
+              </attribute>
+              <ref name="mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+              <optional>
+                <element name="relative_to_average">
+                  <a:documentation>Evaluate the absolute difference once the average difference has been removed?</a:documentation>
+                  <empty/>
+                </element>
+              </optional>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Bed Shear Stress
 
 This diagnostic vector field is only calculated over surface elements/nodes,
 interior nodes will have zero value.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>BedShearStress</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_vector_field_bed_shear_stress"/>
-          </element>
-          <element name="prescribed">
-            <ref name="velocity_mesh_choice"/>
-            <ref name="prescribed_vector_field_no_adapt"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Max Bed Shear Stress.
-
-Note that you need BedShearStress turned on for this to work.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>MaxBedShearStress</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <group>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>BedShearStress</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
               <ref name="internal_algorithm"/>
               <ref name="velocity_mesh_choice"/>
-            </group>
-            <!-- diagnostic_vector_field_max_bed_shear_stress -->
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-        <element name="spin_up_time">
-          <a:documentation>This is the time after which the max operator is
-applied to the bed shear stress.</a:documentation>
-          <ref name="real"/>
+              <ref name="diagnostic_vector_field_bed_shear_stress"/>
+            </element>
+            <element name="prescribed">
+              <ref name="velocity_mesh_choice"/>
+              <ref name="prescribed_vector_field_no_adapt"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
         </element>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Coordinate field remapped to the mesh of your choice.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>DiagnosticCoordinate</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="internal_algorithm"/>
-            <ref name="mesh_choice"/>
-            <ref name="diagnostic_vector_field"/>
+        <element name="vector_field">
+          <a:documentation>Max Bed Shear Stress.
+
+Note that you need BedShearStress turned on for this to work.</a:documentation>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>MaxBedShearStress</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <group>
+                <ref name="internal_algorithm"/>
+                <ref name="velocity_mesh_choice"/>
+              </group>
+              <!-- diagnostic_vector_field_max_bed_shear_stress -->
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+          <element name="spin_up_time">
+            <a:documentation>This is the time after which the max operator is
+applied to the bed shear stress.</a:documentation>
+            <ref name="real"/>
           </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Galerkin projection of one field onto another mesh.
+        </element>
+        <element name="vector_field">
+          <a:documentation>Coordinate field remapped to the mesh of your choice.</a:documentation>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>DiagnosticCoordinate</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="internal_algorithm"/>
+              <ref name="mesh_choice"/>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Galerkin projection of one field onto another mesh.
 
 The field must be in this material_phase.
 
 NOTE: you need the solver options if the mesh
 of this field is continuous.</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>GalerkinProjection</value>
-        </attribute>
-        <choice>
-          <element name="diagnostic">
-            <ref name="legacy_internal_algorithm"/>
-            <element name="source_field_name">
-              <data type="string" datatypeLibrary=""/>
-            </element>
-            <ref name="mesh_choice"/>
-            <optional>
-              <element name="lump_mass">
-                <a:documentation>Lump the mass matrix of the galerkin projection
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>GalerkinProjection</value>
+          </attribute>
+          <choice>
+            <element name="diagnostic">
+              <ref name="legacy_internal_algorithm"/>
+              <element name="source_field_name">
+                <data type="string" datatypeLibrary=""/>
+              </element>
+              <ref name="mesh_choice"/>
+              <optional>
+                <element name="lump_mass">
+                  <a:documentation>Lump the mass matrix of the galerkin projection
 less accurate but faster and might give smoother result.</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-            <optional>
-              <element name="solver">
-                <ref name="linear_solver_options_sym"/>
-              </element>
-            </optional>
+                  <empty/>
+                </element>
+              </optional>
+              <optional>
+                <element name="solver">
+                  <ref name="linear_solver_options_sym"/>
+                </element>
+              </optional>
+              <ref name="diagnostic_vector_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <element name="vector_field">
+          <a:documentation>Computes the buoyancy term</a:documentation>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>Buoyancy</value>
+          </attribute>
+          <element name="diagnostic">
+            <ref name="buoyancy_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
             <ref name="diagnostic_vector_field"/>
           </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Computes the buoyancy term</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>Buoyancy</value>
-        </attribute>
-        <element name="diagnostic">
-          <ref name="buoyancy_algorithm"/>
-          <ref name="velocity_mesh_choice"/>
-          <ref name="diagnostic_vector_field"/>
         </element>
-      </element>
-      <element name="vector_field">
-        <a:documentation>Projects the Coriolis term onto the mesh of this diagnostic field.
+        <element name="vector_field">
+          <a:documentation>Projects the Coriolis term onto the mesh of this diagnostic field.
 Note that multiple projection methods are available (under the
 algorithm option).</a:documentation>
-        <attribute name="rank">
-          <value>1</value>
-        </attribute>
-        <attribute name="name">
-          <value>Coriolis</value>
-        </attribute>
-        <element name="diagnostic">
-          <ref name="coriolis_algorithm"/>
-          <ref name="velocity_mesh_choice"/>
-          <ref name="diagnostic_vector_field"/>
+          <attribute name="rank">
+            <value>1</value>
+          </attribute>
+          <attribute name="name">
+            <value>Coriolis</value>
+          </attribute>
+          <element name="diagnostic">
+            <ref name="coriolis_algorithm"/>
+            <ref name="velocity_mesh_choice"/>
+            <ref name="diagnostic_vector_field"/>
+          </element>
         </element>
-      </element>
-    </choice>
-    <!--
+      </choice>
+      <!--
       Insert new diagnostic vector field here using the template:
              element vector_field {
                  attribute rank { "1" },
@@ -7829,79 +7891,79 @@ algorithm option).</a:documentation>
                  )
              }
     -->
-  </define>
-  <!-- This is the choice of additional tensor fields -->
-  <define name="tensor_field_choice">
-    <!--
+    </define>
+    <!-- This is the choice of additional tensor fields -->
+    <define name="tensor_field_choice">
+      <!--
       The first is a generic field, which may be used for any user-defined field
       that FLUIDITY knows nothing about, or a generic diagnostic
       Prognostic tensor fields are not possible.
     -->
-    <choice>
-      <element name="tensor_field">
-        <a:documentation>Generic field variable (tensor)</a:documentation>
-        <attribute name="rank">
-          <value>2</value>
-        </attribute>
-        <attribute name="name">
-          <data type="string"/>
-        </attribute>
-        <choice>
-          <a:documentation>Field type</a:documentation>
-          <element name="prescribed">
-            <ref name="mesh_choice"/>
-            <ref name="prescribed_tensor_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-          <element name="diagnostic">
-            <ref name="tensor_diagnostic_algorithms"/>
-            <ref name="velocity_mesh_choice"/>
-            <ref name="diagnostic_tensor_field"/>
-          </element>
-        </choice>
-      </element>
-      <!--
-        
+      <choice>
+        <element name="tensor_field">
+          <a:documentation>Generic field variable (tensor)</a:documentation>
+          <attribute name="rank">
+            <value>2</value>
+          </attribute>
+          <attribute name="name">
+            <data type="string"/>
+          </attribute>
+          <choice>
+            <a:documentation>Field type</a:documentation>
+            <element name="prescribed">
+              <ref name="mesh_choice"/>
+              <ref name="prescribed_tensor_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+            <element name="diagnostic">
+              <ref name="tensor_diagnostic_algorithms"/>
+              <ref name="velocity_mesh_choice"/>
+              <ref name="diagnostic_tensor_field"/>
+            </element>
+          </choice>
+        </element>
+        <!--
+
         - - Second is a list of tensor fields that are primarily prescribed,
            but can be aliased.
         - - The list is in order of most frequently used.
-        
+
       -->
-      <element name="___Prescribed_fields_below___">
-        <a:documentation>Prescribed scalar fields below this</a:documentation>
-        <empty/>
-      </element>
-      <element name="tensor_field">
-        <a:documentation>MaterialViscosity field:
+        <element name="___Prescribed_fields_below___">
+          <a:documentation>Prescribed scalar fields below this</a:documentation>
+          <empty/>
+        </element>
+        <element name="tensor_field">
+          <a:documentation>MaterialViscosity field:
 
 Field for the viscosity of this material.
 Required if using a diagnostic bulk viscosity
 in a multimaterial simulation.</a:documentation>
-        <attribute name="rank">
-          <value>2</value>
-        </attribute>
-        <attribute name="name">
-          <value>MaterialViscosity</value>
-        </attribute>
-        <choice>
-          <element name="prescribed">
-            <ref name="mesh_choice"/>
-            <ref name="prescribed_tensor_field"/>
-          </element>
-          <element name="diagnostic">
-            <ref name="mesh_choice"/>
-            <ref name="tensor_python_diagnostic_algorithm"/>
-            <ref name="diagnostic_tensor_field"/>
-          </element>
-          <element name="aliased">
-            <ref name="generic_aliased_field"/>
-          </element>
-        </choice>
-      </element>
-      <!--
-        
+          <attribute name="rank">
+            <value>2</value>
+          </attribute>
+          <attribute name="name">
+            <value>MaterialViscosity</value>
+          </attribute>
+          <choice>
+            <element name="prescribed">
+              <ref name="mesh_choice"/>
+              <ref name="prescribed_tensor_field"/>
+            </element>
+            <element name="diagnostic">
+              <ref name="mesh_choice"/>
+              <ref name="tensor_python_diagnostic_algorithm"/>
+              <ref name="diagnostic_tensor_field"/>
+            </element>
+            <element name="aliased">
+              <ref name="generic_aliased_field"/>
+            </element>
+          </choice>
+        </element>
+        <!--
+
         Insert new prescribed tensor fields here using the template:
                element tensor_field {
                    attribute rank { "2" },
@@ -7916,18 +7978,18 @@ in a multimaterial simulation.</a:documentation>
                       }
                    )
                }|
-        
+
         - - Last is a list of fields that are primarily diagnostic,
            but can be aliased.
         - - The list is in order of most frequently used.
-        
+
       -->
-      <element name="___Diagnostic_Fields_Below___">
-        <a:documentation>Diagnostic tensor fields below this</a:documentation>
-        <empty/>
-      </element>
-    </choice>
-    <!--
+        <element name="___Diagnostic_Fields_Below___">
+          <a:documentation>Diagnostic tensor fields below this</a:documentation>
+          <empty/>
+        </element>
+      </choice>
+      <!--
       Insert new diagnostic tensor field here using the template:
              element tensor_field {
                  attribute name { "NewFieldName" },
@@ -7943,130 +8005,130 @@ in a multimaterial simulation.</a:documentation>
                  )
              }
     -->
-  </define>
-  <define name="cap_option">
-    <element name="cap_values">
-      <a:documentation>Cap the min and max values of this field when using
+    </define>
+    <define name="cap_option">
+      <element name="cap_values">
+        <a:documentation>Cap the min and max values of this field when using
 it as a volume fraction to work out bulk material
 properties.
 No capping used if not selected.</a:documentation>
-      <optional>
-        <element name="upper_cap">
-          <a:documentation>Set the upper bound on the field.
+        <optional>
+          <element name="upper_cap">
+            <a:documentation>Set the upper bound on the field.
 Defaults to huge(0.0)*epsilon(0.0) if not set.</a:documentation>
-          <ref name="real"/>
-        </element>
-      </optional>
-      <optional>
-        <element name="lower_cap">
-          <a:documentation>Set the lower bound on the field.
-Defaults to -huge(0.0)*epsilon(0.0) if not set.</a:documentation>
-          <ref name="real"/>
-        </element>
-      </optional>
-    </element>
-  </define>
-  <define name="surface_tension_option">
-    <element name="surface_tension">
-      <element name="surface_tension_coefficient">
-        <a:documentation>Surface tension coefficient</a:documentation>
-        <ref name="real"/>
-      </element>
-      <optional>
-        <element name="equilibrium_contact_angle">
-          <a:documentation>The equilibrium contact angle (in radians) with the boundaries identified by the surface ids</a:documentation>
-          <ref name="real"/>
-          <element name="surface_ids">
-            <a:documentation>Surface ids:</a:documentation>
-            <ref name="integer_vector"/>
+            <ref name="real"/>
           </element>
+        </optional>
+        <optional>
+          <element name="lower_cap">
+            <a:documentation>Set the lower bound on the field.
+Defaults to -huge(0.0)*epsilon(0.0) if not set.</a:documentation>
+            <ref name="real"/>
+          </element>
+        </optional>
+      </element>
+    </define>
+    <define name="surface_tension_option">
+      <element name="surface_tension">
+        <element name="surface_tension_coefficient">
+          <a:documentation>Surface tension coefficient</a:documentation>
+          <ref name="real"/>
         </element>
-      </optional>
-    </element>
-  </define>
-  <define name="limiter_options">
-    <choice>
-      <element name="limit_face_value">
-        <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
-        <choice>
-          <ref name="sweby_limiter"/>
-          <ref name="ultimate_limiter"/>
-        </choice>
+        <optional>
+          <element name="equilibrium_contact_angle">
+            <a:documentation>The equilibrium contact angle (in radians) with the boundaries identified by the surface ids</a:documentation>
+            <ref name="real"/>
+            <element name="surface_ids">
+              <a:documentation>Surface ids:</a:documentation>
+              <ref name="integer_vector"/>
+            </element>
+          </element>
+        </optional>
       </element>
-      <element name="do_not_limit_face_value">
-        <a:documentation>Do not limit the face value</a:documentation>
-        <empty/>
-      </element>
-    </choice>
-  </define>
-  <!--
+    </define>
+    <define name="limiter_options">
+      <choice>
+        <element name="limit_face_value">
+          <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
+          <choice>
+            <ref name="sweby_limiter"/>
+            <ref name="ultimate_limiter"/>
+          </choice>
+        </element>
+        <element name="do_not_limit_face_value">
+          <a:documentation>Do not limit the face value</a:documentation>
+          <empty/>
+        </element>
+      </choice>
+    </define>
+    <!--
     cv limiter options that
     have NO reliance on any CFL field.
   -->
-  <define name="limiter_options_excluding_cfl">
-    <choice>
-      <element name="limit_face_value">
-        <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
-        <ref name="sweby_limiter"/>
-      </element>
-      <element name="do_not_limit_face_value">
-        <a:documentation>Do not limit the face value</a:documentation>
-        <empty/>
-      </element>
-    </choice>
-  </define>
-  <define name="sweby_limiter">
-    <element name="limiter">
-      <a:documentation>See "High-Resolution Schemes Using Flux Limiters for
+    <define name="limiter_options_excluding_cfl">
+      <choice>
+        <element name="limit_face_value">
+          <a:documentation>Limit the face value to satisfy a boundedness criterion.</a:documentation>
+          <ref name="sweby_limiter"/>
+        </element>
+        <element name="do_not_limit_face_value">
+          <a:documentation>Do not limit the face value</a:documentation>
+          <empty/>
+        </element>
+      </choice>
+    </define>
+    <define name="sweby_limiter">
+      <element name="limiter">
+        <a:documentation>See "High-Resolution Schemes Using Flux Limiters for
 Hyperbolic Conservation-Laws", P. K. Sweby, 1984, Siam
 Journal on Numerical Analysis, 21, 995-1011</a:documentation>
-      <attribute name="name">
-        <value>Sweby</value>
-      </attribute>
-      <optional>
-        <ref name="slope_options"/>
-      </optional>
-      <optional>
-        <ref name="upwind_value_options"/>
-      </optional>
-    </element>
-  </define>
-  <define name="ultimate_limiter">
-    <element name="limiter">
-      <a:documentation>See "The Ultimate Conservative Difference Scheme Applied
+        <attribute name="name">
+          <value>Sweby</value>
+        </attribute>
+        <optional>
+          <ref name="slope_options"/>
+        </optional>
+        <optional>
+          <ref name="upwind_value_options"/>
+        </optional>
+      </element>
+    </define>
+    <define name="ultimate_limiter">
+      <element name="limiter">
+        <a:documentation>See "The Ultimate Conservative Difference Scheme Applied
 to Unsteady One-Dimensional Advection", B. P. Leonard,
 1991, Computer Methods in Applied Mechanics and
 Engineering, 88, 17-74</a:documentation>
-      <attribute name="name">
-        <value>Ultimate</value>
-      </attribute>
-      <ref name="field_based_cfl_number_options"/>
-      <optional>
-        <ref name="upwind_value_options"/>
-      </optional>
-    </element>
-  </define>
-  <define name="slope_options">
-    <element name="slopes">
-      <a:documentation>Control the upper and lower slopes of the NVD limiter</a:documentation>
-      <optional>
-        <element name="lower">
-          <a:documentation>Defaults to Sweby, 1984 limiter (= 1.0) if unselected</a:documentation>
-          <ref name="real"/>
-        </element>
-      </optional>
-      <optional>
-        <element name="upper">
-          <a:documentation>Defaults to Sweby, 1984 limiter (= 2.0) if unselected</a:documentation>
-          <ref name="real"/>
-        </element>
-      </optional>
-    </element>
-  </define>
-  <define name="upwind_value_options">
-    <choice>
-      <element name="project_upwind_value_from_point">
-        <a:documentation>Select the method to be used for calculating the upwind value.
+        <attribute name="name">
+          <value>Ultimate</value>
+        </attribute>
+        <ref name="field_based_cfl_number_options"/>
+        <optional>
+          <ref name="upwind_value_options"/>
+        </optional>
+      </element>
+    </define>
+    <define name="slope_options">
+      <element name="slopes">
+        <a:documentation>Control the upper and lower slopes of the NVD limiter</a:documentation>
+        <optional>
+          <element name="lower">
+            <a:documentation>Defaults to Sweby, 1984 limiter (= 1.0) if unselected</a:documentation>
+            <ref name="real"/>
+          </element>
+        </optional>
+        <optional>
+          <element name="upper">
+            <a:documentation>Defaults to Sweby, 1984 limiter (= 2.0) if unselected</a:documentation>
+            <ref name="real"/>
+          </element>
+        </optional>
+      </element>
+    </define>
+    <define name="upwind_value_options">
+      <choice>
+        <element name="project_upwind_value_from_point">
+          <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8076,30 +8138,30 @@ upwind of the node pair straddling the face.  It is otherwise known as
 anisotropic limiting.
 This is only available on simplex meshes as it involes a search around
 the donor node to find the upwind element.</a:documentation>
-        <optional>
-          <element name="reflect_off_domain_boundaries">
-            <a:documentation>When the donor node is on a domain boundary reflect the projection
+          <optional>
+            <element name="reflect_off_domain_boundaries">
+              <a:documentation>When the donor node is on a domain boundary reflect the projection
 back into the mesh.</a:documentation>
-            <empty/>
-          </element>
-        </optional>
-        <optional>
-          <element name="bound_projected_value_locally">
-            <a:documentation>Constrain the projected value to be between the min and max of the
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="bound_projected_value_locally">
+              <a:documentation>Constrain the projected value to be between the min and max of the
 element values which it was found from.</a:documentation>
-            <empty/>
-          </element>
-        </optional>
-        <optional>
-          <element name="store_upwind_elements">
-            <a:documentation>Store the locations of the elements where the upwind values
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="store_upwind_elements">
+              <a:documentation>Store the locations of the elements where the upwind values
 are projected from for each node pair.
 This inserts an integer csr matrix into state so is memory expensive but
 saves a significant amount of time (searching around the neighbouring elements).
 This is unsafe for moving meshes but should be ok for adaptive meshes.</a:documentation>
-            <optional>
-              <element name="store_upwind_quadrature">
-                <a:documentation>Store the quadrature locations within the elements
+              <optional>
+                <element name="store_upwind_quadrature">
+                  <a:documentation>Store the quadrature locations within the elements
 where the upwind values
 are projected from for each node pair.
 This inserts a real block csr matrix into state so is even more memory
@@ -8108,14 +8170,14 @@ only saves a comparitively
 marginal amount of time (as actually searching the
 neighbouring elements is the
 slowest bit, finding the quadrature is relatively easy).</a:documentation>
-                <empty/>
-              </element>
-            </optional>
-          </element>
-        </optional>
-      </element>
-      <element name="project_upwind_value_from_gradient">
-        <a:documentation>Select the method to be used for calculating the upwind value.
+                  <empty/>
+                </element>
+              </optional>
+            </element>
+          </optional>
+        </element>
+        <element name="project_upwind_value_from_gradient">
+          <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8125,49 +8187,49 @@ using the interpolated gradient at the donor node in the
 direction of the vector
 connecting the node pair straddling the face.
 This is available on all meshes (except if bounding the values).</a:documentation>
-        <choice>
-          <element name="project_from_downwind_value">
-            <a:documentation>Select which node to project from:
+          <choice>
+            <element name="project_from_downwind_value">
+              <a:documentation>Select which node to project from:
 Project from the downwind node (Jasak et al., 1999) so that:
 upwind_value = downwind_value - 2*gradient.vector</a:documentation>
-            <ref name="comment"/>
-          </element>
-          <element name="project_from_donor_value">
-            <a:documentation>Select which node to project from:
+              <ref name="comment"/>
+            </element>
+            <element name="project_from_donor_value">
+              <a:documentation>Select which node to project from:
 Project from the donor node so that:
 upwind_value = donor_value - gradient.vector</a:documentation>
-            <ref name="comment"/>
-          </element>
-        </choice>
-        <optional>
-          <element name="reflect_off_domain_boundaries">
-            <a:documentation>When the donor node is on a domain boundary reflect the projection
+              <ref name="comment"/>
+            </element>
+          </choice>
+          <optional>
+            <element name="reflect_off_domain_boundaries">
+              <a:documentation>When the donor node is on a domain boundary reflect the projection
 back into the mesh.</a:documentation>
-            <empty/>
-          </element>
-        </optional>
-        <optional>
-          <element name="bound_projected_value_locally">
-            <a:documentation>Constrain the projected value to be between the min and max of the
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <element name="bound_projected_value_locally">
+              <a:documentation>Constrain the projected value to be between the min and max of the
 element values which surround it.
 This is only available on simplex meshes as it involes a search around
 the donor node to find the upwind element.</a:documentation>
-            <optional>
-              <element name="store_upwind_elements">
-                <a:documentation>Store the locations of the elements closest to the project value.
+              <optional>
+                <element name="store_upwind_elements">
+                  <a:documentation>Store the locations of the elements closest to the project value.
 This inserts an integer csr matrix into state so is
 memory expensive but
 saves a significant amount of time (searching around
 the neighbouring elements).
 This is unsafe for moving meshes but should be ok for adaptive meshes.</a:documentation>
-                <ref name="comment"/>
-              </element>
-            </optional>
-          </element>
-        </optional>
-      </element>
-      <element name="locally_bound_upwind_value">
-        <a:documentation>Select the method to be used for calculating the upwind value.
+                  <ref name="comment"/>
+                </element>
+              </optional>
+            </element>
+          </optional>
+        </element>
+        <element name="locally_bound_upwind_value">
+          <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8176,10 +8238,10 @@ Chooses an upwind value by selecting the maximum or minimum of the neighbouring
 nodes depending on the local slope of the donor and downwind values.
 Otherwise known as isotropic limiting.
 This is available on all meshes except periodic domains.</a:documentation>
-        <empty/>
-      </element>
-      <element name="pseudo_structured_upwind_value">
-        <a:documentation>Select the method to be used for calculating the upwind value.
+          <empty/>
+        </element>
+        <element name="pseudo_structured_upwind_value">
+          <a:documentation>Select the method to be used for calculating the upwind value.
 If not selected will default to project_upwind_value_from_point for
 simplex element meshes and to a locally_bound_upwind_value for cube
 element meshes.
@@ -8187,767 +8249,770 @@ element meshes.
 Chooses an upwind value by selecting the value at the node most directy
 upwind from the vector connecting the donor and downwind nodes.
 This is available on all meshes.</a:documentation>
-        <empty/>
-      </element>
-    </choice>
-  </define>
-  <define name="field_based_cfl_number_options">
-    <choice>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used.
-
-This uses the control volume definition of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>ControlVolumeCFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>***UNDER TESTING***
-
-Select the Courant Number definition to be used.
-
-This uses the control volume definition of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>CVMaterialDensityCFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used.
-
-This uses the finite element approximation of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>CFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used.</a:documentation>
-        <attribute name="name">
-          <data type="string" datatypeLibrary=""/>
-        </attribute>
-        <empty/>
-      </element>
-    </choice>
-  </define>
-  <define name="dg_field_based_cfl_number_options">
-    <optional>
+          <empty/>
+        </element>
+      </choice>
+    </define>
+    <define name="field_based_cfl_number_options">
       <choice>
         <element name="courant_number">
-          <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+          <a:documentation>Select the Courant Number definition to be used.
 
-Select the Courant Number definition to be used.
-
-This uses the DG finite element approximation of the CFL Number.</a:documentation>
+This uses the control volume definition of the CFL Number.</a:documentation>
           <attribute name="name">
-            <value>DG_CourantNumber</value>
+            <value>ControlVolumeCFLNumber</value>
           </attribute>
           <empty/>
         </element>
         <element name="courant_number">
-          <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+          <a:documentation>***UNDER TESTING***
 
-Select the Courant Number definition to be used.</a:documentation>
+Select the Courant Number definition to be used.
+
+This uses the control volume definition of the CFL Number.</a:documentation>
+          <attribute name="name">
+            <value>CVMaterialDensityCFLNumber</value>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="courant_number">
+          <a:documentation>Select the Courant Number definition to be used.
+
+This uses the finite element approximation of the CFL Number.</a:documentation>
+          <attribute name="name">
+            <value>CFLNumber</value>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="courant_number">
+          <a:documentation>Select the Courant Number definition to be used.</a:documentation>
           <attribute name="name">
             <data type="string" datatypeLibrary=""/>
           </attribute>
           <empty/>
         </element>
       </choice>
-    </optional>
-  </define>
-  <define name="cv_face_cfl_number_options">
-    <choice>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used in the slope of
+    </define>
+    <define name="dg_field_based_cfl_number_options">
+      <optional>
+        <choice>
+          <element name="courant_number">
+            <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+
+Select the Courant Number definition to be used.
+
+This uses the DG finite element approximation of the CFL Number.</a:documentation>
+            <attribute name="name">
+              <value>DG_CourantNumber</value>
+            </attribute>
+            <empty/>
+          </element>
+          <element name="courant_number">
+            <a:documentation>IF NOT SELECTED THEN THE DEFAULT DG_CourantNumber IS USED.
+
+Select the Courant Number definition to be used.</a:documentation>
+            <attribute name="name">
+              <data type="string" datatypeLibrary=""/>
+            </attribute>
+            <empty/>
+          </element>
+        </choice>
+      </optional>
+    </define>
+    <define name="cv_face_cfl_number_options">
+      <choice>
+        <element name="courant_number">
+          <a:documentation>Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses the control volume definition of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>ControlVolumeCFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>***UNDER TESTING***
+          <attribute name="name">
+            <value>ControlVolumeCFLNumber</value>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="courant_number">
+          <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses a control volume definition of the CFL Number
 that incorporates the MaterialDensity.
 Requires a MaterialDensity field in this material_phase!</a:documentation>
-        <attribute name="name">
-          <value>CVMaterialDensityCFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>***UNDER TESTING***
+          <attribute name="name">
+            <value>CVMaterialDensityCFLNumber</value>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="courant_number">
+          <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.
 This uses the finite element approximation of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>CFLNumber</value>
-        </attribute>
-        <empty/>
-      </element>
-      <element name="courant_number">
-        <a:documentation>***UNDER TESTING***
+          <attribute name="name">
+            <value>CFLNumber</value>
+          </attribute>
+          <empty/>
+        </element>
+        <element name="courant_number">
+          <a:documentation>***UNDER TESTING***
 
 Select the Courant Number definition to be used in the slope of
 the NVD diagram upper bound.</a:documentation>
-        <attribute name="name">
-          <data type="string" datatypeLibrary=""/>
-        </attribute>
-        <empty/>
-      </element>
-    </choice>
-  </define>
-  <define name="timestep_cfl_number_options">
-    <choice>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
+          <attribute name="name">
+            <data type="string" datatypeLibrary=""/>
+          </attribute>
+          <empty/>
+        </element>
+      </choice>
+    </define>
+    <define name="timestep_cfl_number_options">
+      <choice>
+        <element name="courant_number">
+          <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
 This uses the finite element approximation of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>CFLNumber</value>
-        </attribute>
-        <ref name="velocity_mesh_choice">
-          <a:documentation>Select the mesh on which you wish to evaluate the CFLNumber.</a:documentation>
-        </ref>
-      </element>
-      <element name="courant_number">
-        <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
+          <attribute name="name">
+            <value>CFLNumber</value>
+          </attribute>
+          <ref name="velocity_mesh_choice">
+            <a:documentation>Select the mesh on which you wish to evaluate the CFLNumber.</a:documentation>
+          </ref>
+        </element>
+        <element name="courant_number">
+          <a:documentation>Select the Courant Number definition to be used for adaptive timestepping.
 This uses the control volume definition of the CFL Number.</a:documentation>
-        <attribute name="name">
-          <value>ControlVolumeCFLNumber</value>
-        </attribute>
-        <ref name="velocity_mesh_choice">
-          <a:documentation>Select the mesh on which you wish to evaluate the ControlVolumeCFLNumber.</a:documentation>
-        </ref>
-      </element>
-    </choice>
-  </define>
-  <define name="mixing_stats">
-    <element name="include_mixing_stats">
-      <a:documentation>Enable to include in the .stat file the fractions of the
+          <attribute name="name">
+            <value>ControlVolumeCFLNumber</value>
+          </attribute>
+          <ref name="velocity_mesh_choice">
+            <a:documentation>Select the mesh on which you wish to evaluate the ControlVolumeCFLNumber.</a:documentation>
+          </ref>
+        </element>
+      </choice>
+    </define>
+    <define name="mixing_stats">
+      <element name="include_mixing_stats">
+        <a:documentation>Enable to include in the .stat file the fractions of the
 scalar field contained in
 bins specified by the user. This allows mixing of the field to be quantified.
 Replaces and expands upon the old heaviside.dat file</a:documentation>
-      <attribute name="name">
-        <data type="string"/>
-      </attribute>
-      <choice>
-        <element name="continuous_galerkin">
-          <a:documentation>Select whether to evaluate the volume fraction over the finite element
+        <attribute name="name">
+          <data type="string"/>
+        </attribute>
+        <choice>
+          <element name="continuous_galerkin">
+            <a:documentation>Select whether to evaluate the volume fraction over the finite element
 (continuous galerkin) or within the control volume (control_volumes).
 
 NOTE: continuous_galerkin only works with linear tets
 
 NOTE: continuous_galerkin is not fully validated yet</a:documentation>
-          <optional>
-            <element name="normalise">
-              <a:documentation>if select normalise the volume fractions will be
+            <optional>
+              <element name="normalise">
+                <a:documentation>if select normalise the volume fractions will be
 divided by the total volume of the domain</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-        </element>
-        <element name="control_volumes">
-          <a:documentation>Select whether to evaluate the volume fraction over the finite element
-(continuous galerkin) or within the control volume (control_volumes).</a:documentation>
-          <optional>
-            <element name="normalise">
-              <a:documentation>if select normalise the volume fractions will be divided by the total volume of the domain</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-        </element>
-      </choice>
-      <element name="mixing_bin_bounds">
-        <a:documentation>The values of the bounds of the bins
-e.g. the values -1.5 0.0 1.5 2.0 will return 4 bins
-and the fraction of the field in each bin with,
--1.5&lt;=field&lt;0.0, 0.0&lt;=field&lt;1.5, 1.5&lt;=field&lt;2.0, 2.0&lt;=field,
-will be calculated.</a:documentation>
-        <choice>
-          <element name="constant">
-            <a:documentation>list of bin bounds</a:documentation>
-            <ref name="real_vector"/>
+                <empty/>
+              </element>
+            </optional>
           </element>
-          <element name="python">
-            <a:documentation>Python function prescribing bin bounds. Functions should be of the form:
+          <element name="control_volumes">
+            <a:documentation>Select whether to evaluate the volume fraction over the finite element
+(continuous galerkin) or within the control volume (control_volumes).</a:documentation>
+            <optional>
+              <element name="normalise">
+                <a:documentation>if select normalise the volume fractions will be divided by the total volume of the domain</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+        </choice>
+        <element name="mixing_bin_bounds">
+          <a:documentation>The values of the bounds of the bins
+e.g. the values -1.5 0.0 1.5 2.0 will return 4 bins
+and the fraction of the field in each bin with, -1.5&lt;=field&lt;0.0, 0.0&lt;=field&lt;1.5, 1.5&lt;=field&lt;2.0, 2.0&lt;=field,
+            <<<<<<< HEAD
+will be calculated.</a:documentation>
+=======
+will be calculated.  </a:documentation>
+>>>>>>> 3751673df (ENH: Allow for independent particle attribute values on spawn and advection; Update particle tests accordingly.)
+        <choice>
+<element name="constant">
+              <a:documentation>list of bin bounds</a:documentation>
+              <ref name="real_vector"/>
+            </element>
+            <element name="python">
+              <a:documentation>Python function prescribing bin bounds. Functions should be of the form:
 
  def val(t):
     # Function code
     return # Return value that should be an array of reals
 
-</a:documentation>
-            <ref name="python_code"/>
-          </element>
-        </choice>
-      </element>
-      <optional>
-        <element name="tolerance">
-          <a:documentation>Define the tolerance beneath the specified bins that should be included.
+              </a:documentation>
+              <ref name="python_code"/>
+            </element>
+          </choice>
+        </element>
+        <optional>
+          <element name="tolerance">
+            <a:documentation>Define the tolerance beneath the specified bins that should be included.
 Defaults to zero at machine tolerance (epsilon(0.0)) if not selected.</a:documentation>
-          <ref name="real"/>
+            <ref name="real"/>
+          </element>
+        </optional>
+      </element>
+    </define>
+    <define name="cv_stats">
+      <element name="include_cv_stats">
+        <a:documentation>Include statistics evaluated on the control volume mesh.</a:documentation>
+        <empty/>
+      </element>
+    </define>
+    <!-- Options for inclusion of calculations of surface integrals in the .stat file -->
+    <define name="surface_integral_stats_base.surface_integral">
+      <attribute name="name">
+        <data type="string"/>
+      </attribute>
+      <optional>
+        <element name="surface_ids">
+          <a:documentation>Surface IDs defining the surface over which to integrate. If disabled, integrates over the whole surface.</a:documentation>
+          <ref name="integer_vector"/>
         </element>
       </optional>
-    </element>
-  </define>
-  <define name="cv_stats">
-    <element name="include_cv_stats">
-      <a:documentation>Include statistics evaluated on the control volume mesh.</a:documentation>
-      <empty/>
-    </element>
-  </define>
-  <!-- Options for inclusion of calculations of surface integrals in the .stat file -->
-  <define name="surface_integral_stats_base.surface_integral">
-    <attribute name="name">
-      <data type="string"/>
-    </attribute>
-    <optional>
-      <element name="surface_ids">
-        <a:documentation>Surface IDs defining the surface over which to integrate. If disabled, integrates over the whole surface.</a:documentation>
-        <ref name="integer_vector"/>
-      </element>
-    </optional>
-    <optional>
-      <element name="normalise">
-        <a:documentation>Enable to normalise the integral by dividing by the surface area</a:documentation>
-        <ref name="comment"/>
-      </element>
-    </optional>
-  </define>
-  <define name="surface_integral_stats_scalar">
-    <element name="surface_integral">
-      <a:documentation>Surface integral calculations. The following integral types are available:
+      <optional>
+        <element name="normalise">
+          <a:documentation>Enable to normalise the integral by dividing by the surface area</a:documentation>
+          <ref name="comment"/>
+        </element>
+      </optional>
+    </define>
+    <define name="surface_integral_stats_scalar">
+      <element name="surface_integral">
+        <a:documentation>Surface integral calculations. The following integral types are available:
  value: Integrates the field
  gradient_normal: Integrates the normal component of the gradient of the field</a:documentation>
-      <ref name="surface_integral_stats_scalar.surface_integral"/>
-    </element>
-  </define>
-  <define name="surface_integral_stats_scalar.surface_integral">
-    <ref name="surface_integral_stats_base.surface_integral"/>
-  </define>
-  <define name="surface_integral_stats_scalar.surface_integral" combine="interleave">
-    <attribute name="type">
-      <choice>
-        <value>value</value>
-        <value>gradient_normal</value>
-      </choice>
-    </attribute>
-  </define>
-  <define name="surface_integral_stats_vector">
-    <element name="surface_integral">
-      <a:documentation>Surface integral calculations. The following integral types are available:
- normal: Integrates the normal component of the field</a:documentation>
-      <ref name="surface_integral_stats_vector.surface_integral"/>
-    </element>
-  </define>
-  <define name="surface_integral_stats_vector.surface_integral">
-    <ref name="surface_integral_stats_base.surface_integral"/>
-  </define>
-  <define name="surface_integral_stats_vector.surface_integral" combine="interleave">
-    <attribute name="type">
-      <value>normal</value>
-    </attribute>
-  </define>
-  <define name="surface_l2norm_stats">
-    <element name="surface_l2norm">
-      <a:documentation>Calculate L2-norm of field over the specified surface</a:documentation>
+        <ref name="surface_integral_stats_scalar.surface_integral"/>
+      </element>
+    </define>
+    <define name="surface_integral_stats_scalar.surface_integral">
       <ref name="surface_integral_stats_base.surface_integral"/>
-    </element>
-  </define>
-  <define name="forcing">
-    <element name="ocean_forcing">
-      <a:documentation>Force the boundary conditions of various fields in ocean simulations</a:documentation>
-      <optional>
-        <element name="iceshelf_meltrate">
-          <optional>
-            <element name="Holland08">
-              <a:documentation>The type of parameterisation</a:documentation>
-              <element name="c0">
-                <a:documentation>Specific heat capacity of water [Jkg^{-1}]. Default value 3974.</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="cI">
-                <a:documentation>Specific heat capacity of ice [Jkg^{-1}] Default value 2009.</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="L">
-                <a:documentation>Transfer of heat and salt through the boundary layer [Jkg^{-1}]. Default value 3.35e5</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="TI">
-                <a:documentation>Temperature of ice [C]. Default value -25, pretty cold</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="a">
-                <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value -0.0573C.</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="b">
-                <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value 0.0832C.</a:documentation>
-                <ref name="real"/>
-              </element>
-              <element name="Cd">
-                <a:documentation>Drag coefficient, 1.5e-3, see Holland and Jenkins's(1999) Cd.</a:documentation>
-                <ref name="real"/>
-              </element>
-              <optional>
-                <element name="melt_surfaceID">
-                  <a:documentation>Surface ID for the ice</a:documentation>
-                  <ref name="integer_vector"/>
+    </define>
+    <define name="surface_integral_stats_scalar.surface_integral" combine="interleave">
+      <attribute name="type">
+        <choice>
+          <value>value</value>
+          <value>gradient_normal</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="surface_integral_stats_vector">
+      <element name="surface_integral">
+        <a:documentation>Surface integral calculations. The following integral types are available:
+ normal: Integrates the normal component of the field</a:documentation>
+        <ref name="surface_integral_stats_vector.surface_integral"/>
+      </element>
+    </define>
+    <define name="surface_integral_stats_vector.surface_integral">
+      <ref name="surface_integral_stats_base.surface_integral"/>
+    </define>
+    <define name="surface_integral_stats_vector.surface_integral" combine="interleave">
+      <attribute name="type">
+        <value>normal</value>
+      </attribute>
+    </define>
+    <define name="surface_l2norm_stats">
+      <element name="surface_l2norm">
+        <a:documentation>Calculate L2-norm of field over the specified surface</a:documentation>
+        <ref name="surface_integral_stats_base.surface_integral"/>
+      </element>
+    </define>
+    <define name="forcing">
+      <element name="ocean_forcing">
+        <a:documentation>Force the boundary conditions of various fields in ocean simulations</a:documentation>
+        <optional>
+          <element name="iceshelf_meltrate">
+            <optional>
+              <element name="Holland08">
+                <a:documentation>The type of parameterisation</a:documentation>
+                <element name="c0">
+                  <a:documentation>Specific heat capacity of water [Jkg^{-1}]. Default value 3974.</a:documentation>
+                  <ref name="real"/>
                 </element>
-              </optional>
-              <element name="melt_LayerLength">
-                <a:documentation>Distance for the far field</a:documentation>
-                <ref name="real"/>
-              </element>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Meltrate, calculated from the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>MeltRate</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                <element name="cI">
+                  <a:documentation>Specific heat capacity of ice [Jkg^{-1}] Default value 2009.</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <element name="L">
+                  <a:documentation>Transfer of heat and salt through the boundary layer [Jkg^{-1}]. Default value 3.35e5</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <element name="TI">
+                  <a:documentation>Temperature of ice [C]. Default value -25, pretty cold</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <element name="a">
+                  <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value -0.0573C.</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <element name="b">
+                  <a:documentation>Tb=aSb+b+cB, See equation (4) of Holland08. Default value 0.0832C.</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <element name="Cd">
+                  <a:documentation>Drag coefficient, 1.5e-3, see Holland and Jenkins's(1999) Cd.</a:documentation>
+                  <ref name="real"/>
+                </element>
+                <optional>
+                  <element name="melt_surfaceID">
+                    <a:documentation>Surface ID for the ice</a:documentation>
+                    <ref name="integer_vector"/>
                   </element>
+                </optional>
+                <element name="melt_LayerLength">
+                  <a:documentation>Distance for the far field</a:documentation>
+                  <ref name="real"/>
                 </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Temperature of the ice-ocean interface, calculated from the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Tb</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Meltrate, calculated from the three equations.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>MeltRate</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Salinity of the ice-ocean interface, calculated from the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Sb</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Temperature of the ice-ocean interface, calculated from the three equations.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Tb</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Heat flux at the ice-ocean interface.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Heat_flux</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Salinity of the ice-ocean interface, calculated from the three equations.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Sb</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Salt flux at the ice-ocean interface.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Salt_flux</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Heat flux at the ice-ocean interface.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Heat_flux</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Temperature of the far field, which is "melt_LayerLength" away from the ice.
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Salt flux at the ice-ocean interface.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Salt_flux</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
+                  </element>
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Temperature of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Tloc</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Tloc</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Salinity of the far field, which is "melt_LayerLength" away from the ice.
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Salinity of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Sloc</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Sloc</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="scalar_field">
-                  <a:documentation>Pressure used in the three equations.
+                </optional>
+                <optional>
+                  <element name="scalar_field">
+                    <a:documentation>Pressure used in the three equations.
 We need to use the pressure at the ice-ocean interface.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Ploc</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Ploc</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="vector_field">
-                  <a:documentation>Velocity of the far field, which is "melt_LayerLength" away from the ice.
+                </optional>
+                <optional>
+                  <element name="vector_field">
+                    <a:documentation>Velocity of the far field, which is "melt_LayerLength" away from the ice.
 This variable feeds into the three equations.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Vloc</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_vector_field"/>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Vloc</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_vector_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="vector_field">
-                  <a:documentation>Location of your far field, which is "melt_LayerLength" away from the ice.
+                </optional>
+                <optional>
+                  <element name="vector_field">
+                    <a:documentation>Location of your far field, which is "melt_LayerLength" away from the ice.
 Location should be perpendicular to the ice-ocean boundary.
 melt_LayerLength = ||Location - Location_org||</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Location</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_vector_field"/>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Location</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_vector_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="vector_field">
-                  <a:documentation>Location of your ice-ocean boundary.</a:documentation>
-                  <attribute name="rank">
-                    <value>0</value>
-                  </attribute>
-                  <attribute name="name">
-                    <value>Location_org</value>
-                  </attribute>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_vector_field"/>
+                </optional>
+                <optional>
+                  <element name="vector_field">
+                    <a:documentation>Location of your ice-ocean boundary.</a:documentation>
+                    <attribute name="rank">
+                      <value>0</value>
+                    </attribute>
+                    <attribute name="name">
+                      <value>Location_org</value>
+                    </attribute>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_vector_field"/>
+                    </element>
                   </element>
-                </element>
-              </optional>
-              <optional>
-                <element name="calculate_boundaries">
-                  <a:documentation>Boundary stuff</a:documentation>
-                  <element name="string_value">
-                    <choice>
-                      <value>neumann</value>
-                      <value>dirichlet</value>
-                    </choice>
+                </optional>
+                <optional>
+                  <element name="calculate_boundaries">
+                    <a:documentation>Boundary stuff</a:documentation>
+                    <element name="string_value">
+                      <choice>
+                        <value>neumann</value>
+                        <value>dirichlet</value>
+                      </choice>
+                    </element>
                   </element>
-                </element>
-              </optional>
-            </element>
-          </optional>
-        </element>
-      </optional>
-      <optional>
-        <element name="shelf">
-          <optional>
-            <element name="amplitude">
-              <a:documentation>Multiplying factor on equilibrium pressure</a:documentation>
-              <ref name="real"/>
-            </element>
-          </optional>
-          <optional>
-            <element name="y_sign">
-              <a:documentation>Change sign of depth / perturbation from original eta_0</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="calculate_only">
-              <a:documentation>Only calculate the field, don't add to pressure (RHS of Momentum)</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="salinity_change_constant">
-              <a:documentation>DeltaS for constant change over ocean,
-or the difference between min and max for a linear variation in S</a:documentation>
-              <ref name="real"/>
-            </element>
-          </optional>
-          <optional>
-            <element name="add_pressure_from_ice">
-              <a:documentation>If the ice shelf is not included in the original mesh and a free-surface initial condition is used to generate the shelf, the hydrostatic pressure where the shelf now exists needs to be included</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="include_density_change_of_ice">
-              <a:documentation>If using a linear variation in S, include the associated change in density of the ice shelf
-NOT arranged to work with add_pressure_from_ice - TODO</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-        </element>
-      </optional>
-      <optional>
-        <element name="external_data_boundary_conditions">
-          <a:documentation>Check this option to use an external data set for the t(0)
-and in/out boundary conditions. This sets up NEMO-type forcing.</a:documentation>
-          <element name="input_file">
-            <a:documentation>Path of the file containing the external data set</a:documentation>
-            <attribute name="file_name">
-              <data type="string"/>
-            </attribute>
+                </optional>
+              </element>
+            </optional>
           </element>
-        </element>
-      </optional>
-      <optional>
-        <element name="bulk_formulae">
-          <a:documentation>Bulk formulae allow the boundary conditions of Temperature, Velocity, Salinty
+        </optional>
+        <optional>
+          <element name="shelf">
+            <optional>
+              <element name="amplitude">
+                <a:documentation>Multiplying factor on equilibrium pressure</a:documentation>
+                <ref name="real"/>
+              </element>
+            </optional>
+            <optional>
+              <element name="y_sign">
+                <a:documentation>Change sign of depth / perturbation from original eta_0</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="calculate_only">
+                <a:documentation>Only calculate the field, don't add to pressure (RHS of Momentum)</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="salinity_change_constant">
+                <a:documentation>DeltaS for constant change over ocean,
+or the difference between min and max for a linear variation in S</a:documentation>
+                <ref name="real"/>
+              </element>
+            </optional>
+            <optional>
+              <element name="add_pressure_from_ice">
+                <a:documentation>If the ice shelf is not included in the original mesh and a free-surface initial condition is used to generate the shelf, the hydrostatic pressure where the shelf now exists needs to be included</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="include_density_change_of_ice">
+                <a:documentation>If using a linear variation in S, include the associated change in density of the ice shelf
+NOT arranged to work with add_pressure_from_ice - TODO</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+        </optional>
+        <optional>
+          <element name="external_data_boundary_conditions">
+            <a:documentation>Check this option to use an external data set for the t(0)
+and in/out boundary conditions. This sets up NEMO-type forcing.</a:documentation>
+            <element name="input_file">
+              <a:documentation>Path of the file containing the external data set</a:documentation>
+              <attribute name="file_name">
+                <data type="string"/>
+              </attribute>
+            </element>
+          </element>
+        </optional>
+        <optional>
+          <element name="bulk_formulae">
+            <a:documentation>Bulk formulae allow the boundary conditions of Temperature, Velocity, Salinty
 and photosynthetic radiation to be set using data obtained from
 the ERA-40 reanalysis (http://data-portal.ecmwf.int/data/d/era40_daily/)</a:documentation>
-          <optional>
-            <element name="bulk_formulae">
-              <a:documentation>The type of bulk formulae to use. Default is NCAR if no selection is made.</a:documentation>
-              <choice>
-                <element name="type">
-                  <a:documentation>Bulk formulae from Large and Yeager (2004)
+            <optional>
+              <element name="bulk_formulae">
+                <a:documentation>The type of bulk formulae to use. Default is NCAR if no selection is made.</a:documentation>
+                <choice>
+                  <element name="type">
+                    <a:documentation>Bulk formulae from Large and Yeager (2004)
 Large, W. G. &amp; Yeager, S. G. Diurnal to decadal global forcing
 for ocean and sea-ice models: The data sets and flux climatologies. NCAR TR.</a:documentation>
-                  <attribute name="name">
-                    <value>NCAR</value>
-                  </attribute>
-                  <empty/>
-                </element>
-                <element name="type">
-                  <a:documentation>Bulk formulae from Fairall et al (2003).
+                    <attribute name="name">
+                      <value>NCAR</value>
+                    </attribute>
+                    <empty/>
+                  </element>
+                  <element name="type">
+                    <a:documentation>Bulk formulae from Fairall et al (2003).
 Bulk Parameterization of Air–Sea Fluxes: Updates and
 Verification for the COARE Algorithm Journal of Climate, 2003, 16, 571-591</a:documentation>
-                  <attribute name="name">
-                    <value>COARE</value>
-                  </attribute>
-                  <empty/>
-                </element>
-                <element name="type">
-                  <a:documentation>Bulk formulae from Kara et al (2005).
+                    <attribute name="name">
+                      <value>COARE</value>
+                    </attribute>
+                    <empty/>
+                  </element>
+                  <element name="type">
+                    <a:documentation>Bulk formulae from Kara et al (2005).
 Stability-Dependent Exchange Coefficients for Air–Sea Fluxes
 Journal of Atmospheric and Oceanic Technology, 2005, 22, 1080-1094</a:documentation>
-                  <attribute name="name">
-                    <value>Kara</value>
-                  </attribute>
-                  <empty/>
-                </element>
-              </choice>
-            </element>
-          </optional>
-          <element name="input_file">
-            <a:documentation>The netCDF data file downloaded from ERA-40 reanalysis website
+                    <attribute name="name">
+                      <value>Kara</value>
+                    </attribute>
+                    <empty/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+            <element name="input_file">
+              <a:documentation>The netCDF data file downloaded from ERA-40 reanalysis website
 (see above)</a:documentation>
-            <attribute name="file_name">
-              <data type="string"/>
-            </attribute>
-          </element>
-          <optional>
-            <element name="input_file_type">
-              <choice>
-                <element name="type">
-                  <a:documentation>What kind of file is this? Currently only ERA40 files are supported</a:documentation>
-                  <attribute name="name">
-                    <value>ERA40</value>
-                  </attribute>
-                  <optional>
-                    <element name="no_accumulation">
-                      <a:documentation>The data from ERA40 website included accumulated values (ppt, ro, ssrd, strd).
+              <attribute name="file_name">
+                <data type="string"/>
+              </attribute>
+            </element>
+            <optional>
+              <element name="input_file_type">
+                <choice>
+                  <element name="type">
+                    <a:documentation>What kind of file is this? Currently only ERA40 files are supported</a:documentation>
+                    <attribute name="name">
+                      <value>ERA40</value>
+                    </attribute>
+                    <optional>
+                      <element name="no_accumulation">
+                        <a:documentation>The data from ERA40 website included accumulated values (ppt, ro, ssrd, strd).
 If these values have been already ammended to instantaneous values, then switch this
 flag on and the accumulation correction will not be applied.</a:documentation>
-                      <empty/>
-                    </element>
-                  </optional>
-                </element>
-                <element name="type">
-                  <attribute name="name">
-                    <value>NSEP</value>
-                  </attribute>
-                  <empty/>
-                </element>
-                <element name="type">
-                  <attribute name="name">
-                    <value>ICOM</value>
-                  </attribute>
-                  <empty/>
-                </element>
-              </choice>
-            </element>
-          </optional>
-          <optional>
-            <element name="position">
-              <a:documentation>Adding a latitude and longitude here (specified as two real numbers)
+                        <empty/>
+                      </element>
+                    </optional>
+                  </element>
+                  <element name="type">
+                    <attribute name="name">
+                      <value>NSEP</value>
+                    </attribute>
+                    <empty/>
+                  </element>
+                  <element name="type">
+                    <attribute name="name">
+                      <value>ICOM</value>
+                    </attribute>
+                    <empty/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+            <optional>
+              <element name="position">
+                <a:documentation>Adding a latitude and longitude here (specified as two real numbers)
 will obtain data from the forcing file at that location. The
 mesh is not translated nor is the mesh put on the sphere, instead the
 specified lat/long is translated into cartesian coordinates and this is simply
 added to the surface mesh node coordinates when fluxes are calculated.</a:documentation>
-              <ref name="real_vector"/>
-              <optional>
-                <element name="single_location">
-                  <a:documentation>Turning on this option will cause all nodes on the surface mesh to
+                <ref name="real_vector"/>
+                <optional>
+                  <element name="single_location">
+                    <a:documentation>Turning on this option will cause all nodes on the surface mesh to
 experience the same forcing, regardless of position. Only really
 useful for psuedo-1D simulations.</a:documentation>
-                  <empty/>
+                    <empty/>
+                  </element>
+                </optional>
+              </element>
+            </optional>
+            <element name="output_fluxes_diagnostics">
+              <a:documentation>Ouput some extra diagnostic fields for the momentum, temperature and salinity fluxes
+These &lt;b&gt;must&lt;/b&gt; be on the velocity mesh</a:documentation>
+              <optional>
+                <element name="vector_field">
+                  <attribute name="rank">
+                    <value>1</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>MomentumFlux</value>
+                  </attribute>
+                  <choice>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
+                    <element name="aliased">
+                      <ref name="generic_aliased_field"/>
+                    </element>
+                  </choice>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>HeatFlux</value>
+                  </attribute>
+                  <choice>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
+                    <element name="aliased">
+                      <ref name="generic_aliased_field"/>
+                    </element>
+                  </choice>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>SalinityFlux</value>
+                  </attribute>
+                  <choice>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
+                    <element name="aliased">
+                      <ref name="generic_aliased_field"/>
+                    </element>
+                  </choice>
+                </element>
+              </optional>
+              <optional>
+                <element name="scalar_field">
+                  <attribute name="rank">
+                    <value>0</value>
+                  </attribute>
+                  <attribute name="name">
+                    <value>PhotosyntheticRadiationDownward</value>
+                  </attribute>
+                  <choice>
+                    <element name="diagnostic">
+                      <ref name="internal_algorithm"/>
+                      <ref name="velocity_mesh_choice"/>
+                      <ref name="diagnostic_scalar_field"/>
+                    </element>
+                    <element name="aliased">
+                      <ref name="generic_aliased_field"/>
+                    </element>
+                  </choice>
                 </element>
               </optional>
             </element>
-          </optional>
-          <element name="output_fluxes_diagnostics">
-            <a:documentation>Ouput some extra diagnostic fields for the momentum, temperature and salinity fluxes
-These &lt;b&gt;must&lt;/b&gt; be on the velocity mesh</a:documentation>
-            <optional>
-              <element name="vector_field">
-                <attribute name="rank">
-                  <value>1</value>
-                </attribute>
-                <attribute name="name">
-                  <value>MomentumFlux</value>
-                </attribute>
-                <choice>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
-                  </element>
-                  <element name="aliased">
-                    <ref name="generic_aliased_field"/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-            <optional>
-              <element name="scalar_field">
-                <attribute name="rank">
-                  <value>0</value>
-                </attribute>
-                <attribute name="name">
-                  <value>HeatFlux</value>
-                </attribute>
-                <choice>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
-                  </element>
-                  <element name="aliased">
-                    <ref name="generic_aliased_field"/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-            <optional>
-              <element name="scalar_field">
-                <attribute name="rank">
-                  <value>0</value>
-                </attribute>
-                <attribute name="name">
-                  <value>SalinityFlux</value>
-                </attribute>
-                <choice>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
-                  </element>
-                  <element name="aliased">
-                    <ref name="generic_aliased_field"/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
-            <optional>
-              <element name="scalar_field">
-                <attribute name="rank">
-                  <value>0</value>
-                </attribute>
-                <attribute name="name">
-                  <value>PhotosyntheticRadiationDownward</value>
-                </attribute>
-                <choice>
-                  <element name="diagnostic">
-                    <ref name="internal_algorithm"/>
-                    <ref name="velocity_mesh_choice"/>
-                    <ref name="diagnostic_scalar_field"/>
-                  </element>
-                  <element name="aliased">
-                    <ref name="generic_aliased_field"/>
-                  </element>
-                </choice>
-              </element>
-            </optional>
           </element>
-        </element>
-      </optional>
-      <optional>
-        <element name="tidal_forcing">
-          <a:documentation>Tidal forcing options</a:documentation>
-          <optional>
-            <element name="M2">
-              <a:documentation>M2</a:documentation>
-              <optional>
-                <element name="frequency">
-                  <a:documentation>Ancient frequencies:
+        </optional>
+        <optional>
+          <element name="tidal_forcing">
+            <a:documentation>Tidal forcing options</a:documentation>
+            <optional>
+              <element name="M2">
+                <a:documentation>M2</a:documentation>
+                <optional>
+                  <element name="frequency">
+                    <a:documentation>Ancient frequencies:
 
 Ma     Frequency
 
@@ -8974,12 +9039,12 @@ Ma     Frequency
 570    1.469e-4
 
 From Poliakow,2005</a:documentation>
-                  <ref name="real"/>
-                </element>
-              </optional>
-              <optional>
-                <element name="amplitude">
-                  <a:documentation>Ma     Amplitude
+                    <ref name="real"/>
+                  </element>
+                </optional>
+                <optional>
+                  <element name="amplitude">
+                    <a:documentation>Ma     Amplitude
 
 0        0.2423
 
@@ -9004,169 +9069,124 @@ From Poliakow,2005</a:documentation>
 570    0.2560
 
 From Poliakow,2005</a:documentation>
+                    <ref name="real"/>
+                  </element>
+                </optional>
+              </element>
+            </optional>
+            <optional>
+              <element name="S2">
+                <a:documentation>S2</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="N2">
+                <a:documentation>N2</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="K2">
+                <a:documentation>K2</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="K1">
+                <a:documentation>K1</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="O1">
+                <a:documentation>O1</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="P1">
+                <a:documentation>P1</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="Q1">
+                <a:documentation>Q1</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="Mf">
+                <a:documentation>Mf</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="Mm">
+                <a:documentation>Mm</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="Ssa">
+                <a:documentation>Ssa</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="all_tidal_components">
+                <a:documentation>Switch on all tidal components</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+            <optional>
+              <element name="love_number">
+                <a:documentation>Sets a user defined Love number. If not active a value of 1.0 is used.
+Recommended value is 0.693</a:documentation>
+                <element name="value">
                   <ref name="real"/>
                 </element>
-              </optional>
-            </element>
-          </optional>
-          <optional>
-            <element name="S2">
-              <a:documentation>S2</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="N2">
-              <a:documentation>N2</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="K2">
-              <a:documentation>K2</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="K1">
-              <a:documentation>K1</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="O1">
-              <a:documentation>O1</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="P1">
-              <a:documentation>P1</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="Q1">
-              <a:documentation>Q1</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="Mf">
-              <a:documentation>Mf</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="Mm">
-              <a:documentation>Mm</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="Ssa">
-              <a:documentation>Ssa</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="all_tidal_components">
-              <a:documentation>Switch on all tidal components</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-          <optional>
-            <element name="love_number">
-              <a:documentation>Sets a user defined Love number. If not active a value of 1.0 is used.
-Recommended value is 0.693</a:documentation>
-              <element name="value">
-                <ref name="real"/>
               </element>
-            </element>
-          </optional>
-          <optional>
-            <element name="sal">
-              <a:documentation>Self attraction and loading term (SAL). This is a simple implementation
+            </optional>
+            <optional>
+              <element name="sal">
+                <a:documentation>Self attraction and loading term (SAL). This is a simple implementation
 that uses a constant beta value</a:documentation>
-              <element name="beta">
-                <ref name="real"/>
+                <element name="beta">
+                  <ref name="real"/>
+                </element>
               </element>
-            </element>
-          </optional>
-          <optional>
-            <element name="chi">
-              <a:documentation>Add the CHI term to the harmonics. You probably only want to do this is you're simulating a specific time</a:documentation>
-              <empty/>
-            </element>
-          </optional>
-        </element>
-      </optional>
-    </element>
-  </define>
-  <define name="biology">
-    <element name="ocean_biology">
-      <a:documentation>Model of biological processes in the ocean.</a:documentation>
-      <choice>
-        <element name="pznd">
-          <a:documentation>A simple model of phytoplankton, zooplankton, general nutrient and detritus.</a:documentation>
-          <choice>
-            <element name="source_and_sink_algorithm">
-              <a:documentation>Python code specifying the source and sink relationships
+            </optional>
+            <optional>
+              <element name="chi">
+                <a:documentation>Add the CHI term to the harmonics. You probably only want to do this is you're simulating a specific time</a:documentation>
+                <empty/>
+              </element>
+            </optional>
+          </element>
+        </optional>
+      </element>
+    </define>
+    <define name="biology">
+      <element name="ocean_biology">
+        <a:documentation>Model of biological processes in the ocean.</a:documentation>
+        <choice>
+          <element name="pznd">
+            <a:documentation>A simple model of phytoplankton, zooplankton, general nutrient and detritus.</a:documentation>
+            <choice>
+              <element name="source_and_sink_algorithm">
+                <a:documentation>Python code specifying the source and sink relationships
 between the biological tracers. This is usually achieved by
 importing fluidity.ocean_biology and calling a scheme from there.</a:documentation>
-              <ref name="python_code"/>
-            </element>
-            <element name="disable_sources_and_sinks">
-              <a:documentation>Do not calculate sources and sinks.
-This option is generally only useful for testing.</a:documentation>
-              <empty/>
-            </element>
-          </choice>
-          <element name="scalar_field">
-            <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
-            <attribute name="rank">
-              <value>0</value>
-            </attribute>
-            <attribute name="name">
-              <value>PhotosyntheticRadiation</value>
-            </attribute>
-            <choice>
-              <element name="prognostic">
-                <ref name="velocity_mesh_choice"/>
-                <ref name="prognostic_photosynthetic_radiation"/>
+                <ref name="python_code"/>
               </element>
-              <element name="prescribed">
-                <ref name="velocity_mesh_choice"/>
-                <ref name="prescribed_scalar_field"/>
+              <element name="disable_sources_and_sinks">
+                <a:documentation>Do not calculate sources and sinks.
+This option is generally only useful for testing.</a:documentation>
+                <empty/>
               </element>
             </choice>
-          </element>
-        </element>
-        <element name="six_component">
-          <a:documentation>6 component biology model, which models Nitrates, Ammonium,
-Phytoplankton, Zooplankton, Detritus and Chlorophyll.
-
-These fields must be enabled in the material phase
-
-Based on the equations in
-Popova, E. E.; Coward, A. C.; Nurser, G. A.; de Cuevas, B.; Fasham, M. J. R. &amp; Anderson, T. R.
-Mechanisms controlling primary and new production in a global ecosystem model - Part I:
-Validation of the biological simulation Ocean Science, 2006, 2, 249-266.
-DOI: 10.5194/os-2-249-2006</a:documentation>
-          <choice>
-            <element name="source_and_sink_algorithm">
-              <a:documentation>Python code specifying the biology model. This takes
-in velocity and light and outputs Phytoplankton, if
-those fields exist.</a:documentation>
-              <ref name="python_code"/>
-            </element>
-            <element name="disable_sources_and_sinks">
-              <a:documentation>Do not calculate biology
-This option is generally only useful for testing.</a:documentation>
-              <empty/>
-            </element>
-          </choice>
-          <optional>
             <element name="scalar_field">
               <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
               <attribute name="rank">
@@ -9186,120 +9206,165 @@ This option is generally only useful for testing.</a:documentation>
                 </element>
               </choice>
             </element>
-          </optional>
-        </element>
-      </choice>
-    </element>
-  </define>
-  <define name="prognostic_photosynthetic_radiation">
-    <element name="equation">
-      <a:documentation>PAR equation.</a:documentation>
-      <attribute name="name">
-        <value>PhotosyntheticRadiation</value>
-      </attribute>
-    </element>
-    <element name="spatial_discretisation">
-      <a:documentation>Spatial discretisation options</a:documentation>
-      <element name="discontinuous_galerkin">
-        <a:documentation>Discontinuous galerkin formulation. You can also use this
+          </element>
+          <element name="six_component">
+            <a:documentation>6 component biology model, which models Nitrates, Ammonium,
+Phytoplankton, Zooplankton, Detritus and Chlorophyll.
+
+These fields must be enabled in the material phase
+
+Based on the equations in
+Popova, E. E.; Coward, A. C.; Nurser, G. A.; de Cuevas, B.; Fasham, M. J. R. &amp; Anderson, T. R.
+Mechanisms controlling primary and new production in a global ecosystem model - Part I:
+Validation of the biological simulation Ocean Science, 2006, 2, 249-266.
+DOI: 10.5194/os-2-249-2006</a:documentation>
+            <choice>
+              <element name="source_and_sink_algorithm">
+                <a:documentation>Python code specifying the biology model. This takes
+in velocity and light and outputs Phytoplankton, if
+those fields exist.</a:documentation>
+                <ref name="python_code"/>
+              </element>
+              <element name="disable_sources_and_sinks">
+                <a:documentation>Do not calculate biology
+This option is generally only useful for testing.</a:documentation>
+                <empty/>
+              </element>
+            </choice>
+            <optional>
+              <element name="scalar_field">
+                <a:documentation>Photosynthetically Active Radiation (PAR)</a:documentation>
+                <attribute name="rank">
+                  <value>0</value>
+                </attribute>
+                <attribute name="name">
+                  <value>PhotosyntheticRadiation</value>
+                </attribute>
+                <choice>
+                  <element name="prognostic">
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="prognostic_photosynthetic_radiation"/>
+                  </element>
+                  <element name="prescribed">
+                    <ref name="velocity_mesh_choice"/>
+                    <ref name="prescribed_scalar_field"/>
+                  </element>
+                </choice>
+              </element>
+            </optional>
+          </element>
+        </choice>
+      </element>
+    </define>
+    <define name="prognostic_photosynthetic_radiation">
+      <element name="equation">
+        <a:documentation>PAR equation.</a:documentation>
+        <attribute name="name">
+          <value>PhotosyntheticRadiation</value>
+        </attribute>
+      </element>
+      <element name="spatial_discretisation">
+        <a:documentation>Spatial discretisation options</a:documentation>
+        <element name="discontinuous_galerkin">
+          <a:documentation>Discontinuous galerkin formulation. You can also use this
 formulation with a continuous field in which case a simple
 galerkin formulation will result.</a:documentation>
-        <empty/>
-      </element>
-    </element>
-    <element name="solver">
-      <a:documentation>Solver</a:documentation>
-      <ref name="linear_solver_options_asym_scalar"/>
-    </element>
-    <!-- Alas, no initial_condition either, so we'd better not checkpoint it... -->
-    <element name="exclude_from_checkpointing">
-      <a:documentation>Disables checkpointing of this field</a:documentation>
-      <ref name="comment"/>
-    </element>
-    <element name="absorption_coefficients">
-      <a:documentation>Coefficients of absorption of photosynthetically active
-radiation for water and phytoplankton.</a:documentation>
-      <element name="water">
-        <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
-        <ref name="real"/>
-      </element>
-      <element name="phytoplankton">
-        <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
-        <ref name="real"/>
-      </element>
-    </element>
-    <optional>
-      <element name="boundary_conditions">
-        <a:documentation>Boundary conditions</a:documentation>
-        <attribute name="name">
-          <data type="string" datatypeLibrary=""/>
-        </attribute>
-        <element name="surface_ids">
-          <a:documentation>Surface id:</a:documentation>
-          <ref name="integer_vector"/>
+          <empty/>
         </element>
-        <choice>
-          <a:documentation>Type</a:documentation>
-          <element name="type">
-            <attribute name="name">
-              <value>dirichlet</value>
-            </attribute>
-            <element name="apply_weakly">
-              <a:documentation>Apply the dirichlet bc weakly.  Only available with
+      </element>
+      <element name="solver">
+        <a:documentation>Solver</a:documentation>
+        <ref name="linear_solver_options_asym_scalar"/>
+      </element>
+      <!-- Alas, no initial_condition either, so we'd better not checkpoint it... -->
+      <element name="exclude_from_checkpointing">
+        <a:documentation>Disables checkpointing of this field</a:documentation>
+        <ref name="comment"/>
+      </element>
+      <element name="absorption_coefficients">
+        <a:documentation>Coefficients of absorption of photosynthetically active
+radiation for water and phytoplankton.</a:documentation>
+        <element name="water">
+          <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
+          <ref name="real"/>
+        </element>
+        <element name="phytoplankton">
+          <a:documentation>Photosynthetically active radiation absorption coefficient for water.</a:documentation>
+          <ref name="real"/>
+        </element>
+      </element>
+      <optional>
+        <element name="boundary_conditions">
+          <a:documentation>Boundary conditions</a:documentation>
+          <attribute name="name">
+            <data type="string" datatypeLibrary=""/>
+          </attribute>
+          <element name="surface_ids">
+            <a:documentation>Surface id:</a:documentation>
+            <ref name="integer_vector"/>
+          </element>
+          <choice>
+            <a:documentation>Type</a:documentation>
+            <element name="type">
+              <attribute name="name">
+                <value>dirichlet</value>
+              </attribute>
+              <element name="apply_weakly">
+                <a:documentation>Apply the dirichlet bc weakly.  Only available with
 discontinuous_galerkin and control_volume
 spatial_discretisations.
 
 If not selected boundary conditions are applied strongly.</a:documentation>
+                <empty/>
+              </element>
+              <ref name="input_choice_real"/>
+            </element>
+            <element name="type">
+              <attribute name="name">
+                <value>bulk_formulae</value>
+              </attribute>
               <empty/>
             </element>
-            <ref name="input_choice_real"/>
-          </element>
-          <element name="type">
-            <attribute name="name">
-              <value>bulk_formulae</value>
-            </attribute>
-            <empty/>
-          </element>
-          <element name="type">
-            <attribute name="name">
-              <value>neumann</value>
-            </attribute>
-            <ref name="input_choice_real"/>
-          </element>
-        </choice>
-      </element>
-    </optional>
-    <ref name="prognostic_scalar_output_options"/>
-    <ref name="prognostic_scalar_stat_options"/>
-    <ref name="scalar_convergence_options"/>
-    <ref name="prognostic_detector_options"/>
-    <ref name="scalar_steady_state_options"/>
-    <ref name="adaptivity_options_scalar_field"/>
-    <optional>
-      <element name="priority">
-        <a:documentation>Set the priority of this field
+            <element name="type">
+              <attribute name="name">
+                <value>neumann</value>
+              </attribute>
+              <ref name="input_choice_real"/>
+            </element>
+          </choice>
+        </element>
+      </optional>
+      <ref name="prognostic_scalar_output_options"/>
+      <ref name="prognostic_scalar_stat_options"/>
+      <ref name="scalar_convergence_options"/>
+      <ref name="prognostic_detector_options"/>
+      <ref name="scalar_steady_state_options"/>
+      <ref name="adaptivity_options_scalar_field"/>
+      <optional>
+        <element name="priority">
+          <a:documentation>Set the priority of this field
 This determines the order in which scalar_fields are solved for:
  - higher numbers have the highest priority
  - lower numbers (including negative) have the lowest priority
  - default if not set is 0</a:documentation>
-        <ref name="integer"/>
-      </element>
-    </optional>
-  </define>
-  <define name="recalculation_options">
-    <element name="do_not_recalculate">
-      <a:documentation>Prevent this field from being recalculated at every timestep.
+          <ref name="integer"/>
+        </element>
+      </optional>
+    </define>
+    <define name="recalculation_options">
+      <element name="do_not_recalculate">
+        <a:documentation>Prevent this field from being recalculated at every timestep.
 This is cheaper especially if you are enforcing discrete properties on the field.</a:documentation>
-      <empty/>
-    </element>
-  </define>
-  <define name="discrete_properties_algorithm_scalar">
-    <element name="enforce_discrete_properties">
-      <a:documentation>Select discrete properties to enforce on the field
+        <empty/>
+      </element>
+    </define>
+    <define name="discrete_properties_algorithm_scalar">
+      <element name="enforce_discrete_properties">
+        <a:documentation>Select discrete properties to enforce on the field
 either after being prescribed or interpolated</a:documentation>
-      <optional>
-        <element name="solenoidal_lagrange_update">
-          <a:documentation>Update this field using the lagrangian multiplier
+        <optional>
+          <element name="solenoidal_lagrange_update">
+            <a:documentation>Update this field using the lagrangian multiplier
 calculated in the solenoidal projection of a
 scalar field.
 
@@ -9308,23 +9373,23 @@ underneath that vector field too.
 
 Note also this only really makes sense for coupled
 fields like velocity and pressure.</a:documentation>
-          <empty/>
-        </element>
-      </optional>
-    </element>
-  </define>
-  <define name="discrete_properties_algorithm_vector">
-    <element name="enforce_discrete_properties">
-      <a:documentation>Select discrete properties to enforce on the field
+            <empty/>
+          </element>
+        </optional>
+      </element>
+    </define>
+    <define name="discrete_properties_algorithm_vector">
+      <element name="enforce_discrete_properties">
+        <a:documentation>Select discrete properties to enforce on the field
 either after being prescribed or interpolated</a:documentation>
-      <optional>
-        <ref name="solenoidal_options"/>
-      </optional>
-    </element>
-  </define>
-  <define name="solenoidal_options">
-    <element name="solenoidal">
-      <a:documentation>Constrained divergence-free projection.
+        <optional>
+          <ref name="solenoidal_options"/>
+        </optional>
+      </element>
+    </define>
+    <define name="solenoidal_options">
+      <element name="solenoidal">
+        <a:documentation>Constrained divergence-free projection.
 This adds an additional constraint that ensures that the field
 is solenoidal, i.e. divergence-free.
 This is equivalent in cost to a pressure solve.
@@ -9333,94 +9398,94 @@ needed.
 
 Note well: this only makes sense for nondivergent
 vector fields, such as incompressible velocity!</a:documentation>
-      <element name="interpolated_field">
-        <a:documentation>Options for the mass matrix of the field being interpolated</a:documentation>
-        <choice>
-          <element name="continuous">
-            <element name="lump_mass_matrix">
-              <a:documentation>Lump the mass matrix for the assembly of the projection matrix
+        <element name="interpolated_field">
+          <a:documentation>Options for the mass matrix of the field being interpolated</a:documentation>
+          <choice>
+            <element name="continuous">
+              <element name="lump_mass_matrix">
+                <a:documentation>Lump the mass matrix for the assembly of the projection matrix
 (not for the initial galerkin projection)
 
 Required when using interpolating continuous fields</a:documentation>
-              <optional>
-                <element name="use_submesh">
-                  <a:documentation>Lump on the submesh.
+                <optional>
+                  <element name="use_submesh">
+                    <a:documentation>Lump on the submesh.
 This only works for simplex meshes and is only
 strictly valid on 2d meshes.</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-            </element>
-          </element>
-          <element name="discontinuous">
-            <optional>
-              <element name="lump_mass_matrix">
-                <a:documentation>Lump the mass matrix for the assembly of the projection matrix
-(not for the initial galerkin projection)</a:documentation>
-                <empty/>
+                    <empty/>
+                  </element>
+                </optional>
               </element>
-            </optional>
-          </element>
-        </choice>
-      </element>
-      <element name="lagrange_multiplier">
-        <a:documentation>Options for the lagrange multiplier
-
-Must be on a continuous mesh!</a:documentation>
-        <ref name="pressure_mesh_choice"/>
-        <element name="spatial_discretisation">
-          <choice>
-            <element name="continuous_galerkin">
-              <optional>
-                <element name="remove_stabilisation_term">
-                  <a:documentation>Remove the stabilisation term from the projection operator.
-
-Automatic when not using P1P1.</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-              <optional>
-                <element name="integrate_divergence_by_parts">
-                  <a:documentation>Integrate the divergence operator by parts.
-
-Automatic when projecting a discontinuous field</a:documentation>
-                  <empty/>
-                </element>
-              </optional>
-              <optional>
-                <element name="test_divergence_with_cv_dual">
-                  <a:documentation>Test the divergence equation with the control volume dual mesh
-of the finite element lagrange multiplier mesh.
-This will make the lagrange multiplier matrix non symmetric which must be
-considered when selecting the lagrange multiplier  solver options.</a:documentation>
-                  <ref name="comment"/>
-                </element>
-              </optional>
             </element>
-            <element name="control_volumes">
-              <empty/>
+            <element name="discontinuous">
+              <optional>
+                <element name="lump_mass_matrix">
+                  <a:documentation>Lump the mass matrix for the assembly of the projection matrix
+(not for the initial galerkin projection)</a:documentation>
+                  <empty/>
+                </element>
+              </optional>
             </element>
           </choice>
         </element>
-        <optional>
-          <element name="reference_node">
-            <ref name="integer"/>
+        <element name="lagrange_multiplier">
+          <a:documentation>Options for the lagrange multiplier
+
+Must be on a continuous mesh!</a:documentation>
+          <ref name="pressure_mesh_choice"/>
+          <element name="spatial_discretisation">
+            <choice>
+              <element name="continuous_galerkin">
+                <optional>
+                  <element name="remove_stabilisation_term">
+                    <a:documentation>Remove the stabilisation term from the projection operator.
+
+Automatic when not using P1P1.</a:documentation>
+                    <empty/>
+                  </element>
+                </optional>
+                <optional>
+                  <element name="integrate_divergence_by_parts">
+                    <a:documentation>Integrate the divergence operator by parts.
+
+Automatic when projecting a discontinuous field</a:documentation>
+                    <empty/>
+                  </element>
+                </optional>
+                <optional>
+                  <element name="test_divergence_with_cv_dual">
+                    <a:documentation>Test the divergence equation with the control volume dual mesh
+of the finite element lagrange multiplier mesh.
+This will make the lagrange multiplier matrix non symmetric which must be
+considered when selecting the lagrange multiplier  solver options.</a:documentation>
+                    <ref name="comment"/>
+                  </element>
+                </optional>
+              </element>
+              <element name="control_volumes">
+                <empty/>
+              </element>
+            </choice>
           </element>
-        </optional>
-        <optional>
-          <element name="repair_stiff_nodes">
-            <a:documentation>**UNDER DEVELOPMENT**
+          <optional>
+            <element name="reference_node">
+              <ref name="integer"/>
+            </element>
+          </optional>
+          <optional>
+            <element name="repair_stiff_nodes">
+              <a:documentation>**UNDER DEVELOPMENT**
 This searches the CMC matrix diagonal looking for nodes that are less than the maximum value time epsilon(0.0) (i.e. nodes that are effectively zero).
 It then zeros that row and column and places a one on the diagonal and a zero on the rhs.
 At a debug level of 2 it also prints out the value and the sum of the row values.
 This is useful as a debugging tool if PETSc complains about zeros on the diagonal (i.e. if you have a stiff node in your mesh) but doesn't necessary produce nice answers at the end.</a:documentation>
-            <empty/>
-          </element>
-        </optional>
-        <optional>
-          <choice>
-            <element name="update_scalar_field">
-              <a:documentation>Update a scalar field using the lagrange multiplier from
+              <empty/>
+            </element>
+          </optional>
+          <optional>
+            <choice>
+              <element name="update_scalar_field">
+                <a:documentation>Update a scalar field using the lagrange multiplier from
 the divergence free projection of this field.  The selected
 scalar field must have solenoidal selected in its interpolation
 options too and it must be on the same mesh as used for the
@@ -9428,13 +9493,13 @@ solenoidal projection above.
 
 Note well: this only really makes sense for scalar fields linked to nondivergent
 vector fields, such as pressure to incompressible velocity!</a:documentation>
-              <attribute name="name">
-                <value>Pressure</value>
-              </attribute>
-              <empty/>
-            </element>
-            <element name="update_scalar_field">
-              <a:documentation>Update a scalar field using the lagrange multiplier from
+                <attribute name="name">
+                  <value>Pressure</value>
+                </attribute>
+                <empty/>
+              </element>
+              <element name="update_scalar_field">
+                <a:documentation>Update a scalar field using the lagrange multiplier from
 the divergence free projection of this field.  The selected
 scalar field must have solenoidal selected in its interpolation
 options too and it must be on the same mesh as used for the
@@ -9442,27 +9507,27 @@ solenoidal projection above.
 
 Note well: this only really makes sense for scalar fields linked to nondivergent
 vector fields, such as pressure to incompressible velocity!</a:documentation>
-              <attribute name="name">
-                <data type="string" datatypeLibrary=""/>
-              </attribute>
-              <empty/>
-            </element>
-          </choice>
-        </optional>
-        <element name="solver">
-          <a:documentation>Solver options for the linear solve.
+                <attribute name="name">
+                  <data type="string" datatypeLibrary=""/>
+                </attribute>
+                <empty/>
+              </element>
+            </choice>
+          </optional>
+          <element name="solver">
+            <a:documentation>Solver options for the linear solve.
 This method requires the inversion of a projection matrix.</a:documentation>
-          <ref name="linear_solver_options_sym"/>
+            <ref name="linear_solver_options_sym"/>
+          </element>
         </element>
       </element>
-    </element>
-  </define>
-  <define name="represcribe_before_interpolation">
-    <element name="represcribe_before_interpolation">
-      <a:documentation>Represcribe the field before interpolation.
+    </define>
+    <define name="represcribe_before_interpolation">
+      <element name="represcribe_before_interpolation">
+        <a:documentation>Represcribe the field before interpolation.
 
 This means the interpolation will not be conservative from the previous mesh so be careful what you're trying to achieve!</a:documentation>
-      <empty/>
-    </element>
-  </define>
-</grammar>
+        <empty/>
+      </element>
+    </define>
+  </grammar>

--- a/tests/lagrange_tracer_lowcourant/lagrange_tracer.flml
+++ b/tests/lagrange_tracer_lowcourant/lagrange_tracer.flml
@@ -74,10 +74,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="field">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
-  return fields["Field"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val (X, t, dt, fields):
+    return fields["Field"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/lagrange_tracer_lowcourant/lagrange_tracer.flml
+++ b/tests/lagrange_tracer_lowcourant/lagrange_tracer.flml
@@ -74,12 +74,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="field">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val (X, t, dt, fields):
     return fields["Field"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attribute_array/particle-attribute-array.flml
+++ b/tests/particle_attribute_array/particle-attribute-array.flml
@@ -95,97 +95,112 @@
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,n):
-  import numpy as np
-  r = np.arange(n)
-  return r</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
+    from numpy import arange
+    return arange(n)</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute_array>
           <scalar_attribute_array name="ArrayFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.arange(n) + fields["tenstest"][1,1]</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange
+    return arange(n) + fields["tenstest"][1, 1]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute_array>
           <scalar_attribute_array name="ArrayOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.arange(n) + fields["old%ArrayFieldAttribute"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange
+    return arange(n) + fields["old%ArrayFieldAttribute"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute_array>
           <vector_attribute_array name="VectorArrayAttribute">
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,n):
-  import numpy as np
-  r = np.arange(n)
-  return np.zeros((n,2)) + r[:,None]</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 1)).T</string_value>
+              </python>
+            </value_on_advection>
           </vector_attribute_array>
           <vector_attribute_array name="VectorFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.zeros((n,2)) + np.arange(n)[:,None] + fields["vectest"][1]</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 1)).T + fields["vectest"][1]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </vector_attribute_array>
           <vector_attribute_array name="VectorOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.zeros((n,2)) + np.arange(n)[:,None] + fields["old%VectorFieldAttribute"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 1)).T + fields["old%VectorFieldAttribute"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </vector_attribute_array>
           <tensor_attribute_array name="TensorArrayAttribute">
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,n):
-  import numpy as np
-  r = np.arange(n)
-  return np.zeros((n,2,2)) + r[:,None,None]</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 2, 1)).T</string_value>
+              </python>
+            </value_on_advection>
           </tensor_attribute_array>
           <tensor_attribute_array name="TensorFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.zeros((n,2,2)) + np.arange(n)[:,None,None] + fields["tenstest"]</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 2, 1)).T + fields["tenstest"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </tensor_attribute_array>
           <tensor_attribute_array name="TensorOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields,n):
-  import numpy as np
-  return np.zeros((n,2,2)) + np.arange(n)[:,None,None] + fields["old%TensorFieldAttribute"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
+    from numpy import arange, tile
+    return tile(arange(n), (2, 2, 1)).T + fields["old%TensorFieldAttribute"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </tensor_attribute_array>
         </attributes>
       </particle_subgroup>
@@ -214,44 +229,55 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="ScalarAttribute">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  return 1</string_value>
-            </python>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="ScalarFieldAttribute">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  return fields["Temperature"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <vector_attribute name="VectorAttribute">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  import numpy as np
-  return np.random.rand(2)</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    from numpy.random import default_rng
+    return default_rng().random(2)</string_value>
+              </python>
+            </value_on_advection>
           </vector_attribute>
           <vector_attribute name="VectorFieldAttribute">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  import numpy as np
-  return np.random.rand(2) + fields["Temperature"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy.random import default_rng
+    return default_rng().random(2) + fields["Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </vector_attribute>
           <tensor_attribute name="TensorAttribute">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  import numpy as np
-  return np.random.rand(2,2)</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    from numpy.random import default_rng
+    return default_rng().random((2, 2))</string_value>
+              </python>
+            </value_on_advection>
           </tensor_attribute>
           <tensor_attribute name="TensorFieldAttribute">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  import numpy as np
-  return np.random.rand(2,2) + fields["Temperature"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy.random import default_rng
+    return default_rng().random((2, 2)) + fields["Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </tensor_attribute>
         </attributes>
       </particle_subgroup>
@@ -271,12 +297,13 @@
               <integer_value rank="0">10</integer_value>
             </dimension>
             <exclude_from_output/>
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,n):
-  import numpy as np
-  r = np.arange(n)
-  return r</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
+    from numpy import arange
+    return arange(n)</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attribute_array/particle-attribute-array.flml
+++ b/tests/particle_attribute_array/particle-attribute-array.flml
@@ -95,112 +95,112 @@
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
     from numpy import arange
     return arange(n)</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
           <scalar_attribute_array name="ArrayFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange
     return arange(n) + fields["tenstest"][1, 1]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
           <scalar_attribute_array name="ArrayOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange
     return arange(n) + fields["old%ArrayFieldAttribute"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
           <vector_attribute_array name="VectorArrayAttribute">
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 1)).T</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute_array>
           <vector_attribute_array name="VectorFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 1)).T + fields["vectest"][1]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute_array>
           <vector_attribute_array name="VectorOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 1)).T + fields["old%VectorFieldAttribute"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute_array>
           <tensor_attribute_array name="TensorArrayAttribute">
             <dimension>
               <integer_value rank="0">10</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 2, 1)).T</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute_array>
           <tensor_attribute_array name="TensorFieldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 2, 1)).T + fields["tenstest"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute_array>
           <tensor_attribute_array name="TensorOldAttribute">
             <dimension>
               <integer_value rank="0">5</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields, n):
     from numpy import arange, tile
     return tile(arange(n), (2, 2, 1)).T + fields["old%TensorFieldAttribute"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute_array>
         </attributes>
       </particle_subgroup>
@@ -229,55 +229,55 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="ScalarAttribute">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="ScalarFieldAttribute">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <vector_attribute name="VectorAttribute">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     from numpy.random import default_rng
     return default_rng().random(2)</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute>
           <vector_attribute name="VectorFieldAttribute">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy.random import default_rng
     return default_rng().random(2) + fields["Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute>
           <tensor_attribute name="TensorAttribute">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     from numpy.random import default_rng
     return default_rng().random((2, 2))</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute>
           <tensor_attribute name="TensorFieldAttribute">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy.random import default_rng
     return default_rng().random((2, 2)) + fields["Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute>
         </attributes>
       </particle_subgroup>
@@ -297,13 +297,13 @@
               <integer_value rank="0">10</integer_value>
             </dimension>
             <exclude_from_output/>
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, n):
     from numpy import arange
     return arange(n)</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes/particle-attributes.flml
+++ b/tests/particle_attributes/particle-attributes.flml
@@ -66,19 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -94,29 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem4"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -134,12 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes/particle-attributes.flml
+++ b/tests/particle_attributes/particle-attributes.flml
@@ -66,17 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -92,28 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem4"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem4"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -131,11 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint/particle-attributes-checkpoint.flml
+++ b/tests/particle_attributes_checkpoint/particle-attributes-checkpoint.flml
@@ -71,25 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -105,28 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -144,11 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -166,19 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  time = t
-  return time</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  dt = t - fields["old%Time"]
-  return dt</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t - fields["old%Time"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint/particle-attributes-checkpoint.flml
+++ b/tests/particle_attributes_checkpoint/particle-attributes-checkpoint.flml
@@ -71,28 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -108,29 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -148,12 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -171,21 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t - fields["old%Time"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint_parallel/particle-attributes-checkpoint-parallel.flml
+++ b/tests/particle_attributes_checkpoint_parallel/particle-attributes-checkpoint-parallel.flml
@@ -71,25 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -105,28 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -144,11 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -166,19 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  time = t
-  return time</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  dt = t - fields["old%Time"]
-  return dt</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t - fields["old%Time"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint_parallel/particle-attributes-checkpoint-parallel.flml
+++ b/tests/particle_attributes_checkpoint_parallel/particle-attributes-checkpoint-parallel.flml
@@ -71,28 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -108,29 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -148,12 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -171,21 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t - fields["old%Time"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint_parallel_flredecomp/particle-attributes.flml
+++ b/tests/particle_attributes_checkpoint_parallel_flredecomp/particle-attributes.flml
@@ -71,25 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -105,28 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem2"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem2"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -144,11 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -166,19 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  time = t
-  return time</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  dt = t - fields["old%Time"]
-  return dt</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return t - fields["old%Time"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_checkpoint_parallel_flredecomp/particle-attributes.flml
+++ b/tests/particle_attributes_checkpoint_parallel_flredecomp/particle-attributes.flml
@@ -71,28 +71,28 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -108,29 +108,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem2"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -148,12 +148,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -171,21 +171,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Time">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="dt">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return t - fields["old%Time"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_outfreq/particle-attributes-outfreq.flml
+++ b/tests/particle_attributes_outfreq/particle-attributes-outfreq.flml
@@ -66,17 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -92,28 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"]+ fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem4"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem4"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -138,11 +141,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_outfreq/particle-attributes-outfreq.flml
+++ b/tests/particle_attributes_outfreq/particle-attributes-outfreq.flml
@@ -66,19 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -94,29 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"]+ fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem4"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -141,12 +141,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_parallel/particle-attributes-parallel.flml
+++ b/tests/particle_attributes_parallel/particle-attributes-parallel.flml
@@ -66,19 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -94,29 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem4"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -134,12 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_parallel/particle-attributes-parallel.flml
+++ b/tests/particle_attributes_parallel/particle-attributes-parallel.flml
@@ -66,17 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -92,28 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem4"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem4"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -131,11 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_parallel_repart/particle-attributes-parallel.flml
+++ b/tests/particle_attributes_parallel_repart/particle-attributes-parallel.flml
@@ -66,19 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -94,29 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem4"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -134,12 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_parallel_repart/particle-attributes-parallel.flml
+++ b/tests/particle_attributes_parallel_repart/particle-attributes-parallel.flml
@@ -66,17 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -92,28 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem4"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem4"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -131,11 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_zoltan/particle-attributes-zoltan.flml
+++ b/tests/particle_attributes_zoltan/particle-attributes-zoltan.flml
@@ -66,19 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">5</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -94,29 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return X[0] + t</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Chem4"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -134,12 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["Temperature"] - fields["old%Temperature"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_attributes_zoltan/particle-attributes-zoltan.flml
+++ b/tests/particle_attributes_zoltan/particle-attributes-zoltan.flml
@@ -66,17 +66,19 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">5</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">5</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  y=fields["old%Temperature"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -92,28 +94,29 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem3">
-            <python>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt):
-  x=X[0]
-  y=x+t
-  return y</string_value>
-            </python>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return X[0] + t</string_value>
+              </python>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x=X[0]
-  z=x+t+fields["Salinity"]+fields["Temperature"]
-  return z</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0] + t + fields["Salinity"] + fields["Temperature"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Chem5">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=fields["old%Chem4"]
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Chem4"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -131,11 +134,12 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem6">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  z=fields["Temperature"]-fields["old%Temperature"]
-  return z</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["Temperature"] - fields["old%Temperature"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_diagnostic_field_from_array/particle-diagnostic-field-from-array.flml
+++ b/tests/particle_diagnostic_field_from_array/particle-diagnostic-field-from-array.flml
@@ -115,25 +115,31 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute_array name="Buff">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <constant>
-              <real_value rank="0">999</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">999</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute_array>
           <scalar_attribute_array name="InsideArray">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>
@@ -161,25 +167,31 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute_array name="Buff">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <constant>
-              <real_value rank="0">999</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">999</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute_array>
           <scalar_attribute_array name="InsideArray">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_diagnostic_field_from_array/particle-diagnostic-field-from-array.flml
+++ b/tests/particle_diagnostic_field_from_array/particle-diagnostic-field-from-array.flml
@@ -115,31 +115,31 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute_array name="Buff">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">999</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
           <scalar_attribute_array name="InsideArray">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>
@@ -167,31 +167,31 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute_array name="Buff">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">999</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
           <scalar_attribute_array name="InsideArray">
             <dimension>
               <integer_value rank="0">3</integer_value>
             </dimension>
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute_array>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
+++ b/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
@@ -97,18 +97,18 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <value_on_initialisation>
+            <initial_attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_initialisation>
-            <value_on_advection>
+            </initial_attribute_value>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return abs(sign(fields["Temperature"] - fields["old%Temperature"]))</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -154,50 +154,50 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Xval">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Yval">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[1]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Xflag">
-            <value_on_initialisation>
+            <initial_attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_initialisation>
-            <value_on_advection>
+            </initial_attribute_value>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return sign(X[0] - fields["old%Xval"])</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Yflag">
-            <value_on_initialisation>
+            <initial_attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_initialisation>
-            <value_on_advection>
+            </initial_attribute_value>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return sign(X[1] - fields["old%Yval"])</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
+++ b/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
@@ -97,11 +97,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <value_on_spawn>
+            <value_on_initialisation>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_spawn>
+            </value_on_initialisation>
             <value_on_advection>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
@@ -172,11 +172,11 @@
             </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Xflag">
-            <value_on_spawn>
+            <value_on_initialisation>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_spawn>
+            </value_on_initialisation>
             <value_on_advection>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
@@ -186,11 +186,11 @@
             </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Yflag">
-            <value_on_spawn>
+            <value_on_initialisation>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_spawn>
+            </value_on_initialisation>
             <value_on_advection>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):

--- a/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
+++ b/tests/particle_diagnostic_fields/particle-diagnostic-fields.flml
@@ -76,7 +76,7 @@
           <integer_value rank="0">5</integer_value>
         </min_cv_threshhold>
         <max_cv_threshhold>
-          <integer_value rank="0">20</integer_value>
+          <integer_value rank="0">25</integer_value>
         </max_cv_threshhold>
         <spawn_location>
           <random/>
@@ -89,35 +89,26 @@
         <initial_position>
           <python>
             <string_value type="code" language="python" lines="20">def val(t):
-  from numpy import arange,zeros,reshape,concatenate,cos,pi
-  a=225
-  b=225
-  c=50625
-  x=zeros(c,float)
-  y=zeros(c,float)
-  k=0
-  for i in range(0,b):
-      for j in range(0,a):
-              x[k]=1.0*i/b
-              y[k]=1.0*j/b
-              k=k+1
+    from numpy import column_stack, linspace, repeat, tile
 
-  return reshape(concatenate((x,y)),(2,c)).T</string_value>
+    x = linspace(0, 1, 225)
+    return column_stack((tile(x, 225), repeat(x, 225)))</string_value>
           </python>
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    if (abs(fields["Temperature"]-fields["old%Temperature"])&gt;0.00001):
-      a = 1
-    else:
-      a = 0
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_spawn>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_spawn>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return abs(sign(fields["Temperature"] - fields["old%Temperature"]))</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -163,52 +154,50 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Xval">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x = X[0]
-  return x</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Yval">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y = X[1]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[1]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Xflag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    x = X[0]
-    oldx = fields["old%Xval"]
-    a=0
-    if (x&gt;oldx):
-      a = 1
-    if (x&lt;oldx):
-      a = -1
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_spawn>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_spawn>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return sign(X[0] - fields["old%Xval"])</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Yflag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    y = X[1]
-    oldy = fields["old%Yval"]
-    a=0
-    if (y&gt;oldy):
-      a = 1
-    if (y&lt;oldy):
-      a = -1
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_spawn>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_spawn>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return sign(X[1] - fields["old%Yval"])</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_dt_test/particle-dt-test.flml
+++ b/tests/particle_dt_test/particle-dt-test.flml
@@ -85,21 +85,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="DtVal">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return dt</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Dtchange">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
   return dt - fields["old%DtVal"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_dt_test/particle-dt-test.flml
+++ b/tests/particle_dt_test/particle-dt-test.flml
@@ -85,20 +85,21 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="DtVal">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x = dt
-  return x</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return dt</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Dtchange">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  oldDT = fields["old%DtVal"]
-  x = dt - oldDT
-  return x</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+  return dt - fields["old%DtVal"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_initialise_after_start/particle-initialise-after-start.flml
+++ b/tests/particle_initialise_after_start/particle-initialise-after-start.flml
@@ -58,42 +58,41 @@
         <initial_position>
           <python>
             <string_value type="code" language="python" lines="20">def val(t):
-  from numpy import arange,zeros,reshape,concatenate
-  if (t==0):
-    x = 0.25+0.5*arange(0,11.)/11.
-    y = zeros(11) + 0.5
-    a = reshape(concatenate((x,y)),(2,11)).T
-  return a</string_value>
+    from numpy import column_stack, linspace, ones
+    x = 0.25 + 0.5 * linspace(0, 1, 11)
+    y = 0.5 * ones(11)
+    return column_stack((x, y))</string_value>
           </python>
         </initial_position>
         <initialise_during_simulation>
           <python>
             <string_value type="code" language="python" lines="20">def val(t):
-  from numpy import arange,zeros,reshape,concatenate
-  if (t&gt;0.15 and t&lt;0.25):
-    x = 0.25+0.5*arange(0,11.)/11.
-    y = 0.25+0.5*arange(0,11.)/11.
-    a = reshape(concatenate((x,y)),(2,11)).T
-  elif (t&gt;0.45 and t&lt;0.55):
-    x = zeros(11) + 0.5
-    y = 0.25+0.5*arange(0,11.)/11.
-    a = reshape(concatenate((x,y)),(2,11)).T
-  else:
-    a = zeros([0,0])
-  return a</string_value>
+    from numpy import column_stack, linspace, ones
+    if 0.15 &lt; t &lt; 0.25:
+        x = 0.25 + 0.5 * linspace(0, 1, 11)
+        return column_stack((x, x))
+    elif 0.45 &lt; t &lt; 0.55:
+        x = 0.5 * ones(11)
+        y = 0.25 + 0.5 * linspace(0, 1, 11)
+        return column_stack((x, y))
+    else:
+        return []</string_value>
           </python>
         </initialise_during_simulation>
         <attributes>
           <scalar_attribute name="Chem1">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t==0):
-    y = 0
-  else:
-    y = fields['old%Chem1'] + 1
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_spawn>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_spawn>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields['old%Chem1'] + 1</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_initialise_after_start/particle-initialise-after-start.flml
+++ b/tests/particle_initialise_after_start/particle-initialise-after-start.flml
@@ -81,11 +81,11 @@
         </initialise_during_simulation>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_spawn>
+            <value_on_initialisation>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_spawn>
+            </value_on_initialisation>
             <value_on_advection>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):

--- a/tests/particle_initialise_after_start/particle-initialise-after-start.flml
+++ b/tests/particle_initialise_after_start/particle-initialise-after-start.flml
@@ -81,18 +81,18 @@
         </initialise_during_simulation>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_initialisation>
+            <initial_attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_initialisation>
-            <value_on_advection>
+            </initial_attribute_value>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields['old%Chem1'] + 1</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_initialise_after_start/particle_initialise_after_start.xml
+++ b/tests/particle_initialise_after_start/particle_initialise_after_start.xml
@@ -38,7 +38,7 @@ val = d['Chem1'][:][idx]
 
 attributes_error = np.zeros(11)
 for i in range(11,22):
-   attributes_error[i-11] = val[i] - 9
+   attributes_error[i-11] = val[i] - 8
 
 attributes_error_2=abs(attributes_error).max()
 
@@ -55,7 +55,7 @@ val = d['Chem1'][:][idx]
 
 attributes_error = np.zeros(11)
 for i in range(22,33):
-   attributes_error[i-22] = val[i] - 6
+   attributes_error[i-22] = val[i] - 5
 
 attributes_error_3=abs(attributes_error).max()
 

--- a/tests/particle_prescribed_vortex_flow/particle-prescribed-vortex-flow.flml
+++ b/tests/particle_prescribed_vortex_flow/particle-prescribed-vortex-flow.flml
@@ -115,9 +115,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -145,9 +147,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_prescribed_vortex_flow/particle-prescribed-vortex-flow.flml
+++ b/tests/particle_prescribed_vortex_flow/particle-prescribed-vortex-flow.flml
@@ -115,11 +115,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -147,11 +147,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_prescribed_vortex_flow_3d/particle-prescribed-vortex-flow-3d.flml
+++ b/tests/particle_prescribed_vortex_flow_3d/particle-prescribed-vortex-flow-3d.flml
@@ -97,9 +97,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -131,9 +133,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_prescribed_vortex_flow_3d/particle-prescribed-vortex-flow-3d.flml
+++ b/tests/particle_prescribed_vortex_flow_3d/particle-prescribed-vortex-flow-3d.flml
@@ -97,11 +97,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -133,11 +133,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Inside">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_rayleigh_taylor_adaptive/particle-rayleigh-taylor-adaptive.flml
+++ b/tests/particle_rayleigh_taylor_adaptive/particle-rayleigh-taylor-adaptive.flml
@@ -125,11 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -158,11 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_rayleigh_taylor_adaptive/particle-rayleigh-taylor-adaptive.flml
+++ b/tests/particle_rayleigh_taylor_adaptive/particle-rayleigh-taylor-adaptive.flml
@@ -125,9 +125,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -156,9 +158,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_rayleigh_taylor_checkpoint/particle-rayleigh-taylor-checkpoint.flml
+++ b/tests/particle_rayleigh_taylor_checkpoint/particle-rayleigh-taylor-checkpoint.flml
@@ -130,9 +130,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">0</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -161,9 +163,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <constant>
-              <real_value rank="0">1</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="0">1</real_value>
+              </constant>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_rayleigh_taylor_checkpoint/particle-rayleigh-taylor-checkpoint.flml
+++ b/tests/particle_rayleigh_taylor_checkpoint/particle-rayleigh-taylor-checkpoint.flml
@@ -130,11 +130,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -163,11 +163,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Chem1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="0">1</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_vectors_tensors/particle-vectors-tensors.flml
+++ b/tests/particle_vectors_tensors/particle-vectors-tensors.flml
@@ -91,11 +91,11 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <value_on_spawn>
+            <value_on_initialisation>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_spawn>
+            </value_on_initialisation>
             <value_on_advection>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):

--- a/tests/particle_vectors_tensors/particle-vectors-tensors.flml
+++ b/tests/particle_vectors_tensors/particle-vectors-tensors.flml
@@ -91,18 +91,18 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <value_on_initialisation>
+            <initial_attribute_value>
               <constant>
                 <real_value rank="0">0</real_value>
               </constant>
-            </value_on_initialisation>
-            <value_on_advection>
+            </initial_attribute_value>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return abs(sign(fields["Temperature"] - fields["old%Temperature"]))</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -130,136 +130,136 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Xval">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[0]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Yval">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return X[1]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Xflag">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return sign(X[0] - fields["old%Xval"])</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Yflag">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     from numpy import sign
     return sign(X[1] - fields["old%Yval"])</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Vectest1">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["vectest"][0]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Vectest2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["vectest"][1]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Tenstest1">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["tenstest"][0, 0]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Tenstest2">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["tenstest"][0, 1]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Tenstest3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["tenstest"][1, 0]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="Tenstest4">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["tenstest"][1, 1]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <scalar_attribute name="OldTens3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["old%Tenstest3"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </scalar_attribute>
           <vector_attribute name="FullVec1">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value rank="1" dim1="dim" shape="2">1 2</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute>
           <vector_attribute name="FullVec2">
-            <value_on_advection>
+            <attribute_value>
               <python>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt):
     return [0, 1]</string_value>
               </python>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute>
           <vector_attribute name="FullVec3">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["vectest"]</string_value>
                 <store_old_attribute/>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </vector_attribute>
           <tensor_attribute name="FullTens">
-            <value_on_advection>
+            <attribute_value>
               <python_fields>
                 <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
     return fields["tenstest"]</string_value>
               </python_fields>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute>
           <tensor_attribute name="FullTens2">
-            <value_on_advection>
+            <attribute_value>
               <constant>
                 <real_value symmetric="false" rank="2" dim1="dim" dim2="dim" shape="2 2">1 2 3 4</real_value>
               </constant>
-            </value_on_advection>
+            </attribute_value>
           </tensor_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/particle_vectors_tensors/particle-vectors-tensors.flml
+++ b/tests/particle_vectors_tensors/particle-vectors-tensors.flml
@@ -91,17 +91,18 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="TempFlag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    if (abs(fields["Temperature"]-fields["old%Temperature"])&gt;0.00001):
-      a = 1
-    else:
-      a = 0
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_spawn>
+              <constant>
+                <real_value rank="0">0</real_value>
+              </constant>
+            </value_on_spawn>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return abs(sign(fields["Temperature"] - fields["old%Temperature"]))</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
         </attributes>
       </particle_subgroup>
@@ -129,137 +130,136 @@
         </initial_position>
         <attributes>
           <scalar_attribute name="Xval">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  x = X[0]
-  return x</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[0]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Yval">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y = X[1]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return X[1]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Xflag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    x = X[0]
-    oldx = fields["old%Xval"]
-    a=0
-    if (x&gt;oldx):
-      a = 1
-    if (x&lt;oldx):
-      a = -1
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return sign(X[0] - fields["old%Xval"])</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Yflag">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  if (t!=0):
-    y = X[1]
-    oldy = fields["old%Yval"]
-    a=0
-    if (y&gt;oldy):
-      a = 1
-    if (y&lt;oldy):
-      a = -1
-  else:
-    a = 0
-  return a</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    from numpy import sign
+    return sign(X[1] - fields["old%Yval"])</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Vectest1">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["vectest"][0]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["vectest"][0]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Vectest2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  return fields["vectest"][1]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["vectest"][1]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Tenstest1">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["tenstest"][0][0]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["tenstest"][0, 0]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Tenstest2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["tenstest"][0][1]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["tenstest"][0, 1]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Tenstest3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["tenstest"][1][0]</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["tenstest"][1, 0]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="Tenstest4">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["tenstest"][1][1]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["tenstest"][1, 1]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <scalar_attribute name="OldTens3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
- return fields["old%Tenstest3"]</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["old%Tenstest3"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </scalar_attribute>
           <vector_attribute name="FullVec1">
-            <constant>
-              <real_value rank="1" dim1="dim" shape="2">1 2</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value rank="1" dim1="dim" shape="2">1 2</real_value>
+              </constant>
+            </value_on_advection>
           </vector_attribute>
           <vector_attribute name="FullVec2">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  y=[0,0]
-  for i in range(0,2):
-    y[i] = i
-  return y</string_value>
-            </python_fields>
+            <value_on_advection>
+              <python>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt):
+    return [0, 1]</string_value>
+              </python>
+            </value_on_advection>
           </vector_attribute>
           <vector_attribute name="FullVec3">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  from numpy import zeros
-  y=zeros(2,float)
-  for i in range(0,2):
-    y[i] = fields["vectest"][i]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["vectest"]</string_value>
+                <store_old_attribute/>
+              </python_fields>
+            </value_on_advection>
           </vector_attribute>
           <tensor_attribute name="FullTens">
-            <python_fields>
-              <string_value type="code" language="python" lines="20">def val(X,t,dt,fields):
-  from numpy import zeros
-  y = zeros((2,2),float)
-  for i in range(0,2):
-    for j in range(0,2):
-      y[i,j]=fields["tenstest"][i,j]
-  return y</string_value>
-              <store_old_attribute/>
-            </python_fields>
+            <value_on_advection>
+              <python_fields>
+                <string_value type="code" language="python" lines="20">def val(X, t, dt, fields):
+    return fields["tenstest"]</string_value>
+              </python_fields>
+            </value_on_advection>
           </tensor_attribute>
           <tensor_attribute name="FullTens2">
-            <constant>
-              <real_value symmetric="false" rank="2" dim1="dim" dim2="dim" shape="2 2">1 2 3 4</real_value>
-            </constant>
+            <value_on_advection>
+              <constant>
+                <real_value symmetric="false" rank="2" dim1="dim" dim2="dim" shape="2 2">1 2 3 4</real_value>
+              </constant>
+            </value_on_advection>
           </tensor_attribute>
         </attributes>
       </particle_subgroup>

--- a/tests/test_energy_stats/test_energy_stats.xml
+++ b/tests/test_energy_stats/test_energy_stats.xml
@@ -22,25 +22,17 @@ for statfile in glob.glob('*.stat'):
     print(statfile, 'end_time: ', times[-1])
 </variable>
     <variable name="errors" language="python">
-from lxml import etree
 import math
+
 import numpy
 from fluidity_tools import stat_parser
-import sys
-from packaging import version
+from lxml import etree
 
-if version.parse(sys.version.split(" ")[0]) >= version.parse("3.8"):
-    import importlib.metadata as im
-    if version.parse(im.version("scipy")) >= version.parse("1.6"):
-        from scipy.integrate import cumulative_trapezoid, trapezoid
-    else:
-        from scipy.integrate import cumtrapz as cumulative_trapezoid, trapz as trapezoid
-else:
-    from pkg_resources import get_distribution
-    if version.parse(get_distribution("scipy").version) >= version.parse("1.6"):
-        from scipy.integrate import cumulative_trapezoid, trapezoid
-    else:
-        from scipy.integrate import cumtrapz as cumulative_trapezoid, trapz as trapezoid
+try:
+    from scipy.integrate import cumulative_trapezoid, trapezoid
+except ImportError:
+    from scipy.integrate import cumtrapz as cumulative_trapezoid
+    from scipy.integrate import trapz as trapezoid
 
 ################################################################################################
 

--- a/tests/test_energy_stats/test_energy_stats.xml
+++ b/tests/test_energy_stats/test_energy_stats.xml
@@ -22,17 +22,25 @@ for statfile in glob.glob('*.stat'):
     print(statfile, 'end_time: ', times[-1])
 </variable>
     <variable name="errors" language="python">
-import vtk
-import glob
-import sys
 from lxml import etree
-import re
-import os
-import scipy.integrate
 import math
-import vtktools
 import numpy
 from fluidity_tools import stat_parser
+import sys
+from packaging import version
+
+if version.parse(sys.version.split(" ")[0]) >= version.parse("3.8"):
+    import importlib.metadata as im
+    if version.parse(im.version("scipy")) >= version.parse("1.6"):
+        from scipy.integrate import cumulative_trapezoid, trapezoid
+    else:
+        from scipy.integrate import cumtrapz as cumulative_trapezoid, trapz as trapezoid
+else:
+    from pkg_resources import get_distribution
+    if version.parse(get_distribution("scipy").version) >= version.parse("1.6"):
+        from scipy.integrate import cumulative_trapezoid, trapezoid
+    else:
+        from scipy.integrate import cumtrapz as cumulative_trapezoid, trapz as trapezoid
 
 ################################################################################################
 
@@ -83,7 +91,7 @@ def IntegrateTrapezoidal(x,y):
 
     integral = 0.0
     for i in range(len(index)-1):
-        integral = integral + abs(scipy.integrate.trapezoid(y[index[i]:index[i+1]+1], x=x[index[i]:index[i+1]+1]))
+        integral = integral + abs(trapezoid(y[index[i]:index[i+1]+1], x=x[index[i]:index[i+1]+1]))
 
     return integral
 
@@ -180,11 +188,11 @@ for statfile in ['lock_exchange_2d.stat', 'lock_exchange_2d_parallel.stat']:
 
 # Potential energy diffused through boundaries
     PEflux = stat["fluid"]["GravitationalPotentialEnergyDensity"]["surface_integral%PEFlux"]*kappa
-    PEout = scipy.integrate.cumulative_trapezoid(PEflux,time)
+    PEout = cumulative_trapezoid(PEflux,time)
 
 # Potential change through diffusion within the domain
     DD = stat["fluid"]["DiffusiveDissipation"]["integral"]*2.0*kappa
-    DDtot = scipy.integrate.cumulative_trapezoid(DD,time)
+    DDtot = cumulative_trapezoid(DD,time)
 
 # Kinetic energy - taken from KineticEnergyDensity (non-Boussinesq)
 # and Velocity (Boussinesq) for illustration
@@ -199,11 +207,11 @@ for statfile in ['lock_exchange_2d.stat', 'lock_exchange_2d_parallel.stat']:
 
 # Diffusive transport of kinetic energy out of domain
     DT = stat["fluid"]["KineticEnergyDensity"]["surface_integral%DiffusiveTransport"]*nu
-    DTtot = scipy.integrate.cumulative_trapezoid(DT,time)
+    DTtot = cumulative_trapezoid(DT,time)
 
 # Kinetic energy lost through viscous dissipation
     VD = stat["fluid"]["ViscousDiss"]["integral"]*rho_0*-1.0
-    VDtot = scipy.integrate.cumulative_trapezoid(VD,time)
+    VDtot = cumulative_trapezoid(VD,time)
 
 # total energy change
 # subtract off initial values of KE and PE

--- a/tests/test_energy_stats/test_energy_stats.xml
+++ b/tests/test_energy_stats/test_energy_stats.xml
@@ -28,7 +28,6 @@ import sys
 from lxml import etree
 import re
 import os
-import scipy.stats
 import scipy.integrate
 import math
 import vtktools
@@ -84,7 +83,7 @@ def IntegrateTrapezoidal(x,y):
 
     integral = 0.0
     for i in range(len(index)-1):
-        integral = integral + abs(scipy.integrate.trapz(y[index[i]:index[i+1]+1], x=x[index[i]:index[i+1]+1]))
+        integral = integral + abs(scipy.integrate.trapezoid(y[index[i]:index[i+1]+1], x=x[index[i]:index[i+1]+1]))
 
     return integral
 
@@ -131,7 +130,7 @@ for statfile in ['lock_exchange_2d.stat', 'lock_exchange_2d_parallel.stat']:
 
 # Potential energy
     PE = stat["fluid"]["GravitationalPotentialEnergyDensity"]["integral"]
-    PE_t = scipy.diff(PE)/dt
+    PE_t = numpy.diff(PE)/dt
 
 # Background potential energy
 # Minimum potential energy available through an adiabatic restratification of the fluid
@@ -181,30 +180,30 @@ for statfile in ['lock_exchange_2d.stat', 'lock_exchange_2d_parallel.stat']:
 
 # Potential energy diffused through boundaries
     PEflux = stat["fluid"]["GravitationalPotentialEnergyDensity"]["surface_integral%PEFlux"]*kappa
-    PEout = scipy.integrate.cumtrapz(PEflux,time)
+    PEout = scipy.integrate.cumulative_trapezoid(PEflux,time)
 
 # Potential change through diffusion within the domain
     DD = stat["fluid"]["DiffusiveDissipation"]["integral"]*2.0*kappa
-    DDtot = scipy.integrate.cumtrapz(DD,time)
+    DDtot = scipy.integrate.cumulative_trapezoid(DD,time)
 
 # Kinetic energy - taken from KineticEnergyDensity (non-Boussinesq)
 # and Velocity (Boussinesq) for illustration
     KE_1 = stat["fluid"]["KineticEnergyDensity"]["integral"]
-    KE_1_t = scipy.diff(KE_1)/dt
+    KE_1_t = numpy.diff(KE_1)/dt
 
     KE_2 = (stat["fluid"]["Velocity%magnitude"]["l2norm"]**2.0)*0.5*rho_0
-    KE_2_t = scipy.diff(KE_2)/dt
+    KE_2_t = numpy.diff(KE_2)/dt
 
     KE = KE_1
     KE_t = KE_1_t
 
 # Diffusive transport of kinetic energy out of domain
     DT = stat["fluid"]["KineticEnergyDensity"]["surface_integral%DiffusiveTransport"]*nu
-    DTtot = scipy.integrate.cumtrapz(DT,time)
+    DTtot = scipy.integrate.cumulative_trapezoid(DT,time)
 
 # Kinetic energy lost through viscous dissipation
     VD = stat["fluid"]["ViscousDiss"]["integral"]*rho_0*-1.0
-    VDtot = scipy.integrate.cumtrapz(VD,time)
+    VDtot = scipy.integrate.cumulative_trapezoid(VD,time)
 
 # total energy change
 # subtract off initial values of KE and PE

--- a/tests/water_collapse_2d/water_collapse_2d.xml
+++ b/tests/water_collapse_2d/water_collapse_2d.xml
@@ -58,7 +58,6 @@ import vtk
 import glob
 import sys
 import os
-import scipy.stats
 import operator
 
 def get_last_dump():
@@ -99,7 +98,6 @@ import vtk
 import glob
 import sys
 import os
-import scipy.stats
 import operator
 
 def get_last_dump():
@@ -140,7 +138,6 @@ import vtk
 import glob
 import sys
 import os
-import scipy.stats
 import operator
 
 def get_last_dump():


### PR DESCRIPTION
Currently, the particle implementation in Fluidity does not allow the user to set initial attribute values for particles initialised during the simulation. Instead, attributes are set to zero and immediately updated according to the provided `constant`, `python` or `python_fields` field in `diamond`. Such an approach does not allow to distinguish particles that have just been initialised during the current timestep from particles that were already present. In particular, this is an issue if particles carry some attributes that represent fields such as concentrations, which can require a non-zero initial value. Importantly, this behaviour only affects particles initialised during the simulation and not particles spawned as a result of control volume thresholds.

In this PR, a strategy to address the above problem is implemented. Within `diamond`, each particle attribute now contains a `value_on_spawn` and a `value_on_advection` fields. `value_on_spawn` is optional; if not provided, `value_on_advection` will be executed at particle initialisation. Before the timestep loop starts and whenever new particles are initialised during the simulation, `value_on_spawn` is executed. At any other time, `value_on_advection` is executed.

The coexistence of `value_on_spawn` and `value_on_advection` brings a potential conflict regarding the current implementation for storing old particle attribute values if `python_fields` are used. Here, the choice is made to only consider `store_old_attribute` under `value_on_advection`; if both `value_on_spawn` and `value_on_advection` are provided, turning on `store_old_attribute` under `value_on_advection` automatically stores old attribute values whether `value_on_spawn` or `value_on_advection` is executed. `store_old_attribute` is, nevertheless, available under `value_on_spawn`, but it is not being used, as mentioned in the updated schemas.

Within the timestep loop, `initialise_particles_during_simulation` is now executed after `particle_cv_check` and `update_particle_attributes_and_fields`. `particle_cv_check` deals with particle spawning, and it seems to me that simulations making use of spawning should not require the initialise during simulation option. `update_particle_attributes_and_fields` comes before `initialise_particles_during_simulation` as it updates attributes on particles that were present at the previous timestep. In turn, `initialise_particles_during_simulation` now both initialises new particles in the domain according to the `initialise_during_simulation` field in `diamond` and sets their attribute values according to the `value_on_spawn` field in `diamond`.

Such proposed changes are backwards-incompatible for two reasons:

- schema structure is different
- specific old attribute values logic for particles initialised during a given timestep is not available anymore (more details after the CI runs)

Additionally, considering the terminology in Fluidity, I am open to renaming `value_on_spawn` to `value_on_initialisation`, which seems more appropriate on second thought.

Finally, many thanks to @angus-g for some preliminary work on this PR.

---

Looking at the CI, tests suites have returned for Bionic and Focal. Groovy is not supported upstream anymore, which echoes to #338. Medium tests passed, so no worries there. For short tests, `particle_attribute_array` fails on Bionic, but not on Focal, because the default NumPy on Bionic does not have the newer random generator. Considering that Bionic support should drop pretty soon, this does not sound like an issue to me. `lagrange_tracer_lowcourant` failed because I missed updating its `flml`. `particle_initialise_after_start` fails, and the failures relate to my second backwards-incompatible reason above. Using the previous implementation, attributes of particles initialised during the simulation would be updated during the same timestep, whereas now there are not anymore. As a result, particles initialised at timestep 2, for example, have their attribute correctly equal to 0 and not 1, as it was before. Finally, `diamond_validation` fails because I missed updating some of the flml that include particles, as mentioned above.

---

Following the second CI, `test_get_rotation_matrix` reported one failure in Unit Focal; I have not investigated. `particle_rayleigh_taylor_mu10`, which I updated in the second commit, yields `Sqr_entrainment_error_24 = 0.0020970997668790683` and `Sqr_entrainment_error_48 = 0.0015043119771471875`, and therefore falls short of the 1e-3 threshold value. When I run the same test on the supercomputer in Canberra, I get `Sqr_entrainment_error_24 = 0.00014354568992100723` and `Sqr_entrainment_error_48 = 0.022645421135390705`. Something I am not sure about is if the mesh is supposed to be structured or not in these simulations, and I guess that would change the results. Remaining tests as before or solved.