### PR TITLE
Fixed bug in linked list where the lastnode wasn't being updated when…

### DIFF
--- a/femtools/Linked_Lists.F90
+++ b/femtools/Linked_Lists.F90
@@ -353,6 +353,7 @@ contains
     deallocate(node)
     prev_node%next => null()
     list%length = list%length - 1
+    list%lastnode => prev_node
   end function ipop_last
 
   function ifetch(list, j)


### PR DESCRIPTION
… the last value was popped off the end of the list. Causes a segfault the next time you try and access the lastnode after a pop_last.