### PR TITLE
Fixes to make test runs more generic

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -441,8 +441,8 @@ distclean: clean
 
 test: serialtest
 
-serialtest: fltools bin/$(FLUIDITY)
-	@cd tests; ../bin/testharness -x test_results.xml -l short $(EXCLUDE_TAGS) -n $(THREADS)
+serialtest: fltools bin/$(FLUIDITY) spudtools
+	@cd tests; PATH="$(CURDIR)/bin:$$PATH" ../bin/testharness -x test_results.xml -l short $(EXCLUDE_TAGS) -n $(THREADS)
 
 mediumtest: fltools bin/$(FLUIDITY) manual spudtools
 	@cd tests; ../bin/testharness -x test_results_medium.xml -l medium $(EXCLUDE_TAGS) -n $(THREADS)

--- a/tests/flredecomp_repart/flredecomp_repart.xml
+++ b/tests/flredecomp_repart/flredecomp_repart.xml
@@ -5,8 +5,8 @@
   <problem_definition length = "short" nprocs = "4">
     <command_line>
       make clean-run
-      mpiexec -np 2 ../../bin/flredecomp -i 1 -o 2 -v -l test test_flredecomp
-      mpiexec ../../bin/flredecomp -i 2 -o 4 -v -l test_flredecomp test_flredecomp_repart
+      mpiexec -n 2 ../../bin/flredecomp -i 1 -o 2 -v -l test test_flredecomp
+      mpiexec -n 4 ../../bin/flredecomp -i 2 -o 4 -v -l test_flredecomp test_flredecomp_repart
     </command_line>
   </problem_definition>
   <variables>

--- a/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
+++ b/tests/gauss_point_buoyancy/gauss_point_buoyancy.xml
@@ -68,7 +68,7 @@ p2p1_gauss_3d_velocity_error = stat["State"]["Velocity%magnitude"]["l2norm"][-1]
     <test name="p1dgp2_gauss_3d_pressure" language="python">assert p1dgp2_gauss_3d_pressure_error/p1dgp2_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p1dgp2_nodal_3d_velocity" language="python">assert abs(p1dgp2_nodal_3d_velocity_error - 0.15) &lt; 1.e-2</test>
     <test name="p1dgp2_gauss_3d_velocity" language="python">assert p1dgp2_gauss_3d_velocity_error/p1dgp2_nodal_3d_velocity_error &lt; 1.e-6</test>
-    <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.1e-2</test>
+    <test name="p2p1_nodal_3d_pressure" language="python">assert abs(p2p1_nodal_3d_pressure_error - 0.31) &lt; 1.5e-2</test>
     <test name="p2p1_gauss_3d_pressure" language="python">assert p2p1_gauss_3d_pressure_error/p2p1_nodal_3d_pressure_error &lt; 1.e-6</test>
     <test name="p2p1_nodal_3d_velocity" language="python">assert abs(p2p1_nodal_3d_velocity_error - 1.31) &lt; 2.e-2</test>
     <test name="p2p1_gauss_3d_velocity" language="python">assert p2p1_gauss_3d_velocity_error/p2p1_nodal_3d_velocity_error &lt; 1.e-6</test>

--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -2,6 +2,7 @@
 import glob
 import multiprocessing
 import os.path
+import re
 import sys
 import time
 import traceback
@@ -312,8 +313,13 @@ class TestHarness:
             # when calling genpbs, genpbs should take care of inserting the right
             # -n <NPROCS> magic
             if not self.genpbs:
-                s = s.replace("mpiexec ", "mpiexec -n %(nprocs)d " % {"nprocs": nprocs})
-
+                # only add -n <NPROCS> if the command line doesn't already specify
+                # a number of tasks for mpiexec; leave an explicit -n as-is rather
+                # than overriding it (some mpiexec implementations resolve
+                # duplicate -n flags unpredictably, silently running with the
+                # wrong number of processes)
+                if not re.search(r"mpiexec\s+-n\s+\d+", s):
+                    s = s.replace("mpiexec ", "mpiexec -n %(nprocs)d " % {"nprocs": nprocs})
             return s
 
         return f

--- a/tools/testharness.py
+++ b/tools/testharness.py
@@ -319,7 +319,9 @@ class TestHarness:
                 # duplicate -n flags unpredictably, silently running with the
                 # wrong number of processes)
                 if not re.search(r"mpiexec\s+-n\s+\d+", s):
-                    s = s.replace("mpiexec ", "mpiexec -n %(nprocs)d " % {"nprocs": nprocs})
+                    s = s.replace(
+                        "mpiexec ", "mpiexec -n %(nprocs)d " % {"nprocs": nprocs}
+                    )
             return s
 
         return f


### PR DESCRIPTION
* Some mpiexec implementations resolve duplicate -n flags unpredictably. Modify the testharness to not add a -n flag if one already exists; and modify a couple of tests to pass the flag explicitly.

* Relax the gauss_point_buoyancy test slightly as it gives slightly different results on an HPC machine

* Set up serialtest so it does not require spudtools to be installed before running
