### PR TITLE
Install NumPy < 2.0 along with Assess

### DIFF
--- a/docker/actions/Dockerfile.actions.noble
+++ b/docker/actions/Dockerfile.actions.noble
@@ -35,4 +35,4 @@ RUN make manual
 RUN sudo make install
 
 # Python module 'assess' is required for some longtests
-RUN python3 -m pip install --break-system-packages assess
+RUN python3 -m pip install --break-system-packages "numpy<2" assess 

--- a/docker/actions/Dockerfile.actions.noble
+++ b/docker/actions/Dockerfile.actions.noble
@@ -35,4 +35,4 @@ RUN make manual
 RUN sudo make install
 
 # Python module 'assess' is required for some longtests
-RUN python3 -m pip install --break-system-packages "numpy<2" assess 
+RUN python3 -m pip install --break-system-packages "numpy<2" assess

--- a/docker/actions/Dockerfile.actions.noble-omp
+++ b/docker/actions/Dockerfile.actions.noble-omp
@@ -34,4 +34,4 @@ RUN make fltools
 RUN make manual
 
 # Python module 'assess' is required for some longtests
-RUN python3 -m pip install --break-system-packages assess
+RUN python3 -m pip install --break-system-packages "numpy<2" assess


### PR DESCRIPTION
Apparently the Assess install in the CI Dockerfile has started to bring in NumPy 2.0. This should work in the general case, but many tests rely on earlier versions of NumPy and will fail under NumPy 2.0. Additionally, since we compile the application under Numpy 1.0, updating it to 2.0 at the end will cause problems. The solution is to install NumPy<2.0 alongside Assess at the end of the dockerfiles.
 