### PR TITLE
Support HDF5 1.12 directly in the source

### DIFF
--- a/configure
+++ b/configure
@@ -14983,51 +14983,9 @@ if test "$with_hdf5" = "no"; then
 fi
 LDFLAGS="$LDFLAGS $HDF5_LDFLAGS"
 
-# Some changes are necesary in H5hut source to build with HDF5 >= 1.12
-
-
-
-  # Used to indicate true or false condition
-  ax_compare_version=false
-
-  # Convert the two version strings to be compared into a format that
-  # allows a simple string comparison.  The end result is that a version
-  # string of the form 1.12.5-r617 will be converted to the form
-  # 0001001200050617.  In other words, each number is zero padded to four
-  # digits, and non digits are removed.
-
-  ax_compare_version_A=`echo ""$HDF5_VERSION"" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
-                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/[^0-9]//g'`
-
-
-  ax_compare_version_B=`echo "1.12" | sed -e 's/\([0-9]*\)/Z\1Z/g' \
-                     -e 's/Z\([0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/Z\([0-9][0-9][0-9]\)Z/Z0\1Z/g' \
-                     -e 's/[^0-9]//g'`
-
-
-    ax_compare_version=`echo "x$ax_compare_version_A
-x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version_A}/true/;s/x${ax_compare_version_B}/false/;1q"`
-
-
-
-    if test "$ax_compare_version" = "true" ; then
-    PATCH_H5hut="yes"
-    else PATCH_H5hut="no"
-  fi
-
-
-if test "$PATCH_H5hut" = "yes" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: HDF5 >= 1.12 detected; applying patches to h5hut." >&5
-printf "%s\n" "$as_me: HDF5 >= 1.12 detected; applying patches to h5hut." >&6;}
-    sed -i -e 's/H5Oget_info(/H5Oget_info1(/' h5hut/test/testframe.c h5hut/src/h5core/private/h5_hdf5.c
-    sed -i -e 's/H5Oget_info (/H5Oget_info1 (/' h5hut/src/h5core/private/h5_hdf5.h
-    sed -i -e 's/H5Oget_info_by_name(/H5Oget_info_by_name1(/' h5hut/src/h5core/private/h5_hdf5.c
-fi
+# H5hut API compatibility with HDF5 >= 1.12 is handled via #if H5_VERSION_GE
+# guards directly in h5hut/src/h5core/private/h5_hdf5.{h,c} and
+# h5hut/test/testframe.c; no source patching is needed at configure time.
 
 #************H5hut***********
 if test -d h5hut; then

--- a/configure.in
+++ b/configure.in
@@ -1465,17 +1465,9 @@ if test "$with_hdf5" = "no"; then
 fi
 LDFLAGS="$LDFLAGS $HDF5_LDFLAGS"
 
-# Some changes are necesary in H5hut source to build with HDF5 >= 1.12
-AX_COMPARE_VERSION(["$HDF5_VERSION"], [ge], 1.12,
-                     [PATCH_H5hut="yes"],
-                     [PATCH_H5hut="no"])
-
-if test "$PATCH_H5hut" = "yes" ; then
-    AC_MSG_NOTICE([HDF5 >= 1.12 detected; applying patches to h5hut.])
-    sed -i -e 's/H5Oget_info(/H5Oget_info1(/' h5hut/test/testframe.c h5hut/src/h5core/private/h5_hdf5.c
-    sed -i -e 's/H5Oget_info (/H5Oget_info1 (/' h5hut/src/h5core/private/h5_hdf5.h
-    sed -i -e 's/H5Oget_info_by_name(/H5Oget_info_by_name1(/' h5hut/src/h5core/private/h5_hdf5.c
-fi
+# H5hut API compatibility with HDF5 >= 1.12 is handled via #if H5_VERSION_GE
+# guards directly in h5hut/src/h5core/private/h5_hdf5.{h,c} and
+# h5hut/test/testframe.c; no source patching is needed at configure time.
 
 #************H5hut***********
 if test -d h5hut; then

--- a/h5hut/src/h5core/private/h5_hdf5.c
+++ b/h5hut/src/h5core/private/h5_hdf5.c
@@ -69,7 +69,11 @@ iter_op_get_obj_type (
         const H5L_info_t* info
         ) {
 	herr_t herr;
+#if H5_VERSION_GE(1, 12, 0)
+	H5O_info1_t objinfo;
+#else
 	H5O_info_t objinfo;
+#endif
 
 	if (info->type == H5L_TYPE_EXTERNAL) {
 		char* buf = h5_calloc (1, info->u.val_size);
@@ -110,10 +114,17 @@ iter_op_get_obj_type (
 			        name);
 			return H5O_TYPE_UNKNOWN;
 		}
+#if H5_VERSION_GE(1, 12, 0)
+		herr = H5Oget_info1(obj_id, &objinfo);
+	}
+	else { // H5L_TYPE_HARD
+		herr = H5Oget_info_by_name1(g_id, name, &objinfo, H5P_DEFAULT);
+#else
 		herr = H5Oget_info(obj_id, &objinfo);
 	}
 	else { // H5L_TYPE_HARD
 		herr = H5Oget_info_by_name(g_id, name, &objinfo, H5P_DEFAULT);
+#endif
 	}
 
 	if (herr < 0) {

--- a/h5hut/src/h5core/private/h5_hdf5.h
+++ b/h5hut/src/h5core/private/h5_hdf5.h
@@ -1292,8 +1292,13 @@ hdf5_close_file (
 		for (ssize_t i = 0; i < max_objs; i++) {
 			hid_t object_id = obj_id_list [i];
 			h5_debug ("Open object: %lld", (long long)object_id);
+#if H5_VERSION_GE(1, 12, 0)
+			H5O_info1_t object_info;
+			if (H5Oget_info1 (object_id, &object_info) < 0)
+#else
 			H5O_info_t object_info;
 			if (H5Oget_info (object_id, &object_info) < 0)
+#endif
 				continue;
 			switch (object_info.type) {
 			case H5O_TYPE_GROUP:

--- a/h5hut/test/testframe.c
+++ b/h5hut/test/testframe.c
@@ -655,10 +655,18 @@ test_open_objects(h5_file_t file, int max_objects)
 		hid_t *list = malloc(sizeof(hid_t)*nopen);
 		H5Fget_obj_ids(hfile, H5F_OBJ_ALL, nopen, list);
 
+#if H5_VERSION_GE(1, 12, 0)
+		H5O_info1_t info;
+#else
 		H5O_info_t info;
+#endif
 		int i;
 		for (i=0; i<nopen; i++) {
+#if H5_VERSION_GE(1, 12, 0)
+			H5Oget_info1(list[i], &info);
+#else
 			H5Oget_info(list[i], &info);
+#endif
 			switch (info.type) {
 			case H5O_TYPE_GROUP:
 				TestErrPrintf("obj%d has type GROUP\n", i);


### PR DESCRIPTION
The current configure has code to patch the h5hut directory in the presence of HDF5 version 1.12. This was done, presumably, in order to avoid touching the h5hut source which was written by a 3rd party. Unfortunately the patch no longer works with HDF5 1.14, and h5hut appears to be no longer maintained. This PR removes the patching code from configure and modifies the h5hut code directly to work with versions of HD5 up to 1.14.6.
