### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/libspud/docker/Dockerfile.ubuntu
+++ b/libspud/docker/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ MAINTAINER tim.greaves@imperial.ac.uk
 
 # Install the required packages for spud building and testing
 RUN apt-get -y update
-RUN apt-get -y install gfortran g++ python3-setuptools python3-all-dev python3-dev debhelper dh-python texlive python3-junit.xml
+RUN apt-get -y install gfortran=4:7.4.* g++=4:7.4.* python3-setuptools=39.0.* python3-all-dev=3.6.* python3-dev=3.6.* debhelper=11.1.* dh-python=3.20180325ubuntu2 texlive=2017.20180305-* python3-junit.xml=1.7-* 
 
 # Make sure the spud user has a userid matching the host system if you
 #   are exposing a volume into the container and need files to be


### PR DESCRIPTION
Hi!
The Dockerfile placed at "libspud/docker/Dockerfile.ubuntu" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved from the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance